### PR TITLE
feat: add support for arithmetic functions `ABS`, `CEIL`, `FLOOR`, `ROUND` and `TRUNC`

### DIFF
--- a/docs/AVAILABLE-FUNCTIONS-AND-OPERATORS.md
+++ b/docs/AVAILABLE-FUNCTIONS-AND-OPERATORS.md
@@ -28,6 +28,7 @@
 
 | PostgreSQL functions | Register for DQL as | Implemented by
 |---|---|---|
+| abs | ABS | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Abs` |
 | all | ALL_OF | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\All` |
 | any | ANY_OF | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Any` |
 | any_value | ANY_VALUE | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\AnyValue` |
@@ -47,11 +48,13 @@
 | array_to_string | ARRAY_TO_STRING | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ArrayToString` |
 | cardinality | ARRAY_CARDINALITY | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Cardinality` |
 | cast | CAST | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Cast` |
+| ceil | CEIL | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ceil` |
 | date_add | DATE_ADD | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\DateAdd` |
 | date_bin | DATE_BIN | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\DateBin` |
 | date_subtract | DATE_SUBTRACT | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\DateSubtract` |
 | daterange | DATERANGE | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Daterange` |
 | extract | DATE_EXTRACT | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\DateExtract` |
+| floor | FLOOR | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Floor` |
 | greatest | GREATEST | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Greatest` |
 | int4range | INT4RANGE | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Int4range` |
 | int8range | INT8RANGE | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Int8range` |
@@ -98,6 +101,7 @@
 | regexp_match | REGEXP_MATCH | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\RegexpMatch` |
 | regexp_replace | REGEXP_REPLACE | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\RegexpReplace` |
 | regexp_substr | REGEXP_SUBSTR | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\RegexpSubstr` |
+| round | ROUND | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Round` |
 | row | ROW | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Row` |
 | row_to_json | ROW_TO_JSON | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\RowToJson` |
 | split_part | SPLIT_PART | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\SplitPart` |
@@ -108,6 +112,7 @@
 | to_jsonb | TO_JSONB | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ToJsonb` |
 | to_tsquery | TO_TSQUERY | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ToTsquery` |
 | to_tsvector | TO_TSVECTOR | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ToTsvector` |
+| trunc | TRUNC | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Trunc` |
 | tsrange | TSRANGE | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Tsrange` |
 | tstzrange | TSTZRANGE | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Tstzrange` |
 | unaccent | UNACCENT | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Unaccent` |

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -147,6 +147,13 @@ $configuration->addCustomStringFunction('NUMRANGE', MartinGeorgiev\Doctrine\ORM\
 $configuration->addCustomStringFunction('TSRANGE', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Tsrange::class);
 $configuration->addCustomStringFunction('TSTZRANGE', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Tstzrange::class);
 
+# Arithmetic functions
+$configuration->addCustomStringFunction('ABS', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Abs::class);
+$configuration->addCustomStringFunction('CEIL', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ceil::class);
+$configuration->addCustomStringFunction('FLOOR', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Floor::class);
+$configuration->addCustomStringFunction('ROUND', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Round::class);
+$configuration->addCustomStringFunction('TRUNC', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Trunc::class);
+
 # other operators
 $configuration->addCustomStringFunction('CAST', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Cast::class);
 $configuration->addCustomStringFunction('ILIKE', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ilike::class);

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -201,6 +201,13 @@ return [
         'NUMRANGE' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Numrange::class,
         'TSRANGE' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Tsrange::class,
         'TSTZRANGE' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Tstzrange::class,
+        
+        # Arithmetic functions
+        'ABS' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Abs::class,
+        'CEIL' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ceil::class,
+        'FLOOR' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Floor::class,
+        'ROUND' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Round::class,
+        'TRUNC' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Trunc::class,
 
         # other operators
         'CAST' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Cast::class,

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -195,6 +195,13 @@ doctrine:
                         NUMRANGE: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Numrange
                         TSRANGE: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Tsrange
                         TSTZRANGE: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Tstzrange
+                        
+                        # Arithmetic functions
+                        ABS: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Abs
+                        CEIL: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ceil
+                        FLOOR: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Floor
+                        ROUND: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Round
+                        TRUNC: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Trunc
 
                         # other operators
                         CAST: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Cast

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseArithmeticFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseArithmeticFunction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * @since 3.2
+ *
+ * @author Jan Klan <jan@klan.com.au>
+ */
+abstract class BaseArithmeticFunction extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return ['ArithmeticPrimary'];
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 1;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 1;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ceil.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ceil.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostgreSQL CEIL().
+ *
+ * @see https://www.postgresql.org/docs/17/functions-math.html
+ * @since 3.2
+ *
+ * @author Jan Klan <jan@klan.com.au>
+ */
+class Ceil extends BaseArithmeticFunction
+{
+    protected function getFunctionName(): string
+    {
+        return 'CEIL';
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Floor.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Floor.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostgreSQL FLOOR().
+ *
+ * @see https://www.postgresql.org/docs/17/functions-math.html
+ * @since 3.2
+ *
+ * @author Jan Klan <jan@klan.com.au>
+ */
+class Floor extends BaseArithmeticFunction
+{
+    protected function getFunctionName(): string
+    {
+        return 'FLOOR';
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Round.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Round.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostgreSQL ROUND().
+ *
+ * @see https://www.postgresql.org/docs/17/functions-math.html
+ * @since 3.2
+ *
+ * @author Jan Klan <jan@klan.com.au>
+ */
+class Round extends BaseArithmeticFunction
+{
+    protected function getFunctionName(): string
+    {
+        return 'ROUND';
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 2;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Trunc.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Trunc.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostgreSQL TRUNC().
+ *
+ * @see https://www.postgresql.org/docs/17/functions-math.html
+ * @since 3.2
+ *
+ * @author Jan Klan <jan@klan.com.au>
+ */
+class Trunc extends BaseArithmeticFunction
+{
+    protected function getFunctionName(): string
+    {
+        return 'TRUNC';
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 2;
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CeilTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CeilTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsDecimals;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ceil;
+
+class CeilTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'CEIL' => Ceil::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT CEIL(c0_.decimal1) AS sclr_0 FROM ContainsDecimals c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            \sprintf('SELECT CEIL(e.decimal1) FROM %s e', ContainsDecimals::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/FloorTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/FloorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsDecimals;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Floor;
+
+class FloorTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'FLOOR' => Floor::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT FLOOR(c0_.decimal1) AS sclr_0 FROM ContainsDecimals c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            \sprintf('SELECT FLOOR(e.decimal1) FROM %s e', ContainsDecimals::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/RoundTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/RoundTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsDecimals;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Round;
+
+class RoundTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ROUND' => Round::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ROUND(c0_.decimal1) AS sclr_0 FROM ContainsDecimals c0_',
+            'SELECT ROUND(c0_.decimal2, 0) AS sclr_0 FROM ContainsDecimals c0_',
+            'SELECT ROUND(c0_.decimal3, 1) AS sclr_0 FROM ContainsDecimals c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            \sprintf('SELECT ROUND(e.decimal1) FROM %s e', ContainsDecimals::class),
+            \sprintf('SELECT ROUND(e.decimal2, 0) FROM %s e', ContainsDecimals::class),
+            \sprintf('SELECT ROUND(e.decimal3, 1) FROM %s e', ContainsDecimals::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TruncTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TruncTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsDecimals;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Trunc;
+
+class TruncTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'TRUNC' => Trunc::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT TRUNC(c0_.decimal1) AS sclr_0 FROM ContainsDecimals c0_',
+            'SELECT TRUNC(c0_.decimal2, 0) AS sclr_0 FROM ContainsDecimals c0_',
+            'SELECT TRUNC(c0_.decimal3, 1) AS sclr_0 FROM ContainsDecimals c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            \sprintf('SELECT TRUNC(e.decimal1) FROM %s e', ContainsDecimals::class),
+            \sprintf('SELECT TRUNC(e.decimal2, 0) FROM %s e', ContainsDecimals::class),
+            \sprintf('SELECT TRUNC(e.decimal3, 1) FROM %s e', ContainsDecimals::class),
+        ];
+    }
+}


### PR DESCRIPTION
There are lots more such functions in PostgreSQL, but this is probably a good start. Others can be added if poeple actually use them. I use those I am proposing to add in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the PostgreSQL arithmetic functions ABS, CEIL, FLOOR, ROUND, and TRUNC in Doctrine ORM queries.

- **Documentation**
  - Updated integration guides for Doctrine, Symfony, and Laravel to include configuration examples for the new arithmetic functions.
  - Expanded the list of available functions in the documentation.

- **Tests**
  - Introduced unit tests to verify the correct behavior of the new arithmetic functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->