### PR TITLE
feat: add limited support for `json_build_object` and `jsonb_build_object`

### DIFF
--- a/docs/AVAILABLE-FUNCTIONS-AND-OPERATORS.md
+++ b/docs/AVAILABLE-FUNCTIONS-AND-OPERATORS.md
@@ -50,6 +50,7 @@
 | int8range | INT8RANGE | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Int8range` |
 | json_agg | JSON_AGG | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonAgg` |
 | json_array_length | JSON_ARRAY_LENGTH | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonArrayLength` |
+| json_build_object | JSON_BUILD_OBJECT | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonBuildObject` |
 | json_each | JSON_EACH | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonEach` |
 | json_each_text | JSON_EACH_TEXT | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonEachText` |
 | json_object_agg | JSON_OBJECT_AGG | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonObjectAgg` |
@@ -60,6 +61,7 @@
 | jsonb_agg | JSONB_AGG | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbAgg` |
 | jsonb_array_elements_text | JSONB_ARRAY_ELEMENTS_TEXT | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbArrayElementsText` |
 | jsonb_array_length | JSONB_ARRAY_LENGTH | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbArrayLength` |
+| jsonb_build_object | JSONB_BUILD_OBJECT | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbBuildObject` |
 | jsonb_each | JSONB_EACH | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbEach` |
 | jsonb_each_text | JSONB_EACH_TEXT | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbEachText` |
 | jsonb_exists | JSONB_EXISTS | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbExists` |

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -32,6 +32,10 @@ use Doctrine\ORM\Configuration;
 
 $configuration = new Configuration();
 
+# Register json functions
+$configuration->addCustomStringFunction('JSON_BUILD_OBJECT', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonBuildObject::class);
+$configuration->addCustomStringFunction('JSONB_BUILD_OBJECT', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbBuildObject::class);
+
 # Register text search functions
 $configuration->addCustomStringFunction('TO_TSQUERY', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ToTsquery::class);
 $configuration->addCustomStringFunction('TO_TSVECTOR', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ToTsvector::class);

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -108,6 +108,9 @@ return [
         # json specific functions
         'JSON_AGG' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonAgg::class,
         'JSON_ARRAY_LENGTH' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonArrayLength::class,
+        'JSON_BUILD_OBJECT' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonBuildObject::class,
+        'JSON_EACH' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonEach::class,
+        'JSON_EACH_TEXT' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonEachText::class,
         'JSON_GET_FIELD' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonGetField::class,
         'JSON_GET_FIELD_AS_TEXT' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonGetFieldAsText::class,
         'JSON_GET_FIELD_AS_INTEGER' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonGetFieldAsInteger::class,
@@ -124,6 +127,7 @@ return [
         'JSONB_ARRAY_ELEMENTS' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbArrayElements::class,
         'JSONB_ARRAY_ELEMENTS_TEXT' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbArrayElementsText::class,
         'JSONB_ARRAY_LENGTH' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbArrayLength::class,
+        'JSONB_BUILD_OBJECT' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbBuildObject::class,
         'JSONB_EACH' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbEach::class,
         'JSONB_EACH_TEXT' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbEachText::class,
         'JSONB_EXISTS' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbExists::class,

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -101,6 +101,7 @@ doctrine:
                         # json specific functions
                         JSON_AGG: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonAgg
                         JSON_ARRAY_LENGTH: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonArrayLength
+                        JSON_BUILD_OBJECT: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonBuildObject
                         JSON_EACH: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonEach
                         JSON_EACH_TEXT: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonEachText
                         JSON_GET_FIELD: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonGetField
@@ -120,6 +121,7 @@ doctrine:
                         JSONB_ARRAY_ELEMENTS: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbArrayElements
                         JSONB_ARRAY_ELEMENTS_TEXT: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbArrayElementsText
                         JSONB_ARRAY_LENGTH: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbArrayLength
+                        JSONB_BUILD_OBJECT: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbBuildObject
                         JSONB_EACH: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbEach
                         JSONB_EACH_TEXT: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbEachText
                         JSONB_EXISTS: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbExists

--- a/docs/USE-CASES-AND-EXAMPLES.md
+++ b/docs/USE-CASES-AND-EXAMPLES.md
@@ -17,3 +17,22 @@ SELECT e
 FROM EmailEntity e
 WHERE ILIKE(e.subject, 'Test email') = TRUE
 ```
+
+Using JSON_BUILD_OBJECT and JSONB_BUILD_OBJECT
+---
+
+These functions currently only support string literals and object references as arguments. Here are some valid examples:
+
+```sql
+-- Basic usage with string literals and entity properties
+SELECT JSON_BUILD_OBJECT('name', e.userName, 'email', e.userEmail) FROM User e
+
+-- Multiple key-value pairs
+SELECT JSONB_BUILD_OBJECT('id', e.id, 'status', 'active', 'type', e.userType) FROM Employee e
+
+-- Invalid usage (will not work):
+SELECT JSON_BUILD_OBJECT('count', COUNT(*))  -- Aggregate functions not supported
+SELECT JSONB_BUILD_OBJECT('number', 123)     -- All number types, NULL and boolean values not supported currently
+```
+
+Note: Keys must always be string literals, while values can be either string literals or object property references.

--- a/docs/USE-CASES-AND-EXAMPLES.md
+++ b/docs/USE-CASES-AND-EXAMPLES.md
@@ -11,7 +11,7 @@ FROM EmailEntity e
 WHERE e.subject ILIKE 'Test email'
 ```
 
-Boolean expression that will parse and is equavelnt to teh above DQL:
+Boolean expression that will parse and is equivalent to the above DQL:
 ```sql
 SELECT e
 FROM EmailEntity e

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonBuildObject.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonBuildObject.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostgreSql JSON_BUILD_OBJECT().
+ *
+ * @see https://www.postgresql.org/docs/17/functions-json.html
+ * @since 2.9.0
+ */
+class JsonBuildObject extends BaseVariadicFunction
+{
+    protected function customiseFunction(): void
+    {
+        $this->setFunctionPrototype('json_build_object(%s)');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbBuildObject.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbBuildObject.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostgreSql JSONB_BUILD_OBJECT().
+ *
+ * @see https://www.postgresql.org/docs/17/functions-json.html
+ * @since 2.9.0
+ */
+class JsonbBuildObject extends BaseVariadicFunction
+{
+    protected function customiseFunction(): void
+    {
+        $this->setFunctionPrototype('jsonb_build_object(%s)');
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonBuildObjectTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonBuildObjectTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsJsons;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonBuildObject;
+
+class JsonBuildObjectTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'JSON_BUILD_OBJECT' => JsonBuildObject::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            "SELECT json_build_object('key1', c0_.object1) AS sclr_0 FROM ContainsJsons c0_",
+            "SELECT json_build_object('key1', UPPER('value1'), 'key2', 'value2') AS sclr_0 FROM ContainsJsons c0_",
+            "SELECT json_build_object('key1', c0_.object1, 'key2', c0_.object2) AS sclr_0 FROM ContainsJsons c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            \sprintf("SELECT JSON_BUILD_OBJECT('key1', e.object1) FROM %s e", ContainsJsons::class),
+            \sprintf("SELECT JSON_BUILD_OBJECT('key1', UPPER('value1'), 'key2', 'value2') FROM %s e", ContainsJsons::class),
+            \sprintf("SELECT JSON_BUILD_OBJECT('key1', e.object1, 'key2', e.object2) FROM %s e", ContainsJsons::class),
+        ];
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbBuildObjectTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbBuildObjectTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsJsons;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbBuildObject;
+
+class JsonbBuildObjectTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'JSONB_BUILD_OBJECT' => JsonbBuildObject::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            "SELECT jsonb_build_object('key1', c0_.object1) AS sclr_0 FROM ContainsJsons c0_",
+            "SELECT jsonb_build_object('key1', UPPER('value1'), 'key2', 'value2') AS sclr_0 FROM ContainsJsons c0_",
+            "SELECT jsonb_build_object('key1', c0_.object1, 'key2', c0_.object2) AS sclr_0 FROM ContainsJsons c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            \sprintf("SELECT JSONB_BUILD_OBJECT('key1', e.object1) FROM %s e", ContainsJsons::class),
+            \sprintf("SELECT JSONB_BUILD_OBJECT('key1', UPPER('value1'), 'key2', 'value2') FROM %s e", ContainsJsons::class),
+            \sprintf("SELECT JSONB_BUILD_OBJECT('key1', e.object1, 'key2', e.object2) FROM %s e", ContainsJsons::class),
+        ];
+    }
+}


### PR DESCRIPTION
Using JSON_BUILD_OBJECT and JSONB_BUILD_OBJECT
---

These functions currently only support string literals and object references as arguments. Here are some valid examples:

```sql
-- Basic usage with string literals and entity properties
SELECT JSON_BUILD_OBJECT('name', e.userName, 'email', e.userEmail) FROM User e

-- Multiple key-value pairs
SELECT JSONB_BUILD_OBJECT('id', e.id, 'status', 'active', 'type', e.userType) FROM Employee e

-- Invalid usage (will not work):
SELECT JSON_BUILD_OBJECT('count', COUNT(*))  -- Aggregate functions not supported
SELECT JSONB_BUILD_OBJECT('number', 123)     -- All number types, NULL and boolean values not supported currently
```

Note: Keys must always be string literals, while values can be either string literals or object property references.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new JSON object creation functions for constructing JSON and JSONB data in database queries across multiple platforms.

- **Documentation**
  - Updated guides and examples to demonstrate usage, detail argument restrictions, and show integration steps for enhanced JSON support in query languages.

- **Tests**
  - Added comprehensive tests to validate the functionality and proper SQL conversion of the new JSON functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->