### PR TITLE
Change `Literal` usage to accept `InputParameter` types

### DIFF
--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppend.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppend.php
@@ -18,6 +18,6 @@ class ArrayAppend extends BaseFunction
     {
         $this->setFunctionPrototype('array_append(%s, %s)');
         $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('Literal');
+        $this->addNodeMapping('StringPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLength.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLength.php
@@ -18,6 +18,6 @@ class ArrayLength extends BaseFunction
     {
         $this->setFunctionPrototype('array_length(%s, %s)');
         $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('Literal');
+        $this->addNodeMapping('StringPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrepend.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrepend.php
@@ -17,7 +17,7 @@ class ArrayPrepend extends BaseFunction
     protected function customiseFunction(): void
     {
         $this->setFunctionPrototype('array_prepend(%s, %s)');
-        $this->addNodeMapping('Literal');
+        $this->addNodeMapping('StringPrimary');
         $this->addNodeMapping('StringPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemove.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemove.php
@@ -18,6 +18,6 @@ class ArrayRemove extends BaseFunction
     {
         $this->setFunctionPrototype('array_remove(%s, %s)');
         $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('Literal');
+        $this->addNodeMapping('StringPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplace.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplace.php
@@ -18,7 +18,7 @@ class ArrayReplace extends BaseFunction
     {
         $this->setFunctionPrototype('array_replace(%s, %s, %s)');
         $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('Literal');
-        $this->addNodeMapping('Literal');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
     }
 }


### PR DESCRIPTION
The use of Literal was preventing usage of doctrine input parameters as `:myQueryInputParameter`

So to allow its use I changed Literals to StringPrimary accepting more diverse parameters including InputParameter and that seemed already well used in code base.

> StringPrimary          ::= StateFieldPathExpression | string | InputParameter | FunctionsReturningStrings | AggregateExpression | CaseExpression

> Literal     ::= string | char | integer | float | boolean

https://www.doctrine-project.org/projects/doctrine-orm/en/2.16/reference/dql-doctrine-query-language.html