### PR TITLE
Define doctrine/lexer dependency range correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,8 @@
         "symfony/cache": "^6.4||^7.0"
     },
     "conflict": {
-        "doctrine/lexer": "< 1.0 || >= 3.0",
-        "doctrine/orm": "< 2.8 || >= 3.0"
+        "doctrine/lexer": "<1.0||>=3.0",
+        "doctrine/orm": "<2.8||>=3.0"
     },
     "suggest": {
         "php": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -40,11 +40,12 @@
         "ext-ctype": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "doctrine/dbal": "~2.5||~3.0"
+        "doctrine/dbal": "~2.10||~3.0"
     },
     "require-dev": {
         "doctrine/annotations": "^2.0",
-        "doctrine/orm": "~2.5||~3.0",
+        "doctrine/lexer": "~1.0||~2.0",
+        "doctrine/orm": "~2.8||~3.0",
         "ekino/phpstan-banned-code": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.48.0",
         "php-coveralls/php-coveralls": "^2.7.0",
@@ -55,9 +56,13 @@
         "rector/rector": "^0.19",
         "symfony/cache": "^6.4||^7.0"
     },
+    "conflict": {
+        "doctrine/lexer": "< 1.0 || >= 3.0",
+        "doctrine/orm": "< 2.8 || >= 4.0"
+    },
     "suggest": {
         "php": "^8.3",
-        "doctrine/orm": "~2.5||~3.0"
+        "doctrine/orm": "~2.8||~3.0"
     },
 
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     },
     "conflict": {
         "doctrine/lexer": "< 1.0 || >= 3.0",
-        "doctrine/orm": "< 2.8 || >= 4.0"
+        "doctrine/orm": "< 2.8 || >= 3.0"
     },
     "suggest": {
         "php": "^8.3",


### PR DESCRIPTION
Related to: https://github.com/doctrine/orm/issues/11192

Also we need to define which `doctrine/orm` version is supported that not accidently a none supported version is installed. Optional dependencies need in composer be handled via `conflict`.

Increase of doctrine/orm and dbal is required as doctrine/lexer was just added after doctrine/orm 2.8.

Similar changes for other doctrine extensions like https://github.com/oroinc/doctrine-extensions/pull/96 are required.