### PR TITLE
Fix deprecations

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseType.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseType.php
@@ -32,6 +32,14 @@ abstract class BaseType extends Type
         return static::TYPE_NAME;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return false;
+    }
+
     private static function throwExceptionIfTypeNameNotConfigured(): void
     {
         if (null === static::TYPE_NAME) {

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseTypeTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseTypeTest.php
@@ -26,7 +26,7 @@ class BaseTypeTest extends TestCase
         $this->platform = $this->createMock(AbstractPlatform::class);
 
         $this->fixture = $this->getMockBuilder(BaseType::class)
-            ->setMethods(null)
+            ->setMethods([])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
     }


### PR DESCRIPTION
* Add requiresSQLCommentHint() to BaseType

See doctrine/DoctrineBundle#947
Fixes #50 

* Drop null parameter on call to TestCase->setMethods()

The method is type hinted to `array` so `null` is throwing a type error