### PR TITLE
Bump minimum Doctrine ORM version to v2.14 and add support for Doctrine ORM v3 & Lexer v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   tests:
-    name: "PHP ${{ matrix.php }} + Composer ${{ matrix.composer-flags }}"
+    name: "PHP ${{ matrix.php }} + Doctrine ORM ${{ matrix.doctrine-orm }} + Composer ${{ matrix.composer-flags }}"
     runs-on: ubuntu-latest
 
     strategy:
@@ -23,10 +23,13 @@ jobs:
           - php: '8.3'
             ignore-php-version: true
             calculate-code-coverage: true
+          - doctrine-orm: '2.14'
+          - doctrine-orm: '3.0'
+          - doctrine-orm: 'latest'
 
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up PHP with PECL extension
       uses: shivammathur/setup-php@v2
       with:
@@ -48,7 +51,14 @@ jobs:
           ${{ runner.os }}-php-
 
     - name: Install composer dependencies
-      run: composer update --prefer-dist --no-interaction --no-progress ${{ matrix.composer-flags }}
+      run: |
+        if [ "${{ matrix.doctrine-orm }}" == "2.14" ]; then
+          composer require doctrine/orm "~2.14" --prefer-dist --no-interaction --no-progress ${{ matrix.composer-flags }}
+        elif [ "${{ matrix.doctrine-orm }}" == "3.0" ]; then
+          composer require doctrine/orm "~3.0" --prefer-dist --no-interaction --no-progress ${{ matrix.composer-flags }}
+        else
+          composer update --prefer-dist --no-interaction --no-progress ${{ matrix.composer-flags }}
+        fi
 
     - name: Run static analysis
       run: composer run-static-analysis

--- a/ci/phpstan/config.neon
+++ b/ci/phpstan/config.neon
@@ -13,3 +13,6 @@ parameters:
     ignoreErrors:
         - '#Parameter \#1 \$phpArray of method MartinGeorgiev\\Doctrine\\DBAL\\Types\\BaseArray::convertToDatabaseValue\(\) expects array\|null, string given.#'
         - '#Parameter \#1 \$postgresArray of method MartinGeorgiev\\Doctrine\\DBAL\\Types\\BaseArray::convertToPHPValue\(\) expects string\|null, int given.#'
+        - '#Property MartinGeorgiev\\Doctrine\\ORM\\Query\\AST\\Functions\\Cast::\$sourceType \(Doctrine\\ORM\\Query\\AST\\Node\) does not accept Doctrine\\ORM\\Query\\AST\\Node\|string#'
+        - '#Access to undefined constant Doctrine\\ORM\\Query\\Lexer::T_[A-Z_]+#'
+        - '#Access to constant [A-Z_]+ on an unknown class Doctrine\\ORM\\Query\\TokenType#'

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,7 @@
         "doctrine/dbal": "~2.10||~3.0"
     },
     "require-dev": {
-        "doctrine/annotations": "^2.0",
-        "doctrine/orm": "~2.8||~3.0",
+        "doctrine/orm": "~2.14||~3.0",
         "ekino/phpstan-banned-code": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.49.0",
         "php-coveralls/php-coveralls": "^2.7.0",
@@ -55,12 +54,9 @@
         "rector/rector": "^1.0.1",
         "symfony/cache": "^6.4||^7.0"
     },
-    "conflict": {
-        "doctrine/orm": "<2.8"
-    },
     "suggest": {
         "php": "^8.3",
-        "doctrine/orm": "~2.8||~3.0"
+        "doctrine/orm": "~2.14||~3.0"
     },
 
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
     },
     "require-dev": {
         "doctrine/annotations": "^2.0",
-        "doctrine/lexer": "~1.0||~2.0",
         "doctrine/orm": "~2.8||~3.0",
         "ekino/phpstan-banned-code": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.49.0",
@@ -57,8 +56,7 @@
         "symfony/cache": "^6.4||^7.0"
     },
     "conflict": {
-        "doctrine/lexer": "<1.0||>=3.0",
-        "doctrine/orm": "<2.8||>=3.0"
+        "doctrine/orm": "<2.8"
     },
     "suggest": {
         "php": "^8.3",

--- a/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsArrays.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsArrays.php
@@ -6,18 +6,12 @@ namespace Fixtures\MartinGeorgiev\Doctrine\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity()
- */
+#[ORM\Entity()]
 class ContainsArrays extends Entity
 {
-    /**
-     * @ORM\Column(type="array")
-     */
+    #[ORM\Column(type: 'json')]
     public array $array1;
 
-    /**
-     * @ORM\Column(type="array")
-     */
+    #[ORM\Column(type: 'json')]
     public array $array2;
 }

--- a/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsDates.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsDates.php
@@ -6,18 +6,12 @@ namespace Fixtures\MartinGeorgiev\Doctrine\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity()]
 class ContainsDates extends Entity
 {
-    /**
-     * @ORM\Column(type="date_immutable")
-     */
+    #[ORM\Column(type: 'date_immutable')]
     public \DateTimeImmutable $date1;
 
-    /**
-     * @ORM\Column(type="date_immutable")
-     */
+    #[ORM\Column(type: 'date_immutable')]
     public \DateTimeImmutable $date2;
 }

--- a/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsIntegers.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsIntegers.php
@@ -6,23 +6,15 @@ namespace Fixtures\MartinGeorgiev\Doctrine\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity()]
 class ContainsIntegers extends Entity
 {
-    /**
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Column(type: 'integer')]
     public int $integer1;
 
-    /**
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Column(type: 'integer')]
     public int $integer2;
 
-    /**
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Column(type: 'integer')]
     public int $integer3;
 }

--- a/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsJsons.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsJsons.php
@@ -6,18 +6,12 @@ namespace Fixtures\MartinGeorgiev\Doctrine\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity()]
 class ContainsJsons extends Entity
 {
-    /**
-     * @ORM\Column(type="json")
-     */
+    #[ORM\Column(type: 'json')]
     public array $object1;
 
-    /**
-     * @ORM\Column(type="json")
-     */
+    #[ORM\Column(type: 'json')]
     public array $object2;
 }

--- a/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsTexts.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsTexts.php
@@ -6,18 +6,12 @@ namespace Fixtures\MartinGeorgiev\Doctrine\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity()]
 class ContainsTexts extends Entity
 {
-    /**
-     * @ORM\Column(type="text")
-     */
+    #[ORM\Column(type: 'text')]
     public string $text1;
 
-    /**
-     * @ORM\Column(type="text")
-     */
+    #[ORM\Column(type: 'text')]
     public string $text2;
 }

--- a/fixtures/MartinGeorgiev/Doctrine/Entity/Entity.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Entity/Entity.php
@@ -15,5 +15,8 @@ abstract class Entity
      *
      * @ORM\GeneratedValue
      */
+    #[ORM\Id()]
+    #[ORM\Column(type: 'string')]
+    #[ORM\GeneratedValue()]
     public string $id;
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseFunction.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @since 0.1
@@ -43,12 +44,14 @@ abstract class BaseFunction extends FunctionNode
 
     public function parse(Parser $parser): void
     {
+        $ormV2 = !\class_exists(TokenType::class);
+
         $this->customiseFunction();
 
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match($ormV2 ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
+        $parser->match($ormV2 ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
         $this->feedParserWithNodes($parser);
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match($ormV2 ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /**
@@ -62,7 +65,7 @@ abstract class BaseFunction extends FunctionNode
             $parserMethod = $this->nodesMapping[$i];
             $this->nodes[$i] = $parser->{$parserMethod}();
             if ($i < $lastNode) {
-                $parser->match(Lexer::T_COMMA);
+                $parser->match(\class_exists(TokenType::class) ? TokenType::T_COMMA : Lexer::T_COMMA);
             }
         }
     }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseFunction.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
+use MartinGeorgiev\Utils\DoctrineOrm;
 
 /**
  * @since 0.1
@@ -44,7 +45,7 @@ abstract class BaseFunction extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $ormV2 = !\class_exists(TokenType::class);
+        $ormV2 = DoctrineOrm::isPre219();
 
         $this->customiseFunction();
 

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseFunction.php
@@ -45,14 +45,14 @@ abstract class BaseFunction extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $ormV2 = DoctrineOrm::isPre219();
+        $shouldUseLexer = DoctrineOrm::isPre219();
 
         $this->customiseFunction();
 
-        $parser->match($ormV2 ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
-        $parser->match($ormV2 ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
+        $parser->match($shouldUseLexer ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
+        $parser->match($shouldUseLexer ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
         $this->feedParserWithNodes($parser);
-        $parser->match($ormV2 ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
+        $parser->match($shouldUseLexer ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /**

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
+use MartinGeorgiev\Utils\DoctrineOrm;
 
 /**
  * @author Martin Georgiev <martin.georgiev@gmail.com>
@@ -27,7 +28,7 @@ abstract class BaseVariadicFunction extends BaseFunction
         }
 
         $aheadType = $lexer->lookahead->type;
-        $ormV2 = !\class_exists(TokenType::class);
+        $ormV2 = DoctrineOrm::isPre219();
 
         while (($ormV2 ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS) !== $aheadType) {
             if (($ormV2 ? Lexer::T_COMMA : TokenType::T_COMMA) === $aheadType) {

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
@@ -28,11 +28,11 @@ abstract class BaseVariadicFunction extends BaseFunction
         }
 
         $aheadType = $lexer->lookahead->type;
-        $ormV2 = DoctrineOrm::isPre219();
+        $shouldUseLexer = DoctrineOrm::isPre219();
 
-        while (($ormV2 ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS) !== $aheadType) {
-            if (($ormV2 ? Lexer::T_COMMA : TokenType::T_COMMA) === $aheadType) {
-                $parser->match($ormV2 ? Lexer::T_COMMA : TokenType::T_COMMA);
+        while (($shouldUseLexer ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS) !== $aheadType) {
+            if (($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA) === $aheadType) {
+                $parser->match($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA);
                 $this->nodes[] = $parser->{$this->commonNodeMapping}();
             }
             $aheadType = $lexer->lookahead->type;

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
@@ -30,13 +30,13 @@ class Cast extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $ormV2 = DoctrineOrm::isPre219();
+        $shouldUseLexer = DoctrineOrm::isPre219();
 
-        $parser->match($ormV2 ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
-        $parser->match($ormV2 ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
+        $parser->match($shouldUseLexer ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
+        $parser->match($shouldUseLexer ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
         $this->sourceType = $parser->SimpleArithmeticExpression();
-        $parser->match($ormV2 ? Lexer::T_AS : TokenType::T_AS);
-        $parser->match($ormV2 ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
+        $parser->match($shouldUseLexer ? Lexer::T_AS : TokenType::T_AS);
+        $parser->match($shouldUseLexer ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
 
         $lexer = $parser->getLexer();
         $token = $lexer->token;
@@ -48,24 +48,24 @@ class Cast extends FunctionNode
         }
 
         $type = $token->value;
-        if ($lexer->isNextToken($ormV2 ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS)) {
-            $parser->match($ormV2 ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
+        if ($lexer->isNextToken($shouldUseLexer ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS)) {
+            $parser->match($shouldUseLexer ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
             $parameter = $parser->Literal();
             $parameters = [$parameter->value];
-            if ($lexer->isNextToken($ormV2 ? Lexer::T_COMMA : TokenType::T_COMMA)) {
-                while ($lexer->isNextToken($ormV2 ? Lexer::T_COMMA : TokenType::T_COMMA)) {
-                    $parser->match($ormV2 ? Lexer::T_COMMA : TokenType::T_COMMA);
+            if ($lexer->isNextToken($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA)) {
+                while ($lexer->isNextToken($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA)) {
+                    $parser->match($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA);
                     $parameter = $parser->Literal();
                     $parameters[] = $parameter->value;
                 }
             }
-            $parser->match($ormV2 ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
+            $parser->match($shouldUseLexer ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
             $type .= '('.\implode(', ', $parameters).')';
         }
 
         $this->targetType = $type;
 
-        $parser->match($ormV2 ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
+        $parser->match($shouldUseLexer ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
     }
 
     public function getSql(SqlWalker $sqlWalker): string

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
+use MartinGeorgiev\Utils\DoctrineOrm;
 
 /**
  * Implementation of PostgreSql CAST().
@@ -29,7 +30,7 @@ class Cast extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $ormV2 = !\class_exists(TokenType::class);
+        $ormV2 = DoctrineOrm::isPre219();
 
         $parser->match($ormV2 ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
         $parser->match($ormV2 ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAgg.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAgg.php
@@ -37,28 +37,28 @@ class StringAgg extends BaseFunction
 
     public function parse(Parser $parser): void
     {
-        $ormV2 = DoctrineOrm::isPre219();
+        $shouldUseLexer = DoctrineOrm::isPre219();
 
         $this->customiseFunction();
 
-        $parser->match($ormV2 ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
-        $parser->match($ormV2 ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
+        $parser->match($shouldUseLexer ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
+        $parser->match($shouldUseLexer ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
 
         $lexer = $parser->getLexer();
-        if ($lexer->isNextToken($ormV2 ? Lexer::T_DISTINCT : TokenType::T_DISTINCT)) {
-            $parser->match($ormV2 ? Lexer::T_DISTINCT : TokenType::T_DISTINCT);
+        if ($lexer->isNextToken($shouldUseLexer ? Lexer::T_DISTINCT : TokenType::T_DISTINCT)) {
+            $parser->match($shouldUseLexer ? Lexer::T_DISTINCT : TokenType::T_DISTINCT);
             $this->isDistinct = true;
         }
 
         $this->expression = $parser->StringPrimary();
-        $parser->match($ormV2 ? Lexer::T_COMMA : TokenType::T_COMMA);
+        $parser->match($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA);
         $this->delimiter = $parser->StringPrimary();
 
-        if ($lexer->isNextToken($ormV2 ? Lexer::T_ORDER : TokenType::T_ORDER)) {
+        if ($lexer->isNextToken($shouldUseLexer ? Lexer::T_ORDER : TokenType::T_ORDER)) {
             $this->orderByClause = $parser->OrderByClause();
         }
 
-        $parser->match($ormV2 ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
+        $parser->match($shouldUseLexer ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
     }
 
     public function getSql(SqlWalker $sqlWalker): string

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAgg.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAgg.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Query\AST\OrderByClause;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * Implementation of PostgreSql STRING_AGG().
@@ -35,26 +36,28 @@ class StringAgg extends BaseFunction
 
     public function parse(Parser $parser): void
     {
+        $ormV2 = !\class_exists(TokenType::class);
+
         $this->customiseFunction();
 
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match($ormV2 ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
+        $parser->match($ormV2 ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
 
         $lexer = $parser->getLexer();
-        if ($lexer->isNextToken(Lexer::T_DISTINCT)) {
-            $parser->match(Lexer::T_DISTINCT);
+        if ($lexer->isNextToken($ormV2 ? Lexer::T_DISTINCT : TokenType::T_DISTINCT)) {
+            $parser->match($ormV2 ? Lexer::T_DISTINCT : TokenType::T_DISTINCT);
             $this->isDistinct = true;
         }
 
         $this->expression = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match($ormV2 ? Lexer::T_COMMA : TokenType::T_COMMA);
         $this->delimiter = $parser->StringPrimary();
 
-        if ($lexer->isNextToken(Lexer::T_ORDER)) {
+        if ($lexer->isNextToken($ormV2 ? Lexer::T_ORDER : TokenType::T_ORDER)) {
             $this->orderByClause = $parser->OrderByClause();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match($ormV2 ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
     }
 
     public function getSql(SqlWalker $sqlWalker): string

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAgg.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StringAgg.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
+use MartinGeorgiev\Utils\DoctrineOrm;
 
 /**
  * Implementation of PostgreSql STRING_AGG().
@@ -36,7 +37,7 @@ class StringAgg extends BaseFunction
 
     public function parse(Parser $parser): void
     {
-        $ormV2 = !\class_exists(TokenType::class);
+        $ormV2 = DoctrineOrm::isPre219();
 
         $this->customiseFunction();
 

--- a/src/MartinGeorgiev/Utils/DoctrineOrm.php
+++ b/src/MartinGeorgiev/Utils/DoctrineOrm.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Utils;
+
+use Doctrine\ORM\Query\TokenType;
+
+/**
+ * @internal
+ */
+final class DoctrineOrm
+{
+    public static function isPre219(): bool
+    {
+        return !\class_exists(TokenType::class);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseComparisonFunctionTestCase.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseComparisonFunctionTestCase.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parser;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseComparisonFunction;
 
@@ -20,14 +22,16 @@ abstract class BaseComparisonFunctionTestCase extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The parser\'s "lookahead" property is not populated with a type');
 
-        $lexer = $this->createMock(Lexer::class);
-        $lexer->lookahead = null;
+        $em = $this->createMock(EntityManager::class);
+        $em->expects($this->any())
+            ->method('getConfiguration')
+            ->willReturn(new Configuration());
 
-        $parser = $this->createMock(Parser::class);
-        $parser
-            ->expects($this->once())
-            ->method('getLexer')
-            ->willReturn($lexer);
+        $query = new Query($em);
+        $query->setDQL('TRUE');
+
+        $parser = new Parser($query);
+        $parser->getLexer()->moveNext();
 
         $this->createFixture()->feedParserWithNodes($parser);
     }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TestCase.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TestCase.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -18,11 +20,10 @@ abstract class TestCase extends BaseTestCase
 
     protected function setUp(): void
     {
-        $configuration = new Configuration();
+        $configuration = ORMSetup::createAttributeMetadataConfiguration([static::FIXTURES_DIRECTORY], false);
         $configuration->setProxyDir(static::FIXTURES_DIRECTORY.'/Proxies');
         $configuration->setProxyNamespace('Fixtures\MartinGeorgiev\Doctrine\Entity\Proxy');
         $configuration->setAutoGenerateProxyClasses(true);
-        $configuration->setMetadataDriverImpl($configuration->newDefaultAnnotationDriver([static::FIXTURES_DIRECTORY], false));
         $this->setConfigurationCache($configuration);
 
         $this->configuration = $configuration;
@@ -107,6 +108,6 @@ abstract class TestCase extends BaseTestCase
 
     private function buildEntityManager(): EntityManager
     {
-        return EntityManager::create(['driver' => 'pdo_sqlite', 'memory' => true], $this->configuration);
+        return new EntityManager(DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true], $this->configuration), $this->configuration);
     }
 }


### PR DESCRIPTION
This is a follow-up for #177

* Update `composer.json` to (re)allow Doctrine ORM v3 & Lexer v3
* Use `Doctrine\ORM\Query\TokenType` over deprecated/removed lexer constants
* Migrate entity fixtures to attributes
