### PR TITLE
feat!: preserve the type of booleans, floats and integers when transforming back and forth between PostgreSQL and PHP

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArray.php
@@ -47,9 +47,10 @@ abstract class BaseIntegerArray extends BaseArray
             return null;
         }
 
-        $isInvalidPHPInt = !(bool) \preg_match('/^-?\d+$/', (string) $item)
-            || (string) $item < $this->getMinValue()
-            || (string) $item > $this->getMaxValue();
+        $stringValue = (string) $item;
+        $isInvalidPHPInt = !(bool) \preg_match('/^-?\d+$/', $stringValue)
+            || $stringValue < $this->getMinValue()
+            || $stringValue > $this->getMaxValue();
         if ($isInvalidPHPInt) {
             throw new ConversionException(\sprintf('Given value of %s content cannot be transformed to valid PHP integer.', \var_export($item, true)));
         }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/TextArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/TextArray.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use MartinGeorgiev\Utils\DataStructure;
+use MartinGeorgiev\Utils\ArrayDataTransformer;
 
 /**
  * Implementation of PostgreSQL TEXT[] data type.
@@ -42,7 +42,7 @@ class TextArray extends BaseType
             return '{}';
         }
 
-        return DataStructure::transformPHPArrayToPostgresTextArray($phpTextArray);
+        return ArrayDataTransformer::transformPHPArrayToPostgresTextArray($phpTextArray);
     }
 
     /**
@@ -65,6 +65,6 @@ class TextArray extends BaseType
             return [];
         }
 
-        return DataStructure::transformPostgresTextArrayToPHPArray($postgresValue);
+        return ArrayDataTransformer::transformPostgresTextArrayToPHPArray($postgresValue);
     }
 }

--- a/src/MartinGeorgiev/Utils/ArrayDataTransformer.php
+++ b/src/MartinGeorgiev/Utils/ArrayDataTransformer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Utils;
 
+use MartinGeorgiev\Utils\Exception\InvalidArrayFormatException;
+
 /**
  * @since 3.0
  *
@@ -18,6 +20,8 @@ class ArrayDataTransformer
     /**
      * This method supports only single-dimensioned text arrays and
      * relays on the default escaping strategy in PostgreSQL (double quotes).
+     *
+     * @throws InvalidArrayFormatException when the input is a multi-dimensional array or has invalid format
      */
     public static function transformPostgresTextArrayToPHPArray(string $postgresArray): array
     {
@@ -28,7 +32,7 @@ class ArrayDataTransformer
         }
 
         if (\str_contains($trimmed, '},{') || \str_starts_with($trimmed, '{{')) {
-            throw new \InvalidArgumentException('Only single-dimensioned arrays are supported');
+            throw InvalidArrayFormatException::multiDimensionalArrayNotSupported();
         }
 
         if ($trimmed === self::POSTGRESQL_EMPTY_ARRAY) {
@@ -40,7 +44,7 @@ class ArrayDataTransformer
         /** @var array<int, mixed>|null $decoded */
         $decoded = \json_decode($jsonArray, true, 512, JSON_BIGINT_AS_STRING);
         if ($decoded === null && \json_last_error() !== JSON_ERROR_NONE) {
-            throw new \InvalidArgumentException('Invalid array format: '.\json_last_error_msg());
+            throw InvalidArrayFormatException::invalidFormat(\json_last_error_msg());
         }
 
         return \array_map(
@@ -52,6 +56,8 @@ class ArrayDataTransformer
     /**
      * This method supports only single-dimensioned PHP arrays.
      * This method relays on the default escaping strategy in PostgreSQL (double quotes).
+     *
+     * @throws InvalidArrayFormatException when the input is a multi-dimensional array or has invalid format
      */
     public static function transformPHPArrayToPostgresTextArray(array $phpArray): string
     {
@@ -60,7 +66,7 @@ class ArrayDataTransformer
         }
 
         if (\array_filter($phpArray, 'is_array')) {
-            throw new \InvalidArgumentException('Only single-dimensioned arrays are supported');
+            throw InvalidArrayFormatException::multiDimensionalArrayNotSupported();
         }
 
         /** @var array<int|string, string> */

--- a/src/MartinGeorgiev/Utils/ArrayDataTransformer.php
+++ b/src/MartinGeorgiev/Utils/ArrayDataTransformer.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace MartinGeorgiev\Utils;
 
 /**
- * Util class with helpers for working with PostgreSQL data structures.
- *
- * @since 0.9
+ * @since 3.0
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  */
-class DataStructure
+class ArrayDataTransformer
 {
     private const POSTGRESQL_EMPTY_ARRAY = '{}';
 
@@ -156,9 +154,6 @@ class DataStructure
 
         // Handle double backslashes
         $value = \str_replace('\\\\', '___DBLBACK___', $value);
-
-        // Handle remaining single backslashes
-        $value = \str_replace('\\', '\\', $value);
 
         // Restore double backslashes
         $value = \str_replace('___DBLBACK___', '\\\\', $value);

--- a/src/MartinGeorgiev/Utils/DataStructure.php
+++ b/src/MartinGeorgiev/Utils/DataStructure.php
@@ -13,78 +13,131 @@ namespace MartinGeorgiev\Utils;
  */
 class DataStructure
 {
+    private const POSTGRESQL_EMPTY_ARRAY = '{}';
+
+    private const POSTGRESQL_NULL_VALUE = 'null';
+
     /**
      * This method supports only single-dimensioned text arrays and
      * relays on the default escaping strategy in PostgreSQL (double quotes).
      */
     public static function transformPostgresTextArrayToPHPArray(string $postgresArray): array
     {
-        $transform = static function (string $textArrayToTransform): array {
-            $indicatesMultipleDimensions = \mb_strpos($textArrayToTransform, '},{') !== false
-                || \mb_strpos($textArrayToTransform, '{{') === 0;
-            if ($indicatesMultipleDimensions) {
-                throw new \InvalidArgumentException('Only single-dimensioned arrays are supported');
-            }
+        $trimmed = \trim($postgresArray);
 
-            $phpArray = \str_getcsv(\trim($textArrayToTransform, '{}'), escape: '\\');
-            foreach ($phpArray as $i => $text) {
-                if ($text === null) {
-                    unset($phpArray[$i]);
+        if ($trimmed === '' || \strtolower($trimmed) === self::POSTGRESQL_NULL_VALUE) {
+            return [];
+        }
 
-                    break;
-                }
+        if (\str_contains($trimmed, '},{') || \str_starts_with($trimmed, '{{')) {
+            throw new \InvalidArgumentException('Only single-dimensioned arrays are supported');
+        }
 
-                $isInteger = \is_numeric($text) && ''.(int) $text === $text;
-                if ($isInteger) {
-                    $phpArray[$i] = (int) $text;
+        if ($trimmed === self::POSTGRESQL_EMPTY_ARRAY) {
+            return [];
+        }
 
-                    continue;
-                }
+        $jsonArray = '['.\trim($trimmed, '{}').']';
 
-                $isFloat = \is_numeric($text) && ''.(float) $text === $text;
-                if ($isFloat) {
-                    $phpArray[$i] = (float) $text;
+        $decoded = \json_decode($jsonArray, true, 512, JSON_BIGINT_AS_STRING);
+        if ($decoded === null && \json_last_error() !== JSON_ERROR_NONE) {
+            throw new \InvalidArgumentException('Invalid array format: '.\json_last_error_msg());
+        }
 
-                    continue;
-                }
-
-                $phpArray[$i] = \stripslashes(\str_replace('\"', '"', $text));
-            }
-
-            return $phpArray;
-        };
-
-        return $transform($postgresArray);
+        return \array_map(
+            static fn ($value): mixed => \is_string($value) ? self::unescapeString($value) : $value,
+            $decoded
+        );
     }
 
     /**
      * This method supports only single-dimensioned PHP arrays.
      * This method relays on the default escaping strategy in PostgreSQL (double quotes).
-     *
-     * @see https://stackoverflow.com/a/5632171/3425372 Kudos to jmz for the inspiration
      */
     public static function transformPHPArrayToPostgresTextArray(array $phpArray): string
     {
-        $transform = static function (array $phpArrayToTransform): string {
-            $result = [];
-            foreach ($phpArrayToTransform as $text) {
-                if (\is_array($text)) {
-                    throw new \InvalidArgumentException('Only single-dimensioned arrays are supported');
-                }
+        if ($phpArray === []) {
+            return self::POSTGRESQL_EMPTY_ARRAY;
+        }
 
-                if (\is_numeric($text) || \ctype_digit($text)) {
-                    $escapedText = $text;
-                } else {
-                    \assert(\is_string($text));
-                    $escapedText = \sprintf('"%s"', \addcslashes($text, '"\\'));
-                }
+        if (\array_filter($phpArray, 'is_array')) {
+            throw new \InvalidArgumentException('Only single-dimensioned arrays are supported');
+        }
 
-                $result[] = $escapedText;
-            }
+        $processed = \array_map(static fn ($value): string => self::formatValue($value), $phpArray);
 
-            return '{'.\implode(',', $result).'}';
-        };
+        return '{'.\implode(',', $processed).'}';
+    }
 
-        return $transform($phpArray);
+    /**
+     * Formats a single value for PostgreSQL array.
+     */
+    private static function formatValue(mixed $value): string
+    {
+        // Handle null
+        if ($value === null) {
+            return 'NULL';
+        }
+
+        // Handle actual numbers
+        if (\is_int($value) || \is_float($value)) {
+            return (string) $value;
+        }
+
+        // Convert to string if not already
+        $stringValue = (string) $value;
+
+        // Handle empty string
+        if ($stringValue === '') {
+            return '""';
+        }
+
+        if (self::isNumericSimple($stringValue)) {
+            return '"'.$stringValue.'"';
+        }
+
+        // Double the backslashes and escape quotes
+        $escaped = \str_replace(
+            ['\\', '"'],
+            ['\\\\', '\"'],
+            $stringValue
+        );
+
+        return '"'.$escaped.'"';
+    }
+
+    private static function isNumericSimple(string $value): bool
+    {
+        // Fast path for obvious numeric strings
+        if ($value === '' || $value[0] === '"') {
+            return false;
+        }
+
+        // Handle scientific notation
+        $lower = \strtolower($value);
+        if (\str_contains($lower, 'e')) {
+            $value = \str_replace('e', '', $lower);
+        }
+
+        // Use built-in numeric check
+        return \is_numeric($value);
+    }
+
+    private static function unescapeString(string $value): string
+    {
+        // First handle escaped quotes
+        $value = \str_replace('\"', '___QUOTE___', $value);
+
+        // Handle double backslashes
+        $value = \str_replace('\\\\', '___DBLBACK___', $value);
+
+        // Handle remaining single backslashes
+        $value = \str_replace('\\', '\\', $value);
+
+        // Restore double backslashes
+        $value = \str_replace('___DBLBACK___', '\\\\', $value);
+
+        // Finally restore quotes
+        return \str_replace('___QUOTE___', '"', $value);
     }
 }

--- a/src/MartinGeorgiev/Utils/Exception/InvalidArrayFormatException.php
+++ b/src/MartinGeorgiev/Utils/Exception/InvalidArrayFormatException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Utils\Exception;
+
+class InvalidArrayFormatException extends \InvalidArgumentException
+{
+    public static function multiDimensionalArrayNotSupported(): self
+    {
+        return new self('Only single-dimensioned arrays are supported');
+    }
+
+    public static function invalidFormat(string $details = ''): self
+    {
+        $message = 'Invalid array format';
+        if ($details !== '') {
+            $message .= ': '.$details;
+        }
+
+        return new self($message);
+    }
+}

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
@@ -82,11 +82,11 @@ class TextArrayTest extends TestCase
                     <<<'END'
 ''"quotes"'' ain't no """worry""", '''right''' Alexander O'Vechkin?
 END,
-                    'back-slashing\double-slashing\\\hooking though',
+                    'back-slashing\double-slashing\\\triple-slashing\\\\\hooking though',
                     'and "double-quotes"',
                 ],
                 'postgresValue' => <<<'END'
-{1,"2",3.4,"5.6","text","some text here","and some here","''\"quotes\"'' ain't no \"\"\"worry\"\"\", '''right''' Alexander O'Vechkin?","back-slashing\\double-slashing\\\\hooking though","and \"double-quotes\""}
+{1,"2",3.4,"5.6","text","some text here","and some here","''\"quotes\"'' ain't no \"\"\"worry\"\"\", '''right''' Alexander O'Vechkin?","back-slashing\\double-slashing\\\\triple-slashing\\\\\\hooking though","and \"double-quotes\""}
 END,
             ],
         ];

--- a/tests/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
+++ b/tests/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
@@ -74,6 +74,8 @@ class TextArrayTest extends TestCase
                 'phpValue' => [
                     1,
                     '2',
+                    3.4,
+                    '5.6',
                     'text',
                     'some text here',
                     'and some here',
@@ -84,7 +86,7 @@ END,
                     'and "double-quotes"',
                 ],
                 'postgresValue' => <<<'END'
-{1,2,"text","some text here","and some here","''\"quotes\"'' ain't no \"\"\"worry\"\"\", '''right''' Alexander O'Vechkin?","back-slashing\\double-slashing\\\\hooking though","and \"double-quotes\""}
+{1,"2",3.4,"5.6","text","some text here","and some here","''\"quotes\"'' ain't no \"\"\"worry\"\"\", '''right''' Alexander O'Vechkin?","back-slashing\\double-slashing\\\\hooking though","and \"double-quotes\""}
 END,
             ],
         ];

--- a/tests/MartinGeorgiev/Utils/ArrayDataTransformerTest.php
+++ b/tests/MartinGeorgiev/Utils/ArrayDataTransformerTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\MartinGeorgiev\Utils;
 
-use MartinGeorgiev\Utils\DataStructure;
+use MartinGeorgiev\Utils\ArrayDataTransformer;
 use PHPUnit\Framework\TestCase;
 
-class DataStructureTest extends TestCase
+class ArrayDataTransformerTest extends TestCase
 {
     /**
      * @test
@@ -18,7 +18,7 @@ class DataStructureTest extends TestCase
      */
     public function can_transform_from_php_value(array $phpValue, string $postgresValue): void
     {
-        self::assertEquals($postgresValue, DataStructure::transformPHPArrayToPostgresTextArray($phpValue));
+        self::assertEquals($postgresValue, ArrayDataTransformer::transformPHPArrayToPostgresTextArray($phpValue));
     }
 
     /**
@@ -30,7 +30,7 @@ class DataStructureTest extends TestCase
      */
     public function can_transform_to_php_value(array $phpValue, string $postgresValue): void
     {
-        self::assertEquals($phpValue, DataStructure::transformPostgresTextArrayToPHPArray($postgresValue));
+        self::assertEquals($phpValue, ArrayDataTransformer::transformPostgresTextArrayToPHPArray($postgresValue));
     }
 
     /**
@@ -118,13 +118,13 @@ class DataStructureTest extends TestCase
             ],
             'mixed numeric formats' => [
                 'phpValue' => [
-                    '1.23',           // regular float string
-                    1.23,             // regular float
-                    '1.230',          // float with trailing zeros
-                    '1.23e4',         // scientific notation
-                    '1.0',            // whole float as string
-                    1.0,              // whole float
-                    '9999999999999999999', // large integer
+                    '1.23',                 // regular float string
+                    1.23,                   // regular float
+                    '1.230',                // float with trailing zeros
+                    '1.23e4',               // scientific notation
+                    '1.0',                  // whole float as string
+                    1.0,                    // whole float
+                    '9999999999999999999',  // large integer
                 ],
                 'postgresValue' => '{"1.23",1.23,"1.230","1.23e4","1.0",1,"9999999999999999999"}',
             ],
@@ -162,7 +162,7 @@ class DataStructureTest extends TestCase
     public function throws_invalid_argument_exception_when_tries_to_non_single_dimensioned_array_from_php_value(array $phpValue, string $postgresValue): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        DataStructure::transformPHPArrayToPostgresTextArray($phpValue);
+        ArrayDataTransformer::transformPHPArrayToPostgresTextArray($phpValue);
     }
 
     /**
@@ -175,7 +175,7 @@ class DataStructureTest extends TestCase
     public function throws_invalid_argument_exception_when_tries_to_non_single_dimensioned_array_to_php_value(array $phpValue, string $postgresValue): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        DataStructure::transformPostgresTextArrayToPHPArray($postgresValue);
+        ArrayDataTransformer::transformPostgresTextArrayToPHPArray($postgresValue);
     }
 
     /**
@@ -212,7 +212,7 @@ class DataStructureTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid array format');
-        DataStructure::transformPostgresTextArrayToPHPArray('{invalid"format}');
+        ArrayDataTransformer::transformPostgresTextArrayToPHPArray('{invalid"format}');
     }
 
     /**
@@ -221,8 +221,8 @@ class DataStructureTest extends TestCase
     public function preserves_numeric_string_types(): void
     {
         $input = ['1', '1.0', '1.00', 1, 1.01];
-        $postgres = DataStructure::transformPHPArrayToPostgresTextArray($input);
-        $output = DataStructure::transformPostgresTextArrayToPHPArray($postgres);
+        $postgres = ArrayDataTransformer::transformPHPArrayToPostgresTextArray($input);
+        $output = ArrayDataTransformer::transformPostgresTextArrayToPHPArray($postgres);
 
         self::assertSame([
             '1',
@@ -241,7 +241,7 @@ class DataStructureTest extends TestCase
         $resource = \fopen('php://memory', 'r');
         \assert(\is_resource($resource));
         $input = [$resource];
-        $result = DataStructure::transformPHPArrayToPostgresTextArray($input);
+        $result = ArrayDataTransformer::transformPHPArrayToPostgresTextArray($input);
         \fclose($resource);
 
         self::assertSame('{"(resource)"}', $result);

--- a/tests/MartinGeorgiev/Utils/DataStructureTest.php
+++ b/tests/MartinGeorgiev/Utils/DataStructureTest.php
@@ -44,25 +44,43 @@ class DataStructureTest extends TestCase
     public static function provideValidTransformations(): array
     {
         return [
-            [
+            'simple integer strings as strings are preserved as strings' => [
                 'phpValue' => [
                     0 => '1',
                     1 => '2',
                     2 => '3',
                     3 => '4',
                 ],
+                'postgresValue' => '{"1","2","3","4"}',
+            ],
+            'simple integer strings' => [
+                'phpValue' => [
+                    0 => 1,
+                    1 => 2,
+                    2 => 3,
+                    3 => 4,
+                ],
                 'postgresValue' => '{1,2,3,4}',
             ],
-            [
+            'decimal numbers represented as strings are preserved as strings' => [
                 'phpValue' => [
                     0 => '1.23',
                     1 => '2.34',
                     2 => '3.45',
                     3 => '4.56',
                 ],
+                'postgresValue' => '{"1.23","2.34","3.45","4.56"}',
+            ],
+            'decimal numbers' => [
+                'phpValue' => [
+                    0 => 1.23,
+                    1 => 2.34,
+                    2 => 3.45,
+                    3 => 4.56,
+                ],
                 'postgresValue' => '{1.23,2.34,3.45,4.56}',
             ],
-            [
+            'mixed content with special characters' => [
                 'phpValue' => [
                     0 => 'dfasdf',
                     1 => 'qw,,e{q"we',
@@ -72,16 +90,48 @@ class DataStructureTest extends TestCase
                 ],
                 'postgresValue' => '{"dfasdf","qw,,e{q\"we","\'qrer\'",604,"\"aaa\",\"b\"\"bb\",\"ccc\""}',
             ],
-            [
+            'empty strings' => [
                 'phpValue' => [
                     0 => '',
                     1 => '',
                 ],
                 'postgresValue' => '{"",""}',
             ],
-            [
+            'empty array' => [
                 'phpValue' => [],
                 'postgresValue' => '{}',
+            ],
+            'scientific notation as strings' => [
+                'phpValue' => ['1.23e4', '2.34e5', '3.45e6'],
+                'postgresValue' => '{"1.23e4","2.34e5","3.45e6"}',
+            ],
+            'scientific notation with negative exponents' => [
+                'phpValue' => ['1.23e-4', '2.34e-5', '3.45e-6'],
+                'postgresValue' => '{"1.23e-4","2.34e-5","3.45e-6"}',
+            ],
+            'whole floats that look like integers' => [
+                'phpValue' => ['1.0', '2.00', '3.000', '4.0000'],
+                'postgresValue' => '{"1.0","2.00","3.000","4.0000"}',
+            ],
+            'large integers beyond PHP_INT_MAX' => [
+                'phpValue' => [
+                    '9223372036854775808',  // PHP_INT_MAX + 1
+                    '9999999999999999999',
+                    '-9223372036854775809', // PHP_INT_MIN - 1
+                ],
+                'postgresValue' => '{"9223372036854775808","9999999999999999999","-9223372036854775809"}',
+            ],
+            'mixed numeric formats' => [
+                'phpValue' => [
+                    '1.23',           // regular float string
+                    1.23,             // regular float
+                    '1.230',          // float with trailing zeros
+                    '1.23e4',         // scientific notation
+                    '1.0',            // whole float as string
+                    1.0,              // whole float
+                    '9999999999999999999', // large integer
+                ],
+                'postgresValue' => '{"1.23",1.23,"1.230","1.23e4","1.0",1,"9999999999999999999"}',
             ],
         ];
     }

--- a/tests/MartinGeorgiev/Utils/DataStructureTest.php
+++ b/tests/MartinGeorgiev/Utils/DataStructureTest.php
@@ -34,12 +34,7 @@ class DataStructureTest extends TestCase
     }
 
     /**
-     * @see https://stackoverflow.com/a/27964420/3425372 Kudos to dmikam for the inspiration
-     *
-     * @return list<array{
-     *     phpValue: array,
-     *     postgresValue: string
-     * }>
+     * @return array<string, array{phpValue: array, postgresValue: string}>
      */
     public static function provideValidTransformations(): array
     {


### PR DESCRIPTION
## Changes to type handling

This PR significantly improves how numeric types and booleans are preserved when transforming data between PostgreSQL arrays and PHP. Previously, type information could be lost during transformation, resulting in unexpected behavior when retrieving data.

### Numbers handling

**Before:**
- Numbers could lose their original type during transformation
- Float values might be converted to integers (e.g., `1.0` → `1`)
- String representation of numbers could be converted to actual numbers

**After:**
- Type information is carefully preserved in both directions
- Integers stay as integers: `1` → `1`
- Floats stay as floats: `1.5` → `1.5`
- Numeric strings stay as strings: `'1.0'` → `'1.0'`

### Examples

#### Integer/float preservation

```php
// Before
$phpArray = [1, 2.5, '3.0'];
// After transformation back from PostgreSQL:
// [1, 2, 3] (types and precision could be lost)

// After
$phpArray = [1, 2.5, '3.0']; 
// After transformation back from PostgreSQL:
// [1, 2.5, '3.0'] (original types preserved)
```

#### Boolean

```php
// Before
$phpArray = [true, false];
// Might be inconsistently handled

// After
$phpArray = [true, false];
// Properly converted to PostgreSQL 'true'/'false' and back
// Returns [true, false] with correct boolean types
```

#### Large integers and scientific notation

```php
// Before
$phpArray = ['9223372036854775808', '1.23e5'];
// After transformation:
// Potential loss of precision or conversion to different types

// After
$phpArray = ['9223372036854775808', '1.23e5'];
// After transformation:
// ['9223372036854775808', '1.23e5'] (preserved exactly)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the conversion process between PostgreSQL text arrays and PHP arrays to enhance reliability and error handling.
  - Improved integer validation logic for cleaner, more maintainable data processing.
  - Introduced a new utility class for transforming data between PostgreSQL text arrays and PHP arrays.

- **Tests**
  - Expanded test coverage to include additional numeric formats such as floats, scientific notation, and very large numbers.
  - Reorganized test cases for clearer behavior definitions and robust transformation validation.
  - Updated return type annotations for better clarity in test case outputs.
  - Added new tests for exception handling and resource cleanup. 
  - Introduced a comprehensive test suite for the new `ArrayDataTransformer` class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->