### PR TITLE
fix: parse text[] as array<string>

### DIFF
--- a/src/MartinGeorgiev/Utils/DataStructure.php
+++ b/src/MartinGeorgiev/Utils/DataStructure.php
@@ -34,20 +34,6 @@ class DataStructure
                     break;
                 }
 
-                $isInteger = \is_numeric($text) && ''.(int) $text === $text;
-                if ($isInteger) {
-                    $phpArray[$i] = (int) $text;
-
-                    continue;
-                }
-
-                $isFloat = \is_numeric($text) && ''.(float) $text === $text;
-                if ($isFloat) {
-                    $phpArray[$i] = (float) $text;
-
-                    continue;
-                }
-
                 if (!\is_string($text)) {
                     $exceptionMessage = 'Unsupported data type encountered. Expected null, integer, float or string value. Instead it is "%s".';
 

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
@@ -44,7 +44,7 @@ class TextArrayTest extends TestCase
             ],
             [
                 'phpValue' => [
-                    1,
+                    '1',
                     '2',
                     'text',
                     'some text here',
@@ -69,7 +69,7 @@ END
      */
     public function has_name(): void
     {
-        $this->assertEquals('text[]', $this->fixture->getName());
+        $this->assertSame('text[]', $this->fixture->getName());
     }
 
     /**
@@ -79,7 +79,7 @@ END
      */
     public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
     {
-        $this->assertEquals($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
     }
 
     /**
@@ -89,6 +89,6 @@ END
      */
     public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
     {
-        $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
     }
 }

--- a/tests/MartinGeorgiev/Utils/DataStructureTest.php
+++ b/tests/MartinGeorgiev/Utils/DataStructureTest.php
@@ -43,7 +43,7 @@ class DataStructureTest extends TestCase
                     0 => 'dfasdf',
                     1 => 'qw,,e{q"we',
                     2 => "'qrer'",
-                    3 => 604,
+                    3 => '604',
                     4 => '"aaa","b""bb","ccc"',
                 ],
                 'postgresValue' => '{"dfasdf","qw,,e{q\"we","\'qrer\'",604,"\"aaa\",\"b\"\"bb\",\"ccc\""}',
@@ -71,7 +71,7 @@ class DataStructureTest extends TestCase
      */
     public function can_transform_from_php_value(array $phpValue, string $postgresValue): void
     {
-        $this->assertEquals($postgresValue, DataStructure::transformPHPArrayToPostgresTextArray($phpValue));
+        $this->assertSame($postgresValue, DataStructure::transformPHPArrayToPostgresTextArray($phpValue));
     }
 
     /**
@@ -83,7 +83,7 @@ class DataStructureTest extends TestCase
      */
     public function can_transform_to_php_value(array $phpValue, string $postgresValue): void
     {
-        $this->assertEquals($phpValue, DataStructure::transformPostgresTextArrayToPHPArray($postgresValue));
+        $this->assertSame($phpValue, DataStructure::transformPostgresTextArrayToPHPArray($postgresValue));
     }
 
     /**


### PR DESCRIPTION
Hey,

The way `MartinGeorgiev\Doctrine\DBAL\Types\TextArray` converts database values to php floats/int broke my expectations.

When I save `['a', '1', '0.1']` to my database, I expect to get back the same `['a', '1', '0.1']`, NOT `['a', 1, 0.1]`. Especially when the column name is "text".

I also checked postgres itself, and there is no magic casting:
```
database=# select pg_typeof(('{0.4}'::text[])[1]);
 pg_typeof
-----------
 text
(1 row)
```