### PR TITLE
fix: improve BC by deprecating `customiseFunction` instead of renaming it straight away

### DIFF
--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseFunction.php
@@ -31,7 +31,28 @@ abstract class BaseFunction extends FunctionNode
      */
     protected array $nodes = [];
 
-    abstract protected function customizeFunction(): void;
+    /**
+     * This method is meant for internal use only, and it is not suggested that the forks of the library depend on it.
+     * It will be made abstract from version 3.0.
+     *
+     * @internal
+     *
+     * @see customiseFunction()
+     */
+    /* abstract */
+    protected function customizeFunction(): void
+    {
+        // Void
+    }
+
+    /**
+     * @deprecated
+     */
+    protected function customiseFunction(): void
+    {
+        \trigger_error('The internal-use method of `customiseFunction()` is deprecated and is now renamed to `customizeFunction()`. `customiseFunction()` will be removed from version 3.0 onwards.', E_USER_DEPRECATED);
+        $this->customizeFunction();
+    }
 
     protected function setFunctionPrototype(string $functionPrototype): void
     {


### PR DESCRIPTION
Renaming the method breaks every class based on `BaseFunction` that is not up-to-date with the renaming. I'm not sure how many people do so, but I do, and my project broke.

Here is my proposal to soften the fall. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Updated a method to a concrete implementation, simplifying the code structure for future enhancements.

- **Chores**
  - Introduced a deprecation warning for legacy methods, informing users of changes and guiding them towards updated functionality for a smoother transition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->