### PR TITLE
Empty strings in quotes

### DIFF
--- a/src/MartinGeorgiev/Utils/DataStructure.php
+++ b/src/MartinGeorgiev/Utils/DataStructure.php
@@ -74,8 +74,6 @@ class DataStructure
 
                 if (\is_numeric($text) || \ctype_digit($text)) {
                     $escapedText = $text;
-                } elseif (empty($text)) {
-                    $escapedText = '';
                 } else {
                     $escapedText = '"'.\str_replace('"', '\"', $text).'"';
                 }

--- a/tests/MartinGeorgiev/Utils/DataStructureTest.php
+++ b/tests/MartinGeorgiev/Utils/DataStructureTest.php
@@ -48,7 +48,7 @@ class DataStructureTest extends TestCase
                     0 => '',
                     1 => '',
                 ],
-                'postgresValue' => '{,}',
+                'postgresValue' => '{"",""}',
             ],
             [
                 'phpValue' => [],


### PR DESCRIPTION
All strings in array must be in quotes (even empty strings). `{,}` is not valid syntax.
For example query `UPDATE foo SET bar = '{,}'` throws an error `ERROR: malformed array literal: "{,}" Detail: Unexpected "," character.`