### PR TITLE
Drop support for dead PHP versions. Modernise CI pipeline.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-/bin/local-php-security-checker* export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -18,21 +18,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '7.4'
-            composer-flags: '--prefer-lowest'
-            continue-on-error: true
-          - php: '7.4'
           - php: '8.0'
           - php: '8.1'
+          - php: '8.2'
             calculate-code-coverage: true
 
     steps:
     - uses: actions/checkout@v3
     
-    - name: Setup PHP with PECL extension
+    - name: Set up PHP with PECL extension
       uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{ matrix.php || '8.1' }}
+        php-version: ${{ matrix.php || '8.2' }}
         coverage: xdebug
         extensions: ctype, json, mbstring
         tools: composer
@@ -53,19 +50,15 @@ jobs:
       run: composer update --prefer-dist --no-interaction --no-progress ${{ matrix.composer-flags }}
 
     - name: Run static analysis
-      continue-on-error: ${{ matrix.continue-on-error || false }}
       run: composer run-static-analysis
 
     - name: Check code style
-      continue-on-error: ${{ matrix.continue-on-error || false }}
       run: composer check-code-style
 
     - name: Check for security vulnerabilities in 3rd party dependencies
-      continue-on-error: ${{ matrix.continue-on-error || false }}
-      run: composer check-security
+      run: composer audit
 
     - name: Run test suite
-      continue-on-error: ${{ matrix.continue-on-error || false }}
       run: composer run-tests-with-clover
 
     - name: Upload coverage results to Coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - php: '8.0'
           - php: '8.1'
           - php: '8.2'
+            ignore-php-version: true
             calculate-code-coverage: true
 
     steps:
@@ -54,6 +55,9 @@ jobs:
 
     - name: Check code style
       run: composer check-code-style
+      if: matrix.ignore-php-version == true
+      env:
+        PHP_CS_FIXER_IGNORE_ENV: 1
 
     - name: Check for security vulnerabilities in 3rd party dependencies
       run: composer audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         include:
           - php: '8.0'
+            continue-on-error: true
           - php: '8.1'
           - php: '8.2'
             ignore-php-version: true
@@ -52,6 +53,7 @@ jobs:
 
     - name: Run static analysis
       run: composer run-static-analysis
+      continue-on-error: ${{ matrix.continue-on-error || false }}
 
     - name: Check code style
       run: composer check-code-style

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-!/bin/local-php-security-checker*
 /bin/
 /vendor/
 composer.lock

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
   environment:
-    php: 8.0
+    php: 8.1
 
 coding_style:
   php:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
   environment:
-    php: 7.4
+    php: 8.0
 
 coding_style:
   php:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/martin-georgiev/postgresql-for-doctrine/badges/quality-score.png)](https://scrutinizer-ci.com/g/martin-georgiev/postgresql-for-doctrine/?branch=master)
-[![Build Status](https://github.com/martin-georgiev/postgresql-for-doctrine/actions/workflows/ci/badge.svg)](https://github.com/martin-georgiev/postgresql-for-doctrine/actions/workflows/ci.yml)
-[![Coverage Status](https://coveralls.io/repos/github/martin-georgiev/postgresql-for-doctrine/badge.svg?branch=master)](https://coveralls.io/github/martin-georgiev/postgresql-for-doctrine?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/martin-georgiev/postgresql-for-doctrine/badges/quality-score.png)](https://scrutinizer-ci.com/g/martin-georgiev/postgresql-for-doctrine/?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/martin-georgiev/postgresql-for-doctrine/badge.svg?branch=main)](https://coveralls.io/github/martin-georgiev/postgresql-for-doctrine?branch=main)
 [![Latest Stable Version](https://poser.pugx.org/martin-georgiev/postgresql-for-doctrine/version)](https://packagist.org/packages/martin-georgiev/postgresql-for-doctrine)
 [![Total Downloads](https://poser.pugx.org/martin-georgiev/postgresql-for-doctrine/downloads)](https://packagist.org/packages/martin-georgiev/postgresql-for-doctrine)
 ----

--- a/ci/php-cs-fixer/config.php
+++ b/ci/php-cs-fixer/config.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-$rootDirectory = __DIR__.'/../../';
+$basePath = __DIR__.'/../../';
 
 $finder = PhpCsFixer\Finder::create()
-    ->in($rootDirectory.'/src')
-    ->in($rootDirectory.'/tests');
+    ->in($basePath.'ci')
+    ->in($basePath.'src')
+    ->in($basePath.'tests');
 
 $config = new PhpCsFixer\Config();
 
@@ -47,6 +48,6 @@ return $config
     )
     ->setRiskyAllowed(true)
     ->setUsingCache(false)
-    ->setIndent("    ")
+    ->setIndent('    ')
     ->setLineEnding("\n")
     ->setFinder($finder);

--- a/ci/rector/config.php
+++ b/ci/rector/config.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector;
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
+use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\If_\ChangeNestedIfsToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\If_\ChangeOrIfContinueToMultiContinueRector;
+use Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
+use Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector;
+use Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $basePath = __DIR__.'/../../';
+    $paths = [
+        $basePath.'ci',
+        $basePath.'src',
+        $basePath.'tests',
+    ];
+    $rectorConfig->paths($paths);
+
+    $rectorConfig->parallel();
+    $rectorConfig->phpstanConfig($basePath.'ci/phpstan/config.neon');
+    $rectorConfig->skip([
+        ClassPropertyAssignToConstructorPromotionRector::class,
+        CallableThisArrayToAnonymousFunctionRector::class,
+        FirstClassCallableRector::class,
+        InlineConstructorDefaultToPropertyRector::class,
+        NewInInitializerRector::class,
+        NullToStrictStringFuncCallArgRector::class,
+        RestoreDefaultNullToNullableTypePropertyRector::class,
+    ]);
+    $rectorConfig->importShortClasses(false);
+    $rectorConfig->importNames(false); // @todo Enable once Rector introduces better support for function imports.
+
+    $rectorConfig->import(SetList::CODE_QUALITY);
+    $rectorConfig->import(SetList::PSR_4);
+    $rectorConfig->import(SetList::PHP_80);
+    $rectorConfig->import(DoctrineSetList::DOCTRINE_CODE_QUALITY);
+    $rectorConfig->import(LevelSetList::UP_TO_PHP_80);
+
+    $rectorConfig->rule(PreparedValueToEarlyReturnRector::class);
+    $rectorConfig->rule(ChangeNestedIfsToEarlyReturnRector::class);
+    $rectorConfig->rule(ChangeOrIfReturnToEarlyReturnRector::class);
+    $rectorConfig->rule(ChangeOrIfContinueToMultiContinueRector::class);
+    $rectorConfig->rule(ChangeNestedForeachIfsToEarlyContinueRector::class);
+    $rectorConfig->rule(RemoveAlwaysElseRector::class);
+    $rectorConfig->rule(ChangeIfElseValueAssignToEarlyReturnRector::class);
+};

--- a/composer.json
+++ b/composer.json
@@ -48,12 +48,12 @@
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "^9.5",
-        "qossmic/deptrac-shim": "^1.0",
+        "qossmic/deptrac-shim": "^0.24||^1.0",
         "rector/rector": "^0.15.1",
-        "symfony/cache": "^4.0||^5.0||^6.0"
+        "symfony/cache": "^5.0||^6.0"
     },
     "suggest": {
-        "php": "^8.1",
+        "php": "^8.2",
         "doctrine/orm": "~2.5||~3.0"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
 
     "require": {
-        "php": "^7.2||^8.0",
+        "php": "^8.0",
         "ext-ctype": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -43,12 +43,13 @@
     },
     "require-dev": {
         "doctrine/orm": "~2.5||~3.0",
-        "friendsofphp/php-cs-fixer": "^3.8",
+        "friendsofphp/php-cs-fixer": "^3.13",
         "php-coveralls/php-coveralls": "^2.5",
-        "phpstan/phpstan": "^1.7",
-        "phpstan/phpstan-phpunit": "^1.1",
+        "phpstan/phpstan": "^1.9",
+        "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "^9.5",
-        "qossmic/deptrac-shim": "^0.23 || ^0.24",
+        "qossmic/deptrac-shim": "^1.0",
+        "rector/rector": "^0.15.1",
         "symfony/cache": "^4.0||^5.0||^6.0"
     },
     "suggest": {
@@ -59,9 +60,6 @@
     "scripts": {
         "check-code-style": [
             "php-cs-fixer fix --config='./ci/php-cs-fixer/config.php' --show-progress=none --dry-run --no-interaction --diff -v"
-        ],
-        "check-security": [
-            "local-php-security-checker"
         ],
         "fix-code-style": [
             "php-cs-fixer fix --config='./ci/php-cs-fixer/config.php' --show-progress=none --no-interaction --diff -v"

--- a/composer.json
+++ b/composer.json
@@ -59,9 +59,11 @@
 
     "scripts": {
         "check-code-style": [
-            "php-cs-fixer fix --config='./ci/php-cs-fixer/config.php' --show-progress=none --dry-run --no-interaction --diff -v"
+            "php-cs-fixer fix --config='./ci/php-cs-fixer/config.php' --show-progress=none --dry-run --no-interaction --diff -v",
+            "rector --config='./ci/rector/config.php' --ansi --no-progress-bar --dry-run"
         ],
         "fix-code-style": [
+            "rector --config='./ci/rector/config.php' --ansi --no-progress-bar",
             "php-cs-fixer fix --config='./ci/php-cs-fixer/config.php' --show-progress=none --no-interaction --diff -v"
         ],
         "run-static-analysis": [

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseArray.php
@@ -50,10 +50,8 @@ abstract class BaseArray extends BaseType
 
     /**
      * Tests if given PHP array item is from compatible type for PostgreSql.
-     *
-     * @param mixed $item
      */
-    protected function isValidArrayItemForDatabase($item): bool
+    protected function isValidArrayItemForDatabase(mixed $item): bool
     {
         return true;
     }
@@ -61,11 +59,9 @@ abstract class BaseArray extends BaseType
     /**
      * Transforms PHP array item to a PostgreSql compatible array item.
      *
-     * @param mixed $item
-     *
      * @return mixed
      */
-    protected function transformArrayItemForPostgres($item)
+    protected function transformArrayItemForPostgres(mixed $item)
     {
         return $item;
     }
@@ -107,11 +103,9 @@ abstract class BaseArray extends BaseType
     /**
      * Transforms PostgreSql array item to a PHP compatible array item.
      *
-     * @param mixed $item
-     *
      * @return mixed
      */
-    protected function transformArrayItemForPHP($item)
+    protected function transformArrayItemForPHP(mixed $item)
     {
         return $item;
     }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArray.php
@@ -24,7 +24,7 @@ abstract class BaseIntegerArray extends BaseArray
     public function isValidArrayItemForDatabase($item): bool
     {
         return (\is_int($item) || \is_string($item))
-            && (bool) \preg_match('/^-?[0-9]+$/', (string) $item)
+            && (bool) \preg_match('/^-?\d+$/', (string) $item)
             && (string) $item >= $this->getMinValue()
             && (string) $item <= $this->getMaxValue();
     }
@@ -38,7 +38,7 @@ abstract class BaseIntegerArray extends BaseArray
             return null;
         }
 
-        $isInvalidPHPInt = (bool) \preg_match('/^-?[0-9]+$/', (string) $item) === false
+        $isInvalidPHPInt = !(bool) \preg_match('/^-?\d+$/', (string) $item)
             || (string) $item < $this->getMinValue()
             || (string) $item > $this->getMaxValue();
         if ($isInvalidPHPInt) {

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArray.php
@@ -38,7 +38,7 @@ class BooleanArray extends BaseArray
     {
         $phpArray = parent::convertToPHPValue($postgresArray, $platform);
         if (\is_array($phpArray)) {
-            $phpArray = \array_map(static function ($value) use ($platform) { return $platform->convertFromBoolean($value); }, $phpArray);
+            $phpArray = \array_map(static fn ($value) => $platform->convertFromBoolean($value), $phpArray);
         }
 
         return $phpArray;

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonTransformer.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonTransformer.php
@@ -20,10 +20,11 @@ trait JsonTransformer
      *
      * @throws ConversionException When given value cannot be encoded
      */
-    protected function transformToPostgresJson($phpValue): string
+    protected function transformToPostgresJson(mixed $phpValue): string
     {
-        $postgresValue = \json_encode($phpValue);
-        if ($postgresValue === false) {
+        try {
+            $postgresValue = \json_encode($phpValue, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
             throw new ConversionException(\sprintf('Value %s can\'t be resolved to valid JSON', \var_export($phpValue, true)));
         }
 
@@ -36,6 +37,6 @@ trait JsonTransformer
     protected function transformFromPostgresJson(string $postgresValue)
     {
         // @phpstan-ignore-next-line
-        return \json_decode($postgresValue, true);
+        return \json_decode($postgresValue, true, 512, JSON_THROW_ON_ERROR);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArray.php
@@ -50,8 +50,14 @@ class JsonbArray extends BaseArray
      */
     public function transformArrayItemForPHP($item): array
     {
-        $transformedValue = $this->transformFromPostgresJson($item);
-        if (!\is_array($transformedValue)) {
+        $transformedValue = null;
+
+        try {
+            $transformedValue = $this->transformFromPostgresJson($item);
+            if (!\is_array($transformedValue)) {
+                throw new UnexpectedTypeOfTransformedPHPValue($item, \gettype($transformedValue));
+            }
+        } catch (\JsonException) {
             throw new UnexpectedTypeOfTransformedPHPValue($item, \gettype($transformedValue));
         }
 

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/TextArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/TextArray.php
@@ -41,7 +41,7 @@ class TextArray extends BaseType
         if (!\is_array($phpTextArray)) {
             throw new \InvalidArgumentException(\sprintf('Value %s is not an array', \var_export($phpTextArray, true)));
         }
-        if (empty($phpTextArray)) {
+        if ($phpTextArray === []) {
             return '{}';
         }
 

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAgg.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAgg.php
@@ -20,25 +20,13 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 class StringAgg extends BaseFunction
 {
-    /**
-     * @var bool
-     */
-    private $isDistinct = false;
+    private bool $isDistinct = false;
 
-    /**
-     * @var Node
-     */
-    private $expression;
+    private Node $expression;
 
-    /**
-     * @var Node
-     */
-    private $delimiter;
+    private Node $delimiter;
 
-    /**
-     * @var OrderByClause|null
-     */
-    private $orderBy;
+    private OrderByClause $orderBy;
 
     protected function customiseFunction(): void
     {
@@ -75,7 +63,7 @@ class StringAgg extends BaseFunction
             $this->isDistinct ? 'distinct ' : '',
             $this->expression->dispatch($sqlWalker),
             $this->delimiter->dispatch($sqlWalker),
-            $this->orderBy ? $this->orderBy->dispatch($sqlWalker) : '',
+            isset($this->orderBy) ? $this->orderBy->dispatch($sqlWalker) : '',
         ];
 
         return \vsprintf($this->functionPrototype, $dispatched);

--- a/src/MartinGeorgiev/Utils/DataStructure.php
+++ b/src/MartinGeorgiev/Utils/DataStructure.php
@@ -48,6 +48,10 @@ class DataStructure
                     continue;
                 }
 
+                if (!\is_string($text)) {
+                    throw new \InvalidArgumentException(\sprintf('Unsupported data type encountered. Expected null, integer, float or string value, got %s', \gettype($text)));
+                }
+
                 $phpArray[$i] = \stripslashes(\str_replace('\"', '"', $text));
             }
 

--- a/src/MartinGeorgiev/Utils/DataStructure.php
+++ b/src/MartinGeorgiev/Utils/DataStructure.php
@@ -49,7 +49,9 @@ class DataStructure
                 }
 
                 if (!\is_string($text)) {
-                    throw new \InvalidArgumentException(\sprintf('Unsupported data type encountered. Expected null, integer, float or string value, got %s', \gettype($text)));
+                    $exceptionMessage = 'Unsupported data type encountered. Expected null, integer, float or string value. Instead it is "%s".';
+
+                    throw new \InvalidArgumentException(\sprintf($exceptionMessage, \gettype($text)));
                 }
 
                 $phpArray[$i] = \stripslashes(\str_replace('\"', '"', $text));
@@ -76,11 +78,7 @@ class DataStructure
                     throw new \InvalidArgumentException('Only single-dimensioned arrays are supported');
                 }
 
-                if (\is_numeric($text) || \ctype_digit($text)) {
-                    $escapedText = $text;
-                } else {
-                    $escapedText = \sprintf('"%s"', \addcslashes($text, '"\\'));
-                }
+                $escapedText = \is_numeric($text) || \ctype_digit($text) ? $text : \sprintf('"%s"', \addcslashes($text, '"\\'));
                 $result[] = $escapedText;
             }
 

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseArrayTest.php
@@ -13,14 +13,14 @@ use PHPUnit\Framework\TestCase;
 class BaseArrayTest extends TestCase
 {
     /**
-     * @var AbstractPlatform|MockObject
+     * @var AbstractPlatform&MockObject
      */
-    private $platform;
+    private MockObject $platform;
 
     /**
-     * @var BaseArray|MockObject
+     * @var BaseArray&MockObject
      */
-    private $fixture;
+    private MockObject $fixture;
 
     protected function setUp(): void
     {

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseArrayTest.php
@@ -54,6 +54,7 @@ class BaseArrayTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      */
     public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
@@ -67,6 +68,7 @@ class BaseArrayTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      */
     public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArrayTest.php
@@ -32,6 +32,7 @@ abstract class BaseIntegerArrayTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider invalidTransformations
      *
      * @param mixed $phpValue
@@ -48,6 +49,7 @@ abstract class BaseIntegerArrayTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      */
     public function can_transform_from_php_value(int $phpValue, string $postgresValue): void
@@ -57,6 +59,7 @@ abstract class BaseIntegerArrayTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      */
     public function can_transform_to_php_value(int $phpValue, string $postgresValue): void

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArrayTest.php
@@ -11,9 +11,9 @@ use PHPUnit\Framework\TestCase;
 abstract class BaseIntegerArrayTest extends TestCase
 {
     /**
-     * @var BaseIntegerArray|MockObject
+     * @var BaseIntegerArray&MockObject
      */
-    protected $fixture;
+    protected MockObject $fixture;
 
     /**
      * @return array<int, mixed>
@@ -34,10 +34,8 @@ abstract class BaseIntegerArrayTest extends TestCase
      * @test
      *
      * @dataProvider invalidTransformations
-     *
-     * @param mixed $phpValue
      */
-    public function can_detect_invalid_for_transformation_php_value($phpValue): void
+    public function can_detect_invalid_for_transformation_php_value(mixed $phpValue): void
     {
         $this->assertFalse($this->fixture->isValidArrayItemForDatabase($phpValue));
     }

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseTypeTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/BaseTypeTest.php
@@ -12,14 +12,14 @@ use PHPUnit\Framework\TestCase;
 class BaseTypeTest extends TestCase
 {
     /**
-     * @var AbstractPlatform|MockObject
+     * @var AbstractPlatform&MockObject
      */
-    private $platform;
+    private MockObject $platform;
 
     /**
-     * @var BaseType|MockObject
+     * @var BaseType&MockObject
      */
-    private $fixture;
+    private MockObject $fixture;
 
     protected function setUp(): void
     {

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/BigIntArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/BigIntArrayTest.php
@@ -28,18 +28,18 @@ class BigIntArrayTest extends BaseIntegerArrayTest
 
     public function invalidTransformations(): array
     {
-        return \array_merge(parent::invalidTransformations(), [['-9223372036854775807.01'], [-9223372036854775809]]);
+        return \array_merge(parent::invalidTransformations(), [['-9223372036854775807.01'], [-9_223_372_036_854_775_809.0]]);
     }
 
     public function validTransformations(): array
     {
         return [
             [
-                'phpValue' => -9223372036854775807,
+                'phpValue' => -9_223_372_036_854_775_807,
                 'postgresValue' => '-9223372036854775807',
             ],
             [
-                'phpValue' => 9223372036854775807,
+                'phpValue' => 9_223_372_036_854_775_807,
                 'postgresValue' => '9223372036854775807',
             ],
         ];

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArrayTest.php
@@ -64,6 +64,7 @@ class BooleanArrayTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      */
     public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue, ?array $platformValue): void
@@ -77,6 +78,7 @@ class BooleanArrayTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      */
     public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArrayTest.php
@@ -12,14 +12,14 @@ use PHPUnit\Framework\TestCase;
 class BooleanArrayTest extends TestCase
 {
     /**
-     * @var AbstractPlatform|MockObject
+     * @var AbstractPlatform&MockObject
      */
-    private $platform;
+    private MockObject $platform;
 
     /**
-     * @var BooleanArray|MockObject
+     * @var BooleanArray&MockObject
      */
-    private $fixture;
+    private MockObject $fixture;
 
     protected function setUp(): void
     {

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/IntegerArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/IntegerArrayTest.php
@@ -31,18 +31,18 @@ class IntegerArrayTest extends BaseIntegerArrayTest
      */
     public function invalidTransformations(): array
     {
-        return \array_merge(parent::invalidTransformations(), [['-2147483647.01'], [2147483649]]);
+        return \array_merge(parent::invalidTransformations(), [['-2147483647.01'], [2_147_483_649]]);
     }
 
     public function validTransformations(): array
     {
         return [
             [
-                'phpValue' => -2147483648,
+                'phpValue' => -2_147_483_648,
                 'postgresValue' => '-2147483648',
             ],
             [
-                'phpValue' => 2147483647,
+                'phpValue' => 2_147_483_647,
                 'postgresValue' => '2147483647',
             ],
         ];

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
@@ -80,6 +80,7 @@ class JsonbArrayTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      */
     public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
@@ -89,6 +90,7 @@ class JsonbArrayTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      */
     public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
@@ -13,14 +13,14 @@ use PHPUnit\Framework\TestCase;
 class JsonbArrayTest extends TestCase
 {
     /**
-     * @var AbstractPlatform|MockObject
+     * @var AbstractPlatform&MockObject
      */
-    private $platform;
+    private MockObject $platform;
 
     /**
-     * @var JsonbArray|MockObject
+     * @var JsonbArray&MockObject
      */
-    private $fixture;
+    private MockObject $fixture;
 
     protected function setUp(): void
     {

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbTest.php
@@ -86,6 +86,7 @@ class JsonbTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      *
      * @param array|float|int|string|null $phpValue
@@ -97,6 +98,7 @@ class JsonbTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      *
      * @param array|float|int|string|null $phpValue

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/JsonbTest.php
@@ -12,14 +12,14 @@ use PHPUnit\Framework\TestCase;
 class JsonbTest extends TestCase
 {
     /**
-     * @var AbstractPlatform|MockObject
+     * @var AbstractPlatform&MockObject
      */
-    private $platform;
+    private MockObject $platform;
 
     /**
-     * @var Jsonb|MockObject
+     * @var Jsonb&MockObject
      */
-    private $fixture;
+    private MockObject $fixture;
 
     protected function setUp(): void
     {

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
@@ -12,14 +12,14 @@ use PHPUnit\Framework\TestCase;
 class TextArrayTest extends TestCase
 {
     /**
-     * @var AbstractPlatform|MockObject
+     * @var AbstractPlatform&MockObject
      */
-    private $platform;
+    private MockObject $platform;
 
     /**
-     * @var MockObject|TextArray
+     * @var MockObject&TextArray
      */
-    private $fixture;
+    private MockObject $fixture;
 
     protected function setUp(): void
     {

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
@@ -76,6 +76,7 @@ END
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      */
     public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
@@ -85,6 +86,7 @@ END
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      */
     public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void

--- a/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/Entity.php
+++ b/tests/MartinGeorgiev/Doctrine/Fixtures/Entity/Entity.php
@@ -10,7 +10,9 @@ abstract class Entity
      * @var string
      *
      * @Id
+     *
      * @Column(type="string")
+     *
      * @GeneratedValue
      */
     public $id;

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TestCase.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TestCase.php
@@ -8,20 +8,16 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 abstract class TestCase extends BaseTestCase
 {
     protected const FIXTURES_DIRECTORY = __DIR__.'/../../../../Fixtures';
 
-    /**
-     * @var Configuration
-     */
-    private $configuration;
+    private Configuration $configuration;
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $configuration = new Configuration();
         $configuration->setProxyDir(static::FIXTURES_DIRECTORY.'/Proxies');
         $configuration->setProxyNamespace('Tests\MartinGeorgiev\Doctrine\Fixtures\Proxies');
@@ -36,7 +32,7 @@ abstract class TestCase extends BaseTestCase
 
     private function setConfigurationCache(Configuration $configuration): void
     {
-        $symfonyArrayAdapterClass = '\Symfony\Component\Cache\Adapter\ArrayAdapter';
+        $symfonyArrayAdapterClass = '\\'.ArrayAdapter::class;
         $useDbalV3 = \class_exists($symfonyArrayAdapterClass) && \method_exists($configuration, 'setMetadataCache') && \method_exists($configuration, 'setQueryCache');
         if ($useDbalV3) {
             // @phpstan-ignore-next-line

--- a/tests/MartinGeorgiev/Utils/DataStructureTest.php
+++ b/tests/MartinGeorgiev/Utils/DataStructureTest.php
@@ -61,6 +61,7 @@ class DataStructureTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      *
      * @param array<int, array<string, array|string>> $phpValue
@@ -72,6 +73,7 @@ class DataStructureTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider validTransformations
      *
      * @param array<int, array<string, array|string>> $phpValue
@@ -107,6 +109,7 @@ class DataStructureTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider invalidTransformations
      *
      * @param array<int, mixed> $phpValue
@@ -119,6 +122,7 @@ class DataStructureTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider invalidTransformations
      *
      * @param array<int, mixed> $phpValue


### PR DESCRIPTION
- Introducing Rector and applying some basic rules
- Dropping support for the now-dead PHP 7 versions
- Upgrade dev dependencies