### PR TITLE
Support for DISTINCT and ORDER BY in STRING_AGG

### DIFF
--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAgg.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAgg.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\AST\OrderByClause;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
 /**
  * Implementation of PostgreSql STRING_AGG().
  *
@@ -14,10 +20,64 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
  */
 class StringAgg extends BaseFunction
 {
+    /**
+     * @var bool
+     */
+    private $isDistinct = false;
+
+    /**
+     * @var Node
+     */
+    private $expression;
+
+    /**
+     * @var Node
+     */
+    private $delimiter;
+
+    /**
+     * @var OrderByClause|null
+     */
+    private $orderBy;
+
     protected function customiseFunction(): void
     {
-        $this->setFunctionPrototype('string_agg(%s, %s)');
-        $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('StringPrimary');
+        $this->setFunctionPrototype('string_agg(%s%s, %s%s)');
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $this->customiseFunction();
+
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+
+        $lexer = $parser->getLexer();
+        if ($lexer->isNextToken(Lexer::T_DISTINCT)) {
+            $parser->match(Lexer::T_DISTINCT);
+            $this->isDistinct = true;
+        }
+
+        $this->expression = $parser->StringPrimary();
+        $parser->match(Lexer::T_COMMA);
+        $this->delimiter = $parser->StringPrimary();
+
+        if ($lexer->isNextToken(Lexer::T_ORDER)) {
+            $this->orderBy = $parser->OrderByClause();
+        }
+
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        $dispatched = [
+            $this->isDistinct ? 'distinct ' : '',
+            $this->expression->dispatch($sqlWalker),
+            $this->delimiter->dispatch($sqlWalker),
+            $this->orderBy ? $this->orderBy->dispatch($sqlWalker) : '',
+        ];
+
+        return \vsprintf($this->functionPrototype, $dispatched);
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAggWithDistinctAndOrderByTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAggWithDistinctAndOrderByTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StringAgg;
+use Tests\MartinGeorgiev\Doctrine\Fixtures\Entity\ContainsTexts;
+
+class StringAggWithDistinctAndOrderByTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'STRING_AGG' => StringAgg::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            "SELECT string_agg(distinct c0_.text1 || c0_.text2, ',' ORDER BY c0_.text1 ASC) AS sclr_0 FROM ContainsTexts c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            \sprintf("SELECT STRING_AGG(DISTINCT CONCAT(e.text1, e.text2), ',' ORDER BY e.text1) FROM %s e", ContainsTexts::class),
+        ];
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAggWithDistinctTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAggWithDistinctTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StringAgg;
+use Tests\MartinGeorgiev\Doctrine\Fixtures\Entity\ContainsTexts;
+
+class StringAggWithDistinctTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'STRING_AGG' => StringAgg::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            "SELECT string_agg(distinct c0_.text1 || c0_.text2, ',') AS sclr_0 FROM ContainsTexts c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            \sprintf("SELECT STRING_AGG(DISTINCT CONCAT(e.text1, e.text2), ',') FROM %s e", ContainsTexts::class),
+        ];
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAggWithOrderByTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAggWithOrderByTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StringAgg;
+use Tests\MartinGeorgiev\Doctrine\Fixtures\Entity\ContainsTexts;
+
+class StringAggWithOrderByTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'STRING_AGG' => StringAgg::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            "SELECT string_agg(c0_.text1 || c0_.text2, ',' ORDER BY c0_.text1 ASC) AS sclr_0 FROM ContainsTexts c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            \sprintf("SELECT STRING_AGG(CONCAT(e.text1, e.text2), ',' ORDER BY e.text1) FROM %s e", ContainsTexts::class),
+        ];
+    }
+}


### PR DESCRIPTION
Hi,

I've added support for `distinct` and `order by` in `string_agg`.

I wasn't completely sure how to implement the optionality as `customiseFunction()` seemed rather inflexible. I ended up overriding the `parse()` and `getSql()` methods. Please let me know how to change it in case this is not okay.

Cheers