### PR TITLE
ci: do not run `CI` workflow if the changes are related only to documentation or GitHub Actions configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,16 @@
 name: CI
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '.github/**'
+      - '**/*.md'
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - '.github/**'
+      - '**/*.md'
 
 permissions:
   contents: read


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the automated workflow to trigger only on impactful changes, reducing unnecessary process runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->