### PR TITLE
Add tests for ORM functions

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,11 +6,10 @@
         convertWarningsToExceptions="true"
         stopOnFailure="false"
         bootstrap="vendor/autoload.php"
-        verbose="true"
-        syntaxCheck="true">
+        verbose="true">
 
     <testsuites>
-        <testsuite>
+        <testsuite name="PostgreSQL-for-Doctrine Test Suite">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppend.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppend.php
@@ -15,6 +15,6 @@ class ArrayAppend extends AbstractFunction
     {
         $this->setFunctionPrototype('array_append(%s, %s)');
         $this->addLiteralMapping('StringPrimary');
-        $this->addLiteralMapping('InputParameter');
+        $this->addLiteralMapping('Literal');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAreOverlapingEachOther.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAreOverlapingEachOther.php
@@ -10,7 +10,7 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  *
  * @deprecated Deprecated since v0.12 and will be removed in v1.0. Use Overlaps instead.
- * @codeCoverageIgnore 
+ * @codeCoverageIgnore
  */
 class ArrayAreOverlapingEachOther extends AbstractFunction
 {

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLength.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLength.php
@@ -15,6 +15,6 @@ class ArrayLength extends AbstractFunction
     {
         $this->setFunctionPrototype('array_length(%s, %s)');
         $this->addLiteralMapping('StringPrimary');
-        $this->addLiteralMapping('InputParameter');
+        $this->addLiteralMapping('Literal');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrepend.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrepend.php
@@ -14,7 +14,7 @@ class ArrayPrepend extends AbstractFunction
     protected function customiseFunction()
     {
         $this->setFunctionPrototype('array_prepend(%s, %s)');
+        $this->addLiteralMapping('Literal');
         $this->addLiteralMapping('StringPrimary');
-        $this->addLiteralMapping('InputParameter');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemove.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemove.php
@@ -15,6 +15,6 @@ class ArrayRemove extends AbstractFunction
     {
         $this->setFunctionPrototype('array_remove(%s, %s)');
         $this->addLiteralMapping('StringPrimary');
-        $this->addLiteralMapping('InputParameter');
+        $this->addLiteralMapping('Literal');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplace.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplace.php
@@ -15,7 +15,7 @@ class ArrayReplace extends AbstractFunction
     {
         $this->setFunctionPrototype('array_replace(%s, %s, %s)');
         $this->addLiteralMapping('StringPrimary');
-        $this->addLiteralMapping('InputParameter');
-        $this->addLiteralMapping('InputParameter');
+        $this->addLiteralMapping('Literal');
+        $this->addLiteralMapping('Literal');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayToString.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayToString.php
@@ -15,6 +15,6 @@ class ArrayToString extends AbstractFunction
     {
         $this->setFunctionPrototype('array_to_string(%s, %s)');
         $this->addLiteralMapping('StringPrimary');
-        $this->addLiteralMapping('InputParameter');
+        $this->addLiteralMapping('StringPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Greatest.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Greatest.php
@@ -25,7 +25,7 @@ class Greatest extends AbstractFunction
      */
     protected function customiseFunction()
     {
-        $this->setFunctionPrototype('GREATEST(%s)');
+        $this->setFunctionPrototype('greatest(%s)');
     }
 
     /**

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbInsert.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbInsert.php
@@ -15,7 +15,7 @@ class JsonbInsert extends AbstractFunction
     {
         $this->setFunctionPrototype('jsonb_insert(%s, %s, %s)');
         $this->addLiteralMapping('StringPrimary');
-        $this->addLiteralMapping('InputParameter');
-        $this->addLiteralMapping('InputParameter');
+        $this->addLiteralMapping('StringPrimary');
+        $this->addLiteralMapping('StringPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbSet.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbSet.php
@@ -15,7 +15,7 @@ class JsonbSet extends AbstractFunction
     {
         $this->setFunctionPrototype('jsonb_set(%s, %s, %s)');
         $this->addLiteralMapping('StringPrimary');
-        $this->addLiteralMapping('InputParameter');
-        $this->addLiteralMapping('InputParameter');
+        $this->addLiteralMapping('StringPrimary');
+        $this->addLiteralMapping('StringPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Least.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Least.php
@@ -16,6 +16,6 @@ class Least extends Greatest
      */
     protected function customiseFunction()
     {
-        $this->setFunctionPrototype('LEAST(%s)');
+        $this->setFunctionPrototype('least(%s)');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringToArray.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringToArray.php
@@ -15,6 +15,6 @@ class StringToArray extends AbstractFunction
     {
         $this->setFunctionPrototype('string_to_array(%s, %s)');
         $this->addLiteralMapping('StringPrimary');
-        $this->addLiteralMapping('InputParameter');
+        $this->addLiteralMapping('StringPrimary');
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/ContainsArray.php
+++ b/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/ContainsArray.php
@@ -17,4 +17,9 @@ class ContainsArray extends Entity
      * @Column(type="array")
      */
     public $array;
+
+    /**
+     * @Column(type="array")
+     */
+    public $anotherArray;
 }

--- a/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/ContainsArray.php
+++ b/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/ContainsArray.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\Fixtures\Entity;
+
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMException;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+/**
+ * @Entity
+ */
+class ContainsArray extends Entity
+{
+    /**
+     * @Column(type="array")
+     */
+    public $array;
+}

--- a/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/ContainsJson.php
+++ b/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/ContainsJson.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\Fixtures\Entity;
+
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMException;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+/**
+ * @Entity
+ */
+class ContainsJson extends Entity
+{
+    /**
+     * @Column(type="json")
+     */
+    public $object;
+}

--- a/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/ContainsSeveralIntegers.php
+++ b/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/ContainsSeveralIntegers.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\Fixtures\Entity;
+
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMException;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+/**
+ * @Entity
+ */
+class ContainsSeveralIntegers extends Entity
+{
+    /**
+     * @Column(type="integer")
+     */
+    public $integer1;
+
+    /**
+     * @Column(type="integer")
+     */
+    public $integer2;
+
+    /**
+     * @Column(type="integer")
+     */
+    public $integer3;
+}

--- a/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/ContainsText.php
+++ b/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/ContainsText.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\Fixtures\Entity;
+
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMException;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+/**
+ * @Entity
+ */
+class ContainsText extends Entity
+{
+    /**
+     * @Column(type="text")
+     */
+    public $text;
+}

--- a/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/Entity.php
+++ b/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/Entity.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\Fixtures\Entity;
+
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMException;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class Entity
+{
+    /**
+     * @Id
+     * @Column(type="string")
+     * @GeneratedValue
+     */
+    public $id;
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AllTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AllTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\All;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class AllTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ALL_OF' => All::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT c0_.id AS id_0 FROM ContainsArray c0_ WHERE c0_.id > ALL(c0_.array)';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT e.id FROM %s e WHERE e.id > ALL_OF(e.array)', ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AnyTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AnyTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Any;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class AnyTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ANY_OF' => Any::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT c0_.id AS id_0 FROM ContainsArray c0_ WHERE c0_.id > ANY(c0_.array)';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT e.id FROM %s e WHERE e.id > ANY_OF(e.array)', ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppendTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppendTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayAppend;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ArrayAppendTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ARRAY_APPEND' => ArrayAppend::class,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getExpectedSql()
+    {
+        return [
+            'SELECT array_append(c0_.array, 1989) AS sclr_0 FROM ContainsArray c0_',
+            "SELECT array_append(c0_.array, 'country') AS sclr_0 FROM ContainsArray c0_",
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getDql()
+    {
+        return [
+            sprintf('SELECT ARRAY_APPEND(e.array, 1989) FROM %s e', ContainsArray::class),
+            sprintf("SELECT ARRAY_APPEND(e.array, 'country') FROM %s e", ContainsArray::class),
+        ];
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayCardinalityTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayCardinalityTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayCardinality;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ArrayCardinalityTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ARRAY_CARDINALITY' => ArrayCardinality::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT cardinality(c0_.array) AS sclr_0 FROM ContainsArray c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT ARRAY_CARDINALITY(e.array) FROM %s e', ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayCatTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayCatTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayCat;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ArrayCatTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ARRAY_CAT' => ArrayCat::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT array_cat(c0_.array, c0_.anotherArray) AS sclr_0 FROM ContainsArray c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT ARRAY_CAT(e.array, e.anotherArray) FROM %s e', ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayDimensionsTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayDimensionsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayDimensions;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ArrayDimensionsTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ARRAY_DIMENSIONS' => ArrayDimensions::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT array_dims(c0_.array) AS sclr_0 FROM ContainsArray c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT ARRAY_DIMENSIONS(e.array) FROM %s e', ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLengthTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLengthTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayLength;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ArrayLengthTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ARRAY_LENGTH' => ArrayLength::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT array_length(c0_.array, 1) AS sclr_0 FROM ContainsArray c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT ARRAY_LENGTH(e.array, 1) FROM %s e', ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayNumberOfDimensionsTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayNumberOfDimensionsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayNumberOfDimensions;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ArrayNumberOfDimensionsTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ARRAY_NUMBER_OF_DIMENSIONS' => ArrayNumberOfDimensions::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT array_ndims(c0_.array) AS sclr_0 FROM ContainsArray c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT ARRAY_NUMBER_OF_DIMENSIONS(e.array) FROM %s e', ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrependTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrependTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayPrepend;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ArrayPrependTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ARRAY_PREPEND' => ArrayPrepend::class,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getExpectedSql()
+    {
+        return [
+            'SELECT array_prepend(1885, c0_.array) AS sclr_0 FROM ContainsArray c0_',
+            "SELECT array_prepend('red', c0_.array) AS sclr_0 FROM ContainsArray c0_",
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getDql()
+    {
+        return [
+            sprintf('SELECT ARRAY_PREPEND(1885, e.array) FROM %s e', ContainsArray::class),
+            sprintf("SELECT ARRAY_PREPEND('red', e.array) FROM %s e", ContainsArray::class),
+        ];
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemoveTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemoveTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayRemove;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ArrayRemoveTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ARRAY_REMOVE' => ArrayRemove::class,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getExpectedSql()
+    {
+        return [
+            'SELECT array_remove(c0_.array, 1944) AS sclr_0 FROM ContainsArray c0_',
+            "SELECT array_remove(c0_.array, 'peach') AS sclr_0 FROM ContainsArray c0_",
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getDql()
+    {
+        return [
+            sprintf('SELECT ARRAY_REMOVE(e.array, 1944) FROM %s e', ContainsArray::class),
+            sprintf("SELECT ARRAY_REMOVE(e.array, 'peach') FROM %s e", ContainsArray::class),
+        ];
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplaceTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplaceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayReplace;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ArrayReplaceTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ARRAY_REPLACE' => ArrayReplace::class,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getExpectedSql()
+    {
+        return [
+            'SELECT array_replace(c0_.array, 1939, 1957) AS sclr_0 FROM ContainsArray c0_',
+            "SELECT array_replace(c0_.array, 'green', 'mint') AS sclr_0 FROM ContainsArray c0_",
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getDql()
+    {
+        return [
+            sprintf('SELECT ARRAY_REPLACE(e.array, 1939, 1957) FROM %s e', ContainsArray::class),
+            sprintf("SELECT ARRAY_REPLACE(e.array, 'green', 'mint') FROM %s e", ContainsArray::class),
+        ];
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayToJsonTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayToJsonTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayToJson;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ArrayToJsonTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ARRAY_TO_JSON' => ArrayToJson::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT array_to_json(c0_.array) AS sclr_0 FROM ContainsArray c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT ARRAY_TO_JSON(e.array) FROM %s e', ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayToStringTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayToStringTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayToString;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ArrayToStringTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'ARRAY_TO_STRING' => ArrayToString::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT array_to_string(c0_.array, '; ') AS sclr_0 FROM ContainsArray c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT ARRAY_TO_STRING(e.array, '; ') FROM %s e", ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ContainsTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ContainsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Contains;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class ContainsTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'CONTAINS' => Contains::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT (c0_.array @> '{681,1185,1878}') AS sclr_0 FROM ContainsArray c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT CONTAINS(e.array, '{681,1185,1878}') FROM %s e", ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GreatestTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GreatestTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Greatest;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsSeveralIntegers;
+
+class GreatestTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'GREATEST' => Greatest::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT greatest(c0_.integer1,c0_.integer2,c0_.integer3) AS sclr_0 FROM ContainsSeveralIntegers c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT GREATEST(e.integer1, e.integer2, e.integer3) FROM %s e', ContainsSeveralIntegers::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/IsContainedByTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/IsContainedByTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\IsContainedBy;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class IsContainedByTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'IS_CONTAINED_BY' => IsContainedBy::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT (c0_.array <@ '{681,1185,1878}') AS sclr_0 FROM ContainsArray c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT IS_CONTAINED_BY(e.array, '{681,1185,1878}') FROM %s e", ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonArrayLengthTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonArrayLengthTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonArrayLength;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonArrayLengthTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSON_ARRAY_LENGTH' => JsonArrayLength::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT json_array_length(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSON_ARRAY_LENGTH(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonEachTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonEachTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonEach;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonEachTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSON_EACH' => JsonEach::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT json_each(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSON_EACH(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonEachTextTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonEachTextTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonEachText;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonEachTextTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSON_EACH_TEXT' => JsonEachText::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT json_each_text(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSON_EACH_TEXT(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonGetFieldAsIntegerTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonGetFieldAsIntegerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonGetFieldAsInteger;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonGetFieldAsIntegerTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSON_GET_FIELD_AS_INTEGER' => JsonGetFieldAsInteger::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT CAST(c0_.object ->> 'rank' as BIGINT) AS sclr_0 FROM ContainsJson c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT JSON_GET_FIELD_AS_INTEGER(e.object, 'rank') FROM %s e", ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonGetFieldAsTextTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonGetFieldAsTextTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonGetFieldAsText;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonGetFieldAsTextTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSON_GET_FIELD_AS_TEXT' => JsonGetFieldAsText::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT (c0_.object ->> 'country') AS sclr_0 FROM ContainsJson c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT JSON_GET_FIELD_AS_TEXT(e.object, 'country') FROM %s e", ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonGetFieldTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonGetFieldTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonGetField;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonGetFieldTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSON_GET_FIELD' => JsonGetField::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT (c0_.object -> 'country') AS sclr_0 FROM ContainsJson c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT JSON_GET_FIELD(e.object, 'country') FROM %s e", ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonGetObjectAsTextTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonGetObjectAsTextTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonGetObjectAsText;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonGetObjectAsTextTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSON_GET_OBJECT_AS_TEXT' => JsonGetObjectAsText::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT (c0_.object #>> '{residency,country}') AS sclr_0 FROM ContainsJson c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT JSON_GET_OBJECT_AS_TEXT(e.object, '{residency,country}') FROM %s e", ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonGetObjectTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonGetObjectTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonGetObject;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonGetObjectTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSON_GET_OBJECT' => JsonGetObject::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT (c0_.object #> '{residency}') AS sclr_0 FROM ContainsJson c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT JSON_GET_OBJECT(e.object, '{residency}') FROM %s e", ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonObjectKeysTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonObjectKeysTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonObjectKeys;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonObjectKeysTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSON_OBJECT_KEYS' => JsonObjectKeys::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT json_object_keys(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSON_OBJECT_KEYS(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonStripNullsTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonStripNullsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonStripNulls;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonStripNullsTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSON_STRIP_NULLS' => JsonStripNulls::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT json_strip_nulls(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSON_STRIP_NULLS(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbArrayElementsTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbArrayElementsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbArrayElements;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonbArrayElementsTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSONB_ARRAY_ELEMENTS' => JsonbArrayElements::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT jsonb_array_elements(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSONB_ARRAY_ELEMENTS(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbArrayElementsTextTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbArrayElementsTextTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbArrayElementsText;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonbArrayElementsTextTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSONB_ARRAY_ELEMENTS_TEXT' => JsonbArrayElementsText::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT jsonb_array_elements_text(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSONB_ARRAY_ELEMENTS_TEXT(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbArrayLengthTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbArrayLengthTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbArrayLength;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonbArrayLengthTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSONB_ARRAY_LENGTH' => JsonbArrayLength::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT jsonb_array_length(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSONB_ARRAY_LENGTH(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbEachTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbEachTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbEach;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonbEachTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSONB_EACH' => JsonbEach::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT jsonb_each(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSONB_EACH(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbEachTextTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbEachTextTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbEachText;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonbEachTextTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSONB_EACH_TEXT' => JsonbEachText::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT jsonb_each_text(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSONB_EACH_TEXT(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbExistsTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbExistsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbExists;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonbExistsTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSONB_EXISTS' => JsonbExists::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT jsonb_exists(c0_.object, 'country') AS sclr_0 FROM ContainsJson c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT JSONB_EXISTS(e.object, 'country') FROM %s e", ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbInsertTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbInsertTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbInsert;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonbInsertTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSONB_INSERT' => JsonbInsert::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT jsonb_insert(c0_.object, '{country}', '{\"iso_3166_a3_code\":\"BGR\"}') AS sclr_0 FROM ContainsJson c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT JSONB_INSERT(e.object, '{country}', '{\"iso_3166_a3_code\":\"BGR\"}') FROM %s e", ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbObjectKeysTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbObjectKeysTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbObjectKeys;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonbObjectKeysTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSONB_OBJECT_KEYS' => JsonbObjectKeys::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT jsonb_object_keys(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSONB_OBJECT_KEYS(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbSetTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbSetTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbSet;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonbSetTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSONB_SET' => JsonbSet::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT jsonb_set(c0_.object, '{country}', '{\"iso_3166_a3_code\":\"BGR\"}') AS sclr_0 FROM ContainsJson c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT JSONB_SET(e.object, '{country}', '{\"iso_3166_a3_code\":\"BGR\"}') FROM %s e", ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbStripNullsTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbStripNullsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbStripNulls;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsJson;
+
+class JsonbStripNullsTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'JSONB_STRIP_NULLS' => JsonbStripNulls::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT jsonb_strip_nulls(c0_.object) AS sclr_0 FROM ContainsJson c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT JSONB_STRIP_NULLS(e.object) FROM %s e', ContainsJson::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LeastTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LeastTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Least;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsSeveralIntegers;
+
+class LeastTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'LEAST' => Least::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT least(c0_.integer1,c0_.integer2,c0_.integer3) AS sclr_0 FROM ContainsSeveralIntegers c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT LEAST(e.integer1, e.integer2, e.integer3) FROM %s e', ContainsSeveralIntegers::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Overlaps;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class OverlapsTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'OVERLAPS' => Overlaps::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT (c0_.array && '{681,1185,1878}') AS sclr_0 FROM ContainsArray c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT OVERLAPS(e.array, '{681,1185,1878}') FROM %s e", ContainsArray::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringToArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringToArrayTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StringToArray;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsText;
+
+class StringToArrayTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'STRING_TO_ARRAY' => StringToArray::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT string_to_array(c0_.text, ',') AS sclr_0 FROM ContainsText c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT STRING_TO_ARRAY(e.text, ',') FROM %s e", ContainsText::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TestCase.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TestCase.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMException;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    /**
+     * @var Configuration
+     */
+    protected $configuration;
+
+    protected function setUp()
+    {
+        $this->configuration = new Configuration();
+        $this->configuration->setMetadataCacheImpl(new ArrayCache());
+        $this->configuration->setQueryCacheImpl(new ArrayCache());
+        $this->configuration->setProxyDir(__DIR__.'/../../../../Fixtures/Proxies');
+        $this->configuration->setProxyNamespace('MartinGeorgiev\Tests\Doctrine\Fixtures\Proxies');
+        $this->configuration->setAutoGenerateProxyClasses(true);
+        $this->configuration->setMetadataDriverImpl($this->configuration->newDefaultAnnotationDriver(__DIR__.'/../../../../Fixtures/Entities'));
+
+        $this->registerFunction();
+    }
+
+    private function registerFunction()
+    {
+        foreach ($this->getStringFunctions() as $dqlFunction => $functionClass) {
+            $this->configuration->addCustomStringFunction($dqlFunction, $functionClass);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [];
+    }
+
+    /**
+     * @return string
+     */
+    abstract protected function getExpectedSql();
+
+    /**
+     * @return string
+     */
+    abstract protected function getDql();
+
+    /**
+     * @test
+     */
+    public function dql_is_transformed_to_valid_sql()
+    {
+        $this->assertSqlFromDql($this->getExpectedSql(), $this->getDql());
+    }
+
+    /**
+     * @param string $expectedSql
+     * @param string $dql
+     * @param array $paramsForDql
+     */
+    private function assertSqlFromDql($expectedSql, $dql, array $paramsForDql = [])
+    {
+        $query = $this->buildEntityManager()->createQuery($dql);
+        foreach ($paramsForDql as $paramName => $paramValue) {
+            $query->setParameter($paramName, $paramValue);
+        }
+        $this->assertEquals($expectedSql, $query->getSQL());
+    }
+
+    /**
+     * @return EntityManager
+     * @throws ORMException
+     */
+    private function buildEntityManager()
+    {
+        return EntityManager::create(['driver' => 'pdo_sqlite', 'memory' => true], $this->configuration);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ToTsqueryTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ToTsqueryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ToTsquery;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsText;
+
+class ToTsqueryTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'TO_TSQUERY' => ToTsquery::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT to_tsquery(c0_.text) AS sclr_0 FROM ContainsText c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT TO_TSQUERY(e.text) FROM %s e', ContainsText::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ToTsvectorTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ToTsvectorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ToTsvector;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsText;
+
+class ToTsvectorTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'TO_TSVECTOR' => ToTsvector::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT to_tsvector(c0_.text) AS sclr_0 FROM ContainsText c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT TO_TSVECTOR(e.text) FROM %s e', ContainsText::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TsmatchTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TsmatchTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ToTsquery;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ToTsvector;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Tsmatch;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsText;
+
+class TsmatchTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'TO_TSQUERY' => ToTsquery::class,
+            'TO_TSVECTOR' => ToTsvector::class,
+            'TSMATCH' => Tsmatch::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return "SELECT (to_tsvector(c0_.text) @@ to_tsquery('testing')) AS sclr_0 FROM ContainsText c0_";
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf("SELECT TSMATCH(TO_TSVECTOR(e.text), TO_TSQUERY('testing')) FROM %s e", ContainsText::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/UnnestTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/UnnestTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MartinGeorgiev\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Unnest;
+use MartinGeorgiev\Tests\Doctrine\Fixtures\Entity\ContainsArray;
+
+class UnnestTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    protected function getStringFunctions()
+    {
+        return [
+            'UNNEST' => Unnest::class,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedSql()
+    {
+        return 'SELECT unnest(c0_.array) AS sclr_0 FROM ContainsArray c0_';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDql()
+    {
+        return sprintf('SELECT UNNEST(e.array) FROM %s e', ContainsArray::class);
+    }
+}


### PR DESCRIPTION
Update expected nodes from `InputParameter` to `Literal|StringParamater` for some functions. This addresses more frequent use-cases with their usage.