### PR TITLE
ci: skip `sloth` when the PR author is the `release-please` bot

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release-please:
-    name: Release
+    name: Create new release PR
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4

--- a/.github/workflows/sloth.yml
+++ b/.github/workflows/sloth.yml
@@ -12,7 +12,15 @@ jobs:
   sloth:
     runs-on: ubuntu-latest
     steps:
-      - name: Sloth
+      - name: Skip for release-please
+        id: check_release_please
+        if: github.event.pull_request.user.id == 41898282 # release-please[bot]
+        run: |
+          echo "Skipping Sloth check for release-please PR"
+          exit 0
+
+      - name: Run Sloth
+        if: ${{ always() && steps.check_release_please.outcome == 'skipped' }}
         uses: lendable/sloth@e1fd9a2df2549f6e64188f274bc5d3b39d7842ed # 0.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the label for an automated release job to provide clearer identification.
  - Added a conditional step in an internal workflow to bypass a routine check for pull requests initiated by a designated system account, streamlining the process without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->