### PR TITLE
CI pipeline changes, drop PHP 5.5 support

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
   environment:
-    php: '5.6.9'
+    php: 7.2
 
 coding_style:
   php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   - if [ "$DEPENDENCIES" = "beta" ]; then
       composer config minimum-stability beta;
       composer update -n --prefer-dist;
-    else if [ "$DEPENDENCIES" = "low" ]; then
+    elif [ "$DEPENDENCIES" = "low" ]; then
       composer update -n --prefer-dist --prefer-lowest;
     else
       composer update -n --prefer-dist;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,57 +1,71 @@
 language: php
 
+sudo: false
+
 cache:
   directories:
     - $HOME/.composer/cache
 
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
+
 env:
   global:
-    - DEPENDENCIES=no
+    - LATEST_PHP_VERSION="7.2"
+  matrix:
+    - DEPENDENCIES="beta"
+    - DEPENDENCIES="low"
+    - DEPENDENCIES="stable"
 
 matrix:
-  include:
-    - php: 5.6
-    - php: 5.6
-      env: DEPENDENCIES=beta
-    - php: 5.6
-      env: DEPENDENCIES=low
-    - php: 7.0
-    - php: 7.0
-      env: DEPENDENCIES=beta
-    - php: 7.0
-      env: DEPENDENCIES=low
-    - php: 7.1
-    - php: 7.1
-      env: DEPENDENCIES=beta
-    - php: 7.1
-      env: DEPENDENCIES=low
-    - php: 7.2
-    - php: 7.2
-      env: DEPENDENCIES=beta
-    - php: 7.2
-      env: DEPENDENCIES=low
-    - php: nightly
+  fast_finish: true
   allow_failures:
     - php: nightly
-    - env: DEPENDENCIES=beta
-    - env: DEPENDENCIES=low
+    - env: DEPENDENCIES="beta"
 
 before_install:
-  - composer self-update
-  # Set composer minimum-stability configuration filter to beta versions
-  - if [ "$DEPENDENCIES" = "beta" ]; then perl -pi -e 's/^}$/,"minimum-stability":"beta"}/' composer.json; fi;
-  # Disable xdebug, there is no use of it being enabled
-  - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
-  # Prevent Travis throwing an out of memory error
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  # Test if we have a token for github as the project may hit the 60 rph limit
-  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
+  - if [ -n "$GH_TOKEN" ]; then
+      composer config github-oauth.github.com ${GH_TOKEN};
+    fi;
+  - mkdir -p build/logs
 
 install:
-  - if [ "$DEPENDENCIES" = "no" ]; then composer update; fi;
-  - if [ "$DEPENDENCIES" = "low" ]; then composer --prefer-lowest --prefer-stable update; fi;
+  - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
+      composer remove friendsofphp/php-cs-fixer phpstan/phpstan --dev;
+    fi
+  - if [ "$DEPENDENCIES" = "beta" ]; then
+      composer config minimum-stability beta;
+      composer update -n --prefer-dist;
+    else if [ "$DEPENDENCIES" = "low" ]; then
+      composer update -n --prefer-dist --prefer-lowest;
+    else
+      composer update -n --prefer-dist;
+    fi;
 
 script:
-  - composer validate-files
-  - composer check-code-style
-  - composer tests
+  - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
+      echo "File validation is skipped for older PHP versions";
+    else
+      composer validate-files;
+    fi;
+  - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
+      echo "Static analysis is skipped for older PHP versions";
+    else
+      composer run-static-analysis;
+    fi;
+  - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
+      echo "Code style check is skipped for older PHP versions";
+    else
+      composer check-code-style;
+    fi;
+  - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
+      echo "Security check is skipped for older PHP versions";
+    else
+      composer check-security;
+    fi;
+  - composer run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
   allow_failures:
     - php: nightly
     - env: DEPENDENCIES="beta"
+    - env: DEPENDENCIES="low"
 
 before_install:
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/martin-georgiev/postgresql-for-doctrine/badges/quality-score.png)](https://scrutinizer-ci.com/g/martin-georgiev/postgresql-for-doctrine/?branch=master)
 [![Build Status](https://api.travis-ci.org/martin-georgiev/postgresql-for-doctrine.svg?branch=master)](https://www.travis-ci.org/martin-georgiev/postgresql-for-doctrine)
+[![Latest Stable Version](https://poser.pugx.org/martin-georgiev/postgresql-for-doctrine/version)](https://packagist.org/packages/martin-georgiev/postgresql-for-doctrine)
+[![Total Downloads](https://poser.pugx.org/martin-georgiev/postgresql-for-doctrine/downloads)](https://packagist.org/packages/martin-georgiev/postgresql-for-doctrine)
 ----
 ## What's this?
 This package provides Doctrine support for some specific PostgreSQL 9.4+ features:

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,7 @@
     "name": "martin-georgiev/postgresql-for-doctrine",
     "type": "library",
     "description": "PostgreSQL enhancements for Doctrine. Provides support for JSONB and array data types and operators and other specific functions.",
-    "keywords": ["martin georgiev", "doctrine2", "postgresql", "postgres", "dbal", "jsonb", "array data types"],
-    "minimum-stability": "stable",
+    "keywords": ["martin georgiev", "doctrine", "postgresql", "postgres", "dbal", "jsonb", "array data types"],
     "license": "MIT",
     "authors": [
         {
@@ -11,17 +10,7 @@
             "email": "martin.georgiev@gmail.com"
         }
     ],
-    "require": {
-        "php": ">=5.5",
-        "doctrine/dbal": "~2.5",
-        "doctrine/orm": "~2.5"
-    },
-    "require-dev": {
-        "friendsofphp/php-cs-fixer": "*",
-        "jakub-onderka/php-parallel-lint": "^0.9.2",
-        "phpunit/phpunit": "~5.0",
-        "sensiolabs/security-checker": "^4.1"
-    },
+
     "autoload": {
         "psr-4": {
             "MartinGeorgiev\\": "src/MartinGeorgiev/"
@@ -32,26 +21,52 @@
             "MartinGeorgiev\\Tests\\": "tests/MartinGeorgiev/"
         }
     },
+
+    "require": {
+        "php": ">=5.6",
+        "doctrine/dbal": "~2.5",
+        "doctrine/orm": "~2.5"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "*",
+        "jakub-onderka/php-parallel-lint": "^1.0",
+        "phpstan/phpstan": "^0.10.2",
+        "phpunit/phpunit": "^5.7",
+        "sensiolabs/security-checker": "^4.1"
+    },
+
     "scripts": {
         "check-code-style": [
-            "vendor/bin/php-cs-fixer fix --config='./.php_cs' --show-progress=none --dry-run --no-interaction -v"
+            "bin/php-cs-fixer fix --config='./.php_cs' --show-progress=none --dry-run --no-interaction --diff -v"
+        ],
+        "check-security": [
+            "bin/security-checker security:check"
         ],
         "fix-code-style": [
-            "vendor/bin/php-cs-fixer fix --config='./.php_cs' --show-progress=none --no-interaction -v"
+            "bin/php-cs-fixer fix --config='./.php_cs' --show-progress=none --no-interaction --diff -v"
         ],
-        "tests": [
-            "vendor/bin/phpunit"
+        "run-static-analysis": [
+            "bin/phpstan analyse --level=3 src/"
+        ],
+        "run-static-analysis-including-tests": [
+            "@run-static-analysis",
+            "bin/phpstan analyse --level=3 tests/"
+        ],
+        "run-tests": [
+            "bin/phpunit"
         ],
         "validate-files": [
-            "vendor/bin/parallel-lint --exclude vendor ."
+            "bin/parallel-lint --exclude vendor --exclude bin ."
         ]
     },
+
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
         }
     },
     "config": {
+        "bin-dir": "bin",
         "sort-packages": true
     },
     "prefer-stable": true


### PR DESCRIPTION
- Bump min required PHP version to 5.6 (discontinue support for 5.5)
- Update Travis configuration with better matrices and new CI steps
- Tidy up composer.json