### PR TITLE
Fix php84 `str_getcsv` deprecation in  DataStructure.php

### DIFF
--- a/src/MartinGeorgiev/Utils/DataStructure.php
+++ b/src/MartinGeorgiev/Utils/DataStructure.php
@@ -26,7 +26,7 @@ class DataStructure
                 throw new \InvalidArgumentException('Only single-dimensioned arrays are supported');
             }
 
-            $phpArray = \str_getcsv(\trim($textArrayToTransform, '{}'), escape: '');
+            $phpArray = \str_getcsv(\trim($textArrayToTransform, '{}'), escape: '\\');
             foreach ($phpArray as $i => $text) {
                 if ($text === null) {
                     unset($phpArray[$i]);

--- a/src/MartinGeorgiev/Utils/DataStructure.php
+++ b/src/MartinGeorgiev/Utils/DataStructure.php
@@ -26,7 +26,7 @@ class DataStructure
                 throw new \InvalidArgumentException('Only single-dimensioned arrays are supported');
             }
 
-            $phpArray = \str_getcsv(\trim($textArrayToTransform, '{}'));
+            $phpArray = \str_getcsv(\trim($textArrayToTransform, '{}'), escape: '');
             foreach ($phpArray as $i => $text) {
                 if ($text === null) {
                     unset($phpArray[$i]);


### PR DESCRIPTION
>  As of PHP 8.4.0, depending on the default value of escape is deprecated. It needs to be provided explicitly either positionally or by the use of named arguments. 

https://www.php.net/manual/en/function.str-getcsv.php

A very minimal patch/quick fix.. tell me if you want anything