### PR TITLE
fix: wrap up ORM v3 throwable when parsing fails in variadic functions

### DIFF
--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
@@ -27,9 +27,13 @@ abstract class BaseVariadicFunction extends BaseFunction
     {
         $lexer = $parser->getLexer();
 
-        $this->nodes[] = $parser->{$this->commonNodeMapping}();
-        if ($lexer->lookahead?->type === null) {
-            throw ParserException::missingLookaheadType();
+        try {
+            $this->nodes[] = $parser->{$this->commonNodeMapping}();
+            if ($lexer->lookahead?->type === null) {
+                throw ParserException::missingLookaheadType();
+            }
+        } catch (\Throwable $throwable) {
+            throw ParserException::withThrowable($throwable);
         }
 
         $aheadType = $lexer->lookahead->type;

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Exception/ParserException.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Exception/ParserException.php
@@ -10,4 +10,9 @@ class ParserException extends \RuntimeException
     {
         return new self("The parser's 'lookahead' property is not populated with a type");
     }
+
+    public static function withThrowable(\Throwable $throwable): self
+    {
+        return new self($throwable->getMessage(), $throwable->getCode(), $throwable);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to provide clearer, more informative messages when unexpected issues occur.
- **New Features**
  - Enhanced error reporting with additional context to assist in troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->