### PR TITLE
feat: add `NULL` value support for `array_append()`, `array_replace()`, `array_prepend()`, `array_remove()` and improve test scenarios for `NULL`

### DIFF
--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppend.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppend.php
@@ -18,6 +18,6 @@ class ArrayAppend extends BaseFunction
     {
         $this->setFunctionPrototype('array_append(%s, %s)');
         $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('ArithmeticPrimary');
+        $this->addNodeMapping('NewValue');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrepend.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrepend.php
@@ -17,7 +17,7 @@ class ArrayPrepend extends BaseFunction
     protected function customizeFunction(): void
     {
         $this->setFunctionPrototype('array_prepend(%s, %s)');
-        $this->addNodeMapping('ArithmeticPrimary');
+        $this->addNodeMapping('NewValue');
         $this->addNodeMapping('StringPrimary');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemove.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemove.php
@@ -18,6 +18,6 @@ class ArrayRemove extends BaseFunction
     {
         $this->setFunctionPrototype('array_remove(%s, %s)');
         $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('ArithmeticPrimary');
+        $this->addNodeMapping('NewValue');
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplace.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplace.php
@@ -18,7 +18,7 @@ class ArrayReplace extends BaseFunction
     {
         $this->setFunctionPrototype('array_replace(%s, %s, %s)');
         $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('ArithmeticPrimary');
-        $this->addNodeMapping('ArithmeticPrimary');
+        $this->addNodeMapping('NewValue');
+        $this->addNodeMapping('NewValue');
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppendTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayAppendTest.php
@@ -22,6 +22,7 @@ class ArrayAppendTest extends TestCase
             'appends string element to array' => "SELECT array_append(c0_.array1, 'new-value') AS sclr_0 FROM ContainsArrays c0_",
             'appends numeric element to array' => 'SELECT array_append(c0_.array1, 42) AS sclr_0 FROM ContainsArrays c0_',
             'appends element using parameter' => 'SELECT array_append(c0_.array1, ?) AS sclr_0 FROM ContainsArrays c0_',
+            'appends null to array' => 'SELECT array_append(c0_.array1, null) AS sclr_0 FROM ContainsArrays c0_',
         ];
     }
 
@@ -31,6 +32,7 @@ class ArrayAppendTest extends TestCase
             'appends string element to array' => \sprintf("SELECT ARRAY_APPEND(e.array1, 'new-value') FROM %s e", ContainsArrays::class),
             'appends numeric element to array' => \sprintf('SELECT ARRAY_APPEND(e.array1, 42) FROM %s e', ContainsArrays::class),
             'appends element using parameter' => \sprintf('SELECT ARRAY_APPEND(e.array1, :dql_parameter) FROM %s e', ContainsArrays::class),
+            'appends null to array' => \sprintf('SELECT ARRAY_APPEND(e.array1, NULL) FROM %s e', ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrependTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPrependTest.php
@@ -22,6 +22,7 @@ class ArrayPrependTest extends TestCase
             'prepends string element to array' => "SELECT array_prepend('new-value', c0_.array1) AS sclr_0 FROM ContainsArrays c0_",
             'prepends numeric element to array' => 'SELECT array_prepend(42, c0_.array1) AS sclr_0 FROM ContainsArrays c0_',
             'prepends element using parameter' => 'SELECT array_prepend(?, c0_.array1) AS sclr_0 FROM ContainsArrays c0_',
+            'prepends null to array' => 'SELECT array_prepend(null, c0_.array1) AS sclr_0 FROM ContainsArrays c0_',
         ];
     }
 
@@ -31,6 +32,7 @@ class ArrayPrependTest extends TestCase
             'prepends string element to array' => \sprintf("SELECT ARRAY_PREPEND('new-value', e.array1) FROM %s e", ContainsArrays::class),
             'prepends numeric element to array' => \sprintf('SELECT ARRAY_PREPEND(42, e.array1) FROM %s e', ContainsArrays::class),
             'prepends element using parameter' => \sprintf('SELECT ARRAY_PREPEND(:dql_parameter, e.array1) FROM %s e', ContainsArrays::class),
+            'prepends null to array' => \sprintf('SELECT ARRAY_PREPEND(NULL, e.array1) FROM %s e', ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemoveTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayRemoveTest.php
@@ -22,6 +22,7 @@ class ArrayRemoveTest extends TestCase
             'removes string element from array' => "SELECT array_remove(c0_.array1, 'value-to-remove') AS sclr_0 FROM ContainsArrays c0_",
             'removes numeric element from array' => 'SELECT array_remove(c0_.array1, 42) AS sclr_0 FROM ContainsArrays c0_',
             'removes element using parameter' => 'SELECT array_remove(c0_.array1, ?) AS sclr_0 FROM ContainsArrays c0_',
+            'removes null from array' => 'SELECT array_remove(c0_.array1, null) AS sclr_0 FROM ContainsArrays c0_',
         ];
     }
 
@@ -31,6 +32,7 @@ class ArrayRemoveTest extends TestCase
             'removes string element from array' => \sprintf("SELECT ARRAY_REMOVE(e.array1, 'value-to-remove') FROM %s e", ContainsArrays::class),
             'removes numeric element from array' => \sprintf('SELECT ARRAY_REMOVE(e.array1, 42) FROM %s e', ContainsArrays::class),
             'removes element using parameter' => \sprintf('SELECT ARRAY_REMOVE(e.array1, :dql_parameter) FROM %s e', ContainsArrays::class),
+            'removes null from array' => \sprintf('SELECT ARRAY_REMOVE(e.array1, NULL) FROM %s e', ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplaceTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayReplaceTest.php
@@ -22,6 +22,9 @@ class ArrayReplaceTest extends TestCase
             'replaces string element in array' => "SELECT array_replace(c0_.array1, 'old-value', 'new-value') AS sclr_0 FROM ContainsArrays c0_",
             'replaces numeric element in array' => 'SELECT array_replace(c0_.array1, 42, 43) AS sclr_0 FROM ContainsArrays c0_',
             'replaces element using parameters' => 'SELECT array_replace(c0_.array1, ?, ?) AS sclr_0 FROM ContainsArrays c0_',
+            'replaces null with string' => "SELECT array_replace(c0_.array1, null, 'new-value') AS sclr_0 FROM ContainsArrays c0_",
+            'replaces value with null' => "SELECT array_replace(c0_.array1, 'old-value', null) AS sclr_0 FROM ContainsArrays c0_",
+            'replaces null with null' => 'SELECT array_replace(c0_.array1, null, null) AS sclr_0 FROM ContainsArrays c0_',
         ];
     }
 
@@ -31,6 +34,9 @@ class ArrayReplaceTest extends TestCase
             'replaces string element in array' => \sprintf("SELECT ARRAY_REPLACE(e.array1, 'old-value', 'new-value') FROM %s e", ContainsArrays::class),
             'replaces numeric element in array' => \sprintf('SELECT ARRAY_REPLACE(e.array1, 42, 43) FROM %s e', ContainsArrays::class),
             'replaces element using parameters' => \sprintf('SELECT ARRAY_REPLACE(e.array1, :old_value, :new_value) FROM %s e', ContainsArrays::class),
+            'replaces null with string' => \sprintf("SELECT ARRAY_REPLACE(e.array1, NULL, 'new-value') FROM %s e", ContainsArrays::class),
+            'replaces value with null' => \sprintf("SELECT ARRAY_REPLACE(e.array1, 'old-value', NULL) FROM %s e", ContainsArrays::class),
+            'replaces null with null' => \sprintf('SELECT ARRAY_REPLACE(e.array1, NULL, NULL) FROM %s e', ContainsArrays::class),
         ];
     }
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbSetLaxTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbSetLaxTest.php
@@ -19,16 +19,28 @@ class JsonbSetLaxTest extends TestCase
     protected function getExpectedSqlStatements(): array
     {
         return [
-            "SELECT jsonb_set_lax(c0_.object1, '{country}', '{\"iso_3166_a3_code\":\"BGR\"}') AS sclr_0 FROM ContainsJsons c0_",
-            "SELECT jsonb_set_lax(c0_.object1, '{country}', null) AS sclr_0 FROM ContainsJsons c0_",
+            'modifies top-level property' => "SELECT jsonb_set_lax(c0_.object1, '{country}', '{\"iso_3166_a3_code\":\"BGR\"}') AS sclr_0 FROM ContainsJsons c0_",
+            'sets property to null' => "SELECT jsonb_set_lax(c0_.object1, '{country}', null) AS sclr_0 FROM ContainsJsons c0_",
+            'modifies nested property' => "SELECT jsonb_set_lax(c0_.object1, '{address,city}', '\"Sofia\"') AS sclr_0 FROM ContainsJsons c0_",
+            'modifies array element at index' => "SELECT jsonb_set_lax(c0_.object1, '{phones,0}', '\"+1234567890\"') AS sclr_0 FROM ContainsJsons c0_",
+            'uses parameters for path and value' => 'SELECT jsonb_set_lax(c0_.object1, ?, ?) AS sclr_0 FROM ContainsJsons c0_',
+            'modifies deeply nested array element' => "SELECT jsonb_set_lax(c0_.object1, '{user,contacts,0,phone}', '\"+1234567890\"') AS sclr_0 FROM ContainsJsons c0_",
+            'sets boolean property' => "SELECT jsonb_set_lax(c0_.object1, '{is_active}', 'true') AS sclr_0 FROM ContainsJsons c0_",
+            'sets numeric property' => "SELECT jsonb_set_lax(c0_.object1, '{count}', '42') AS sclr_0 FROM ContainsJsons c0_",
         ];
     }
 
     protected function getDqlStatements(): array
     {
         return [
-            \sprintf("SELECT JSONB_SET_LAX(e.object1, '{country}', '{\"iso_3166_a3_code\":\"BGR\"}') FROM %s e", ContainsJsons::class),
-            \sprintf("SELECT JSONB_SET_LAX(e.object1, '{country}', null) FROM %s e", ContainsJsons::class),
+            'modifies top-level property' => \sprintf("SELECT JSONB_SET_LAX(e.object1, '{country}', '{\"iso_3166_a3_code\":\"BGR\"}') FROM %s e", ContainsJsons::class),
+            'sets property to null' => \sprintf("SELECT JSONB_SET_LAX(e.object1, '{country}', null) FROM %s e", ContainsJsons::class),
+            'modifies nested property' => \sprintf("SELECT JSONB_SET_LAX(e.object1, '{address,city}', '\"Sofia\"') FROM %s e", ContainsJsons::class),
+            'modifies array element at index' => \sprintf("SELECT JSONB_SET_LAX(e.object1, '{phones,0}', '\"+1234567890\"') FROM %s e", ContainsJsons::class),
+            'uses parameters for path and value' => \sprintf('SELECT JSONB_SET_LAX(e.object1, :path, :value) FROM %s e', ContainsJsons::class),
+            'modifies deeply nested array element' => \sprintf("SELECT JSONB_SET_LAX(e.object1, '{user,contacts,0,phone}', '\"+1234567890\"') FROM %s e", ContainsJsons::class),
+            'sets boolean property' => \sprintf("SELECT JSONB_SET_LAX(e.object1, '{is_active}', 'true') FROM %s e", ContainsJsons::class),
+            'sets numeric property' => \sprintf("SELECT JSONB_SET_LAX(e.object1, '{count}', '42') FROM %s e", ContainsJsons::class),
         ];
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Array manipulation functions (append, prepend, remove, and replace) have been updated to support a broader range of input types, including handling of null values.
  - Enhanced behavior for JSON update functions improves the clarity of output expectations.

- **Tests**
  - Comprehensive test cases have been added and refined to ensure the correct processing of null values in array operations and to validate the improved output formats for JSON updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->