### PR TITLE
ci: upload the coverage results once and only based on the latest dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
           - php: '8.1'
             doctrine-orm: '2.14'
             doctrine-lexer: '1.2'
-          - php: '8.4'
+          - php: '8.4' # Run coverage report only based on the latest dependencies
+            doctrine-lexer: 'latest'
+            doctrine-orm: 'latest'
             calculate-code-coverage: true
         exclude:
           - doctrine-orm: '2.14'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the automated testing configuration to leverage the latest dependency versions, enhancing test coverage reporting for PHP 8.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->