### PR TITLE
bug: avoid infinite parsing loop for `GREATEST()` and `LEAST()` by using `SimpleArithmeticExpression`

### DIFF
--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseComparisonFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseComparisonFunction.php
@@ -11,5 +11,5 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
  */
 abstract class BaseComparisonFunction extends BaseVariadicFunction
 {
-    protected string $commonNodeMapping = 'ArithmeticPrimary';
+    protected string $commonNodeMapping = 'SimpleArithmeticExpression';
 }

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GreatestTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GreatestTest.php
@@ -26,14 +26,18 @@ class GreatestTest extends BaseComparisonFunctionTestCase
     protected function getExpectedSqlStatements(): array
     {
         return [
-            'SELECT greatest(c0_.integer1, c0_.integer2, c0_.integer3) AS sclr_0 FROM ContainsIntegers c0_',
+            'multiple column values' => 'SELECT greatest(c0_.integer1, c0_.integer2, c0_.integer3) AS sclr_0 FROM ContainsIntegers c0_',
+            'column value with expression' => 'SELECT greatest(c0_.integer1 * 100, SQRT(11) * 150) AS sclr_0 FROM ContainsIntegers c0_',
+            'multiple expressions' => 'SELECT greatest(SQRT(30) * 100, SQRT(11) * 150) AS sclr_0 FROM ContainsIntegers c0_',
         ];
     }
 
     protected function getDqlStatements(): array
     {
         return [
-            \sprintf('SELECT GREATEST(e.integer1, e.integer2, e.integer3) FROM %s e', ContainsIntegers::class),
+            'multiple column values' => \sprintf('SELECT GREATEST(e.integer1, e.integer2, e.integer3) FROM %s e', ContainsIntegers::class),
+            'column value with expression' => \sprintf('SELECT GREATEST(e.integer1 * 100, sqrt(11) * 150) FROM %s e', ContainsIntegers::class),
+            'multiple expressions' => \sprintf('SELECT GREATEST(sqrt(30) * 100, sqrt(11) * 150) FROM %s e', ContainsIntegers::class),
         ];
     }
 

--- a/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LeastTest.php
+++ b/tests/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LeastTest.php
@@ -26,14 +26,18 @@ class LeastTest extends BaseComparisonFunctionTestCase
     protected function getExpectedSqlStatements(): array
     {
         return [
-            'SELECT least(c0_.integer1, c0_.integer2, c0_.integer3) AS sclr_0 FROM ContainsIntegers c0_',
+            'multiple column values' => 'SELECT least(c0_.integer1, c0_.integer2, c0_.integer3) AS sclr_0 FROM ContainsIntegers c0_',
+            'column value with expression' => 'SELECT least(c0_.integer1 * 100, SQRT(11) * 150) AS sclr_0 FROM ContainsIntegers c0_',
+            'multiple expressions' => 'SELECT least(SQRT(30) * 100, SQRT(11) * 150) AS sclr_0 FROM ContainsIntegers c0_',
         ];
     }
 
     protected function getDqlStatements(): array
     {
         return [
-            \sprintf('SELECT LEAST(e.integer1, e.integer2, e.integer3) FROM %s e', ContainsIntegers::class),
+            'multiple column values' => \sprintf('SELECT LEAST(e.integer1, e.integer2, e.integer3) FROM %s e', ContainsIntegers::class),
+            'column value with expression' => \sprintf('SELECT LEAST(e.integer1 * 100, sqrt(11) * 150) FROM %s e', ContainsIntegers::class),
+            'multiple expressions' => \sprintf('SELECT LEAST(sqrt(30) * 100, sqrt(11) * 150) FROM %s e', ContainsIntegers::class),
         ];
     }
 


### PR DESCRIPTION
…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced arithmetic expression processing to improve the accuracy and reliability of query evaluations.

- **Tests**
  - Expanded and diversified testing scenarios for handling maximum and minimum value functions, ensuring robust performance across varied arithmetic contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->