### PR TITLE
chore: tidy up links in some of the phpdoc blocks

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Cidr.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Cidr.php
@@ -12,7 +12,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Traits\CidrValidationTrait;
 /**
  * Implementation of PostgreSQL CIDR data type.
  *
- * @see https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-CIDR
+ * @see https://www.postgresql.org/docs/17/datatype-net-types.html#DATATYPE-CIDR
  * @since 3.0
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/CidrArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/CidrArray.php
@@ -10,7 +10,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Traits\CidrValidationTrait;
 /**
  * Implementation of PostgreSQL CIDR[] data type.
  *
- * @see https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-CIDR
+ * @see https://www.postgresql.org/docs/17/datatype-net-types.html#DATATYPE-CIDR
  * @since 3.0
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/DoublePrecisionArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/DoublePrecisionArray.php
@@ -7,7 +7,7 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types;
 /**
  * Implementation of PostgreSQL DOUBLE PRECISION[] data type.
  *
- * @see https://www.postgresql.org/docs/current/datatype-numeric.html
+ * @see https://www.postgresql.org/docs/17/datatype-numeric.html
  * @since 3.0
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Inet.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Inet.php
@@ -12,7 +12,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Traits\InetValidationTrait;
 /**
  * Implementation of PostgreSQL INET data type.
  *
- * @see https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-INET
+ * @see https://www.postgresql.org/docs/17/datatype-net-types.html#DATATYPE-INET
  * @since 3.0
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/InetArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/InetArray.php
@@ -10,7 +10,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Traits\InetValidationTrait;
 /**
  * Implementation of PostgreSQL INET[] data type.
  *
- * @see https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-INET
+ * @see https://www.postgresql.org/docs/17/datatype-net-types.html#DATATYPE-INET
  * @since 3.0
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr.php
@@ -12,7 +12,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Traits\MacaddrValidationTrait;
 /**
  * Implementation of PostgreSQL MACADDR data type.
  *
- * @see https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-MACADDR
+ * @see https://www.postgresql.org/docs/17/datatype-net-types.html#DATATYPE-MACADDR
  * @since 3.0
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrArray.php
@@ -9,7 +9,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddrArrayItemForPHPE
 /**
  * Implementation of PostgreSQL MACADDR[] data type.
  *
- * @see https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-MACADDR
+ * @see https://www.postgresql.org/docs/17/datatype-net-types.html#DATATYPE-MACADDR
  * @since 3.0
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/RealArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/RealArray.php
@@ -7,7 +7,7 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types;
 /**
  * Implementation of PostgreSQL REAL[] data type.
  *
- * @see https://www.postgresql.org/docs/current/datatype-numeric.html
+ * @see https://www.postgresql.org/docs/17/datatype-numeric.html
  * @since 3.0
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayDimensions.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayDimensions.php
@@ -7,7 +7,7 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 /**
  * Implementation of PostgreSQL ARRAY_DIMS().
  *
- * @see http://www.postgresql.org/docs/9.6/static/functions-array.html
+ * @see https://www.postgresql.org/docs/9.6/static/functions-array.html
  * @since 0.10
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLength.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayLength.php
@@ -7,7 +7,7 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 /**
  * Implementation of PostgreSQL ARRAY_LENGTH().
  *
- * @see http://www.postgresql.org/docs/9.4/static/functions-array.html
+ * @see https://www.postgresql.org/docs/9.4/static/functions-array.html
  * @since 0.9
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayNumberOfDimensions.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayNumberOfDimensions.php
@@ -7,7 +7,7 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 /**
  * Implementation of PostgreSQL ARRAY_NDIMS().
  *
- * @see http://www.postgresql.org/docs/9.6/static/functions-array.html
+ * @see https://www.postgresql.org/docs/9.6/static/functions-array.html
  * @since 0.10
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
@@ -16,7 +16,7 @@ use MartinGeorgiev\Utils\DoctrineOrm;
 /**
  * Implementation of PostgreSQL CAST().
  *
- * @see https://www.postgresql.org/docs/current/sql-createcast.html
+ * @see https://www.postgresql.org/docs/17/sql-createcast.html
  * @see https://github.com/beberlei/DoctrineExtensions/blob/f3536d881637f6ddc7ca1d6595d18c15e06eb1d9/src/Query/Mysql/Cast.php
  * @since 2.0
  *

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Unaccent.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Unaccent.php
@@ -9,7 +9,7 @@ use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentFor
 /**
  * Implementation of PostgreSQL UNACCENT.
  *
- * @see http://www.postgresql.org/docs/current/static/unaccent.html
+ * @see https://www.postgresql.org/docs/17/unaccent.html
  *
  * @author Martin Hasoň <martin.hason@gmail.com>
  */

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Unnest.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Unnest.php
@@ -7,7 +7,7 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 /**
  * Implementation of PostgreSQL UNNEST() for single array argument.
  *
- * @see http://www.postgresql.org/docs/9.6/static/functions-array.html
+ * @see https://www.postgresql.org/docs/9.6/static/functions-array.html
  * @since 0.10
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated external reference links to PostgreSQL documentation to point to version 17.
	- Revised URLs to use secure HTTPS, ensuring all documentation references are current and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->