### PR TITLE
ci: bump initial version of the pleas-release bot

### DIFF
--- a/.github/actions/release-please/config.json
+++ b/.github/actions/release-please/config.json
@@ -18,7 +18,7 @@
       "type": "sentence-case"
     }
   ],
-  "initial-version": "2.8.0",
+  "initial-version": "3.0.0",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "release-type": "simple",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application’s starting release version to 3.0.0, indicating a significant version milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->