### PR TITLE
Allows :dql_parameters with ARRAY_* functions

### DIFF
--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppend.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppend.php
@@ -18,6 +18,6 @@ class ArrayAppend extends BaseFunction
     {
         $this->setFunctionPrototype('array_append(%s, %s)');
         $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('Literal');
+        $this->addNodeMapping('ArithmeticPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLength.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLength.php
@@ -18,6 +18,6 @@ class ArrayLength extends BaseFunction
     {
         $this->setFunctionPrototype('array_length(%s, %s)');
         $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('Literal');
+        $this->addNodeMapping('ArithmeticPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrepend.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrepend.php
@@ -17,7 +17,7 @@ class ArrayPrepend extends BaseFunction
     protected function customiseFunction(): void
     {
         $this->setFunctionPrototype('array_prepend(%s, %s)');
-        $this->addNodeMapping('Literal');
+        $this->addNodeMapping('ArithmeticPrimary');
         $this->addNodeMapping('StringPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemove.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemove.php
@@ -18,6 +18,6 @@ class ArrayRemove extends BaseFunction
     {
         $this->setFunctionPrototype('array_remove(%s, %s)');
         $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('Literal');
+        $this->addNodeMapping('ArithmeticPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplace.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplace.php
@@ -18,7 +18,7 @@ class ArrayReplace extends BaseFunction
     {
         $this->setFunctionPrototype('array_replace(%s, %s, %s)');
         $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('Literal');
-        $this->addNodeMapping('Literal');
+        $this->addNodeMapping('ArithmeticPrimary');
+        $this->addNodeMapping('ArithmeticPrimary');
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppendTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppendTest.php
@@ -21,7 +21,7 @@ class ArrayAppendTest extends TestCase
         return [
             'SELECT array_append(c0_.array1, 1989) AS sclr_0 FROM ContainsArrays c0_',
             "SELECT array_append(c0_.array1, 'country') AS sclr_0 FROM ContainsArrays c0_",
-            "SELECT array_append(c0_.array1, ?) AS sclr_0 FROM ContainsArrays c0_",
+            'SELECT array_append(c0_.array1, ?) AS sclr_0 FROM ContainsArrays c0_',
         ];
     }
 
@@ -30,7 +30,7 @@ class ArrayAppendTest extends TestCase
         return [
             \sprintf('SELECT ARRAY_APPEND(e.array1, 1989) FROM %s e', ContainsArrays::class),
             \sprintf("SELECT ARRAY_APPEND(e.array1, 'country') FROM %s e", ContainsArrays::class),
-            \sprintf("SELECT ARRAY_APPEND(e.array1, :dql_parameter) FROM %s e", ContainsArrays::class),
+            \sprintf('SELECT ARRAY_APPEND(e.array1, :dql_parameter) FROM %s e', ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppendTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppendTest.php
@@ -21,6 +21,7 @@ class ArrayAppendTest extends TestCase
         return [
             'SELECT array_append(c0_.array1, 1989) AS sclr_0 FROM ContainsArrays c0_',
             "SELECT array_append(c0_.array1, 'country') AS sclr_0 FROM ContainsArrays c0_",
+            "SELECT array_append(c0_.array1, ?) AS sclr_0 FROM ContainsArrays c0_",
         ];
     }
 
@@ -29,6 +30,7 @@ class ArrayAppendTest extends TestCase
         return [
             \sprintf('SELECT ARRAY_APPEND(e.array1, 1989) FROM %s e', ContainsArrays::class),
             \sprintf("SELECT ARRAY_APPEND(e.array1, 'country') FROM %s e", ContainsArrays::class),
+            \sprintf("SELECT ARRAY_APPEND(e.array1, :dql_parameter) FROM %s e", ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLengthTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLengthTest.php
@@ -20,6 +20,7 @@ class ArrayLengthTest extends TestCase
     {
         return [
             'SELECT array_length(c0_.array1, 1) AS sclr_0 FROM ContainsArrays c0_',
+            'SELECT array_length(c0_.array1, ?) AS sclr_0 FROM ContainsArrays c0_',
         ];
     }
 
@@ -27,6 +28,7 @@ class ArrayLengthTest extends TestCase
     {
         return [
             \sprintf('SELECT ARRAY_LENGTH(e.array1, 1) FROM %s e', ContainsArrays::class),
+            \sprintf('SELECT ARRAY_LENGTH(e.array1, :dql_parameter) FROM %s e', ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrependTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrependTest.php
@@ -21,7 +21,7 @@ class ArrayPrependTest extends TestCase
         return [
             'SELECT array_prepend(1885, c0_.array1) AS sclr_0 FROM ContainsArrays c0_',
             "SELECT array_prepend('red', c0_.array1) AS sclr_0 FROM ContainsArrays c0_",
-            "SELECT array_prepend(?, c0_.array1) AS sclr_0 FROM ContainsArrays c0_",
+            'SELECT array_prepend(?, c0_.array1) AS sclr_0 FROM ContainsArrays c0_',
         ];
     }
 
@@ -30,7 +30,7 @@ class ArrayPrependTest extends TestCase
         return [
             \sprintf('SELECT ARRAY_PREPEND(1885, e.array1) FROM %s e', ContainsArrays::class),
             \sprintf("SELECT ARRAY_PREPEND('red', e.array1) FROM %s e", ContainsArrays::class),
-            \sprintf("SELECT ARRAY_PREPEND(:dql_parameter, e.array1) FROM %s e", ContainsArrays::class),
+            \sprintf('SELECT ARRAY_PREPEND(:dql_parameter, e.array1) FROM %s e', ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrependTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrependTest.php
@@ -21,6 +21,7 @@ class ArrayPrependTest extends TestCase
         return [
             'SELECT array_prepend(1885, c0_.array1) AS sclr_0 FROM ContainsArrays c0_',
             "SELECT array_prepend('red', c0_.array1) AS sclr_0 FROM ContainsArrays c0_",
+            "SELECT array_prepend(?, c0_.array1) AS sclr_0 FROM ContainsArrays c0_",
         ];
     }
 
@@ -29,6 +30,7 @@ class ArrayPrependTest extends TestCase
         return [
             \sprintf('SELECT ARRAY_PREPEND(1885, e.array1) FROM %s e', ContainsArrays::class),
             \sprintf("SELECT ARRAY_PREPEND('red', e.array1) FROM %s e", ContainsArrays::class),
+            \sprintf("SELECT ARRAY_PREPEND(:dql_parameter, e.array1) FROM %s e", ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemoveTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemoveTest.php
@@ -21,7 +21,7 @@ class ArrayRemoveTest extends TestCase
         return [
             'SELECT array_remove(c0_.array1, 1944) AS sclr_0 FROM ContainsArrays c0_',
             "SELECT array_remove(c0_.array1, 'peach') AS sclr_0 FROM ContainsArrays c0_",
-            "SELECT array_remove(c0_.array1, ?) AS sclr_0 FROM ContainsArrays c0_",
+            'SELECT array_remove(c0_.array1, ?) AS sclr_0 FROM ContainsArrays c0_',
         ];
     }
 
@@ -30,7 +30,7 @@ class ArrayRemoveTest extends TestCase
         return [
             \sprintf('SELECT ARRAY_REMOVE(e.array1, 1944) FROM %s e', ContainsArrays::class),
             \sprintf("SELECT ARRAY_REMOVE(e.array1, 'peach') FROM %s e", ContainsArrays::class),
-            \sprintf("SELECT ARRAY_REMOVE(e.array1, :dql_parameter) FROM %s e", ContainsArrays::class),
+            \sprintf('SELECT ARRAY_REMOVE(e.array1, :dql_parameter) FROM %s e', ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemoveTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemoveTest.php
@@ -21,6 +21,7 @@ class ArrayRemoveTest extends TestCase
         return [
             'SELECT array_remove(c0_.array1, 1944) AS sclr_0 FROM ContainsArrays c0_',
             "SELECT array_remove(c0_.array1, 'peach') AS sclr_0 FROM ContainsArrays c0_",
+            "SELECT array_remove(c0_.array1, ?) AS sclr_0 FROM ContainsArrays c0_",
         ];
     }
 
@@ -29,6 +30,7 @@ class ArrayRemoveTest extends TestCase
         return [
             \sprintf('SELECT ARRAY_REMOVE(e.array1, 1944) FROM %s e', ContainsArrays::class),
             \sprintf("SELECT ARRAY_REMOVE(e.array1, 'peach') FROM %s e", ContainsArrays::class),
+            \sprintf("SELECT ARRAY_REMOVE(e.array1, :dql_parameter) FROM %s e", ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplaceTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplaceTest.php
@@ -21,7 +21,7 @@ class ArrayReplaceTest extends TestCase
         return [
             'SELECT array_replace(c0_.array1, 1939, 1957) AS sclr_0 FROM ContainsArrays c0_',
             "SELECT array_replace(c0_.array1, 'green', 'mint') AS sclr_0 FROM ContainsArrays c0_",
-            'SELECT array_replace(c0_.array1, 'green', ?) AS sclr_0 FROM ContainsArrays c0_',
+            "SELECT array_replace(c0_.array1, 'green', ?) AS sclr_0 FROM ContainsArrays c0_",
         ];
     }
 
@@ -30,7 +30,7 @@ class ArrayReplaceTest extends TestCase
         return [
             \sprintf('SELECT ARRAY_REPLACE(e.array1, 1939, 1957) FROM %s e', ContainsArrays::class),
             \sprintf("SELECT ARRAY_REPLACE(e.array1, 'green', 'mint') FROM %s e", ContainsArrays::class),
-            \sprintf('SELECT ARRAY_REPLACE(e.array1, 'green', :dql_parameter) FROM %s e', ContainsArrays::class),
+            \sprintf("SELECT ARRAY_REPLACE(e.array1, 'green', :dql_parameter) FROM %s e", ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplaceTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplaceTest.php
@@ -21,7 +21,7 @@ class ArrayReplaceTest extends TestCase
         return [
             'SELECT array_replace(c0_.array1, 1939, 1957) AS sclr_0 FROM ContainsArrays c0_',
             "SELECT array_replace(c0_.array1, 'green', 'mint') AS sclr_0 FROM ContainsArrays c0_",
-            "SELECT array_replace(c0_.array1, 'green', ?) AS sclr_0 FROM ContainsArrays c0_",
+            'SELECT array_replace(c0_.array1, 'green', ?) AS sclr_0 FROM ContainsArrays c0_',
         ];
     }
 
@@ -30,7 +30,7 @@ class ArrayReplaceTest extends TestCase
         return [
             \sprintf('SELECT ARRAY_REPLACE(e.array1, 1939, 1957) FROM %s e', ContainsArrays::class),
             \sprintf("SELECT ARRAY_REPLACE(e.array1, 'green', 'mint') FROM %s e", ContainsArrays::class),
-            \sprintf("SELECT ARRAY_REPLACE(e.array1, 'green', :dql_parameter) FROM %s e", ContainsArrays::class),
+            \sprintf('SELECT ARRAY_REPLACE(e.array1, 'green', :dql_parameter) FROM %s e', ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplaceTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplaceTest.php
@@ -21,6 +21,7 @@ class ArrayReplaceTest extends TestCase
         return [
             'SELECT array_replace(c0_.array1, 1939, 1957) AS sclr_0 FROM ContainsArrays c0_',
             "SELECT array_replace(c0_.array1, 'green', 'mint') AS sclr_0 FROM ContainsArrays c0_",
+            "SELECT array_replace(c0_.array1, 'green', ?) AS sclr_0 FROM ContainsArrays c0_",
         ];
     }
 
@@ -29,6 +30,7 @@ class ArrayReplaceTest extends TestCase
         return [
             \sprintf('SELECT ARRAY_REPLACE(e.array1, 1939, 1957) FROM %s e', ContainsArrays::class),
             \sprintf("SELECT ARRAY_REPLACE(e.array1, 'green', 'mint') FROM %s e", ContainsArrays::class),
+            \sprintf("SELECT ARRAY_REPLACE(e.array1, 'green', :dql_parameter) FROM %s e", ContainsArrays::class),
         ];
     }
 }


### PR DESCRIPTION
before it was only possible to do `ARRAY_APPEND(e.myarray, 'a_literal')` so it was impossible to have the value coming from php (without resorting to DQL injection)

We now allow also the following syntax `ARRAY_APPEND(e.myarray, :foobar)`