### PR TITLE
Drop support for PHP 7.1

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
   environment:
-    php: 7.2
+    php: 7.4
 
 coding_style:
   php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
   - nightly
 
 env:
   global:
-    - LATEST_PHP_VERSION="7.3"
+    - LATEST_PHP_VERSION="7.4"
   matrix:
     - DEPENDENCIES="beta"
     - DEPENDENCIES="low"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
 
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ext-ctype": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -47,7 +47,7 @@
         "php-coveralls/php-coveralls": "^2.1",
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-phpunit": "^0.11",
-        "phpunit/phpunit": "^7.5 || ^8.0",
+        "phpunit/phpunit": "^8.5",
         "sensiolabs/security-checker": "^6.0",
         "doctrine/orm": "~2.5"
     },


### PR DESCRIPTION
Additionally, update the CI steps to assess the project against PHP 7.4 by default