### PR TITLE
Allow the primitive types of integer, string and float to be stored in a Jsonb field

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -37,7 +37,7 @@ return PhpCsFixer\Config::create()
             'php_unit_method_casing' => ['case' => 'snake_case'],
             'php_unit_test_class_requires_covers' => false,
             'phpdoc_types_order' => ['null_adjustment' => 'always_last'],
-            'simplified_null_return' => true,
+            'simplified_null_return' => false,
             'single_line_comment_style' => false,
             'static_lambda' => true,
             'yoda_style' => false,

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/TypeException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/TypeException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+/**
+ * @since 1.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+abstract class TypeException extends \Exception
+{
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/UnexpectedTypeOfTransformedPHPValue.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/UnexpectedTypeOfTransformedPHPValue.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+/**
+ * @since 1.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class UnexpectedTypeOfTransformedPHPValue extends TypeException
+{
+    public function __construct(string $untransformedValue, string $typeOfTransformedPHPValue)
+    {
+        $message = \sprintf(
+            'Transforming a PostgreSql value "%s" results to an unexpected PHP value from type "%s".',
+            $untransformedValue,
+            $typeOfTransformedPHPValue
+        );
+        parent::__construct($message);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonTransformer.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonTransformer.php
@@ -16,7 +16,7 @@ use Doctrine\DBAL\Types\ConversionException;
 trait JsonTransformer
 {
     /**
-     * @param mixed $phpValue Value bus be suitable for JSON encoding
+     * @param mixed $phpValue Value must be suitable for JSON encoding
      *
      * @throws ConversionException When given value cannot be encoded
      */
@@ -30,7 +30,10 @@ trait JsonTransformer
         return $postgresValue;
     }
 
-    protected function transformFromPostgresJson(string $postgresValue): array
+    /**
+     * @return array|float|int|string|null
+     */
+    protected function transformFromPostgresJson(string $postgresValue)
     {
         return \json_decode($postgresValue, true);
     }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Jsonb.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Jsonb.php
@@ -47,7 +47,7 @@ class Jsonb extends BaseType
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         if ($value === null) {
-            return;
+            return null;
         }
 
         return $this->transformFromPostgresJson($value);

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Jsonb.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Jsonb.php
@@ -41,11 +41,13 @@ class Jsonb extends BaseType
      * Converts a value from its database representation to its PHP representation of this type.
      *
      * @param string|null $value the value to convert
+     *
+     * @return array|float|int|string|null
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?array
+    public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         if ($value === null) {
-            return null;
+            return;
         }
 
         return $this->transformFromPostgresJson($value);

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArray.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\UnexpectedTypeOfTransformedPHPValue;
+
 /**
  * Implementation of PostgreSql JSONB[] data type.
  *
@@ -42,6 +44,11 @@ class JsonbArray extends BaseArray
 
     public function transformArrayItemForPHP($item): array
     {
-        return $this->transformFromPostgresJson($item);
+        $transformedValue = $this->transformFromPostgresJson($item);
+        if (!\is_array($transformedValue)) {
+            throw new UnexpectedTypeOfTransformedPHPValue($item, \gettype($transformedValue));
+        }
+
+        return $transformedValue;
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MartinGeorgiev\Tests\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\UnexpectedTypeOfTransformedPHPValue;
 use MartinGeorgiev\Doctrine\DBAL\Types\JsonbArray;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -88,5 +89,17 @@ class JsonbArrayTest extends TestCase
     public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
     {
         $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @test
+     */
+    public function throws_an_error_when_transformed_value_is_not_an_array(): void
+    {
+        $this->expectException(UnexpectedTypeOfTransformedPHPValue::class);
+
+        $postgresValue = '"a string encoded as json"';
+
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbTest.php
@@ -43,6 +43,18 @@ class JsonbTest extends TestCase
                 'postgresValue' => '[]',
             ],
             [
+                'phpValue' => 13,
+                'postgresValue' => '13',
+            ],
+            [
+                'phpValue' => 13.93,
+                'postgresValue' => '13.93',
+            ],
+            [
+                'phpValue' => 'a string value',
+                'postgresValue' => '"a string value"',
+            ],
+            [
                 'phpValue' => [681, 1185, 1878, 1989],
                 'postgresValue' => '[681,1185,1878,1989]',
             ],
@@ -70,8 +82,10 @@ class JsonbTest extends TestCase
     /**
      * @test
      * @dataProvider validTransformations
+     *
+     * @var array|float|int|string|null
      */
-    public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
+    public function can_transform_from_php_value($phpValue, ?string $postgresValue): void
     {
         $this->assertEquals($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
     }
@@ -79,8 +93,10 @@ class JsonbTest extends TestCase
     /**
      * @test
      * @dataProvider validTransformations
+     *
+     * @var array|float|int|string|null
      */
-    public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
+    public function can_transform_to_php_value($phpValue, ?string $postgresValue): void
     {
         $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
     }


### PR DESCRIPTION
This PR addresses the `jsonb` limitation described in #58. Until now the only way to work-around it was to wrap the desired primitive value in an array, which honestly was a hack.
The changes are not perceived as backwards incompatible as full compatibility for older values is maintained.