### PR TITLE
feat: add the ability to specify range bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ This package provides comprehensive Doctrine support for PostgreSQL features:
   - Array aggregation (`array_agg`)
   - Array manipulation (`array_append`, `array_prepend`, `array_remove`, `array_replace`, `array_shuffle`)
   - Array dimensions and length
+- **Range functions**
+  - Arithmetic ranges (`int4range`, `int8range`, `numrange`)
+  - Date ranges (`daterange`, `tsrange`, `tstzrange`)
 - **JSON Functions**
   - JSON construction (`json_build_object`, `jsonb_build_object`)
   - JSON manipulation and transformation

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseRangeFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseRangeFunction.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * @see https://www.postgresql.org/docs/17/rangetypes.html
+ * @since 3.1
+ *
+ * @author Jan Klan <jan@klan.com.au>
+ */
+abstract class BaseRangeFunction extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return [
+            'ArithmeticPrimary',
+            'ArithmeticPrimary',
+            'StringPrimary',
+        ];
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 2;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 3;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Daterange.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Daterange.php
@@ -12,12 +12,19 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  */
-class Daterange extends BaseFunction
+class Daterange extends BaseRangeFunction
 {
-    protected function customizeFunction(): void
+    protected function getFunctionName(): string
     {
-        $this->setFunctionPrototype('daterange(%s, %s)');
-        $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('StringPrimary');
+        return 'daterange';
+    }
+
+    protected function getNodeMappingPattern(): array
+    {
+        return [
+            'StringPrimary',
+            'StringPrimary',
+            'StringPrimary',
+        ];
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Int4range.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Int4range.php
@@ -12,12 +12,10 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  */
-class Int4range extends BaseFunction
+class Int4range extends BaseRangeFunction
 {
-    protected function customizeFunction(): void
+    protected function getFunctionName(): string
     {
-        $this->setFunctionPrototype('int4range(%s, %s)');
-        $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('StringPrimary');
+        return 'int4range';
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Int8range.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Int8range.php
@@ -12,12 +12,10 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  */
-class Int8range extends BaseFunction
+class Int8range extends BaseRangeFunction
 {
-    protected function customizeFunction(): void
+    protected function getFunctionName(): string
     {
-        $this->setFunctionPrototype('int8range(%s, %s)');
-        $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('StringPrimary');
+        return 'int8range';
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Numrange.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Numrange.php
@@ -12,12 +12,10 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  */
-class Numrange extends BaseFunction
+class Numrange extends BaseRangeFunction
 {
-    protected function customizeFunction(): void
+    protected function getFunctionName(): string
     {
-        $this->setFunctionPrototype('numrange(%s, %s)');
-        $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('StringPrimary');
+        return 'numrange';
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Tsrange.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Tsrange.php
@@ -12,12 +12,19 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  */
-class Tsrange extends BaseFunction
+class Tsrange extends BaseRangeFunction
 {
-    protected function customizeFunction(): void
+    protected function getFunctionName(): string
     {
-        $this->setFunctionPrototype('tsrange(%s, %s)');
-        $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('StringPrimary');
+        return 'tsrange';
+    }
+
+    protected function getNodeMappingPattern(): array
+    {
+        return [
+            'StringPrimary',
+            'StringPrimary',
+            'StringPrimary',
+        ];
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Tstzrange.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Tstzrange.php
@@ -12,12 +12,19 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  */
-class Tstzrange extends BaseFunction
+class Tstzrange extends BaseRangeFunction
 {
-    protected function customizeFunction(): void
+    protected function getFunctionName(): string
     {
-        $this->setFunctionPrototype('tstzrange(%s, %s)');
-        $this->addNodeMapping('StringPrimary');
-        $this->addNodeMapping('StringPrimary');
+        return 'tstzrange';
+    }
+
+    protected function getNodeMappingPattern(): array
+    {
+        return [
+            'StringPrimary',
+            'StringPrimary',
+            'StringPrimary',
+        ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Int4rangeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Int4rangeTest.php
@@ -20,6 +20,7 @@ class Int4rangeTest extends TestCase
     {
         return [
             'SELECT int4range(c0_.integer1, c0_.integer2) AS sclr_0 FROM ContainsIntegers c0_',
+            'SELECT int4range(c0_.integer1, c0_.integer2, \'[)\') AS sclr_0 FROM ContainsIntegers c0_',
         ];
     }
 
@@ -27,6 +28,7 @@ class Int4rangeTest extends TestCase
     {
         return [
             \sprintf('SELECT INT4RANGE(e.integer1, e.integer2) FROM %s e', ContainsIntegers::class),
+            \sprintf('SELECT INT4RANGE(e.integer1, e.integer2, \'[)\') FROM %s e', ContainsIntegers::class),
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Int8rangeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Int8rangeTest.php
@@ -20,6 +20,7 @@ class Int8rangeTest extends TestCase
     {
         return [
             'SELECT int8range(c0_.integer1, c0_.integer2) AS sclr_0 FROM ContainsIntegers c0_',
+            'SELECT int8range(c0_.integer1, c0_.integer2, \'[)\') AS sclr_0 FROM ContainsIntegers c0_',
         ];
     }
 
@@ -27,6 +28,7 @@ class Int8rangeTest extends TestCase
     {
         return [
             \sprintf('SELECT INT8RANGE(e.integer1, e.integer2) FROM %s e', ContainsIntegers::class),
+            \sprintf('SELECT INT8RANGE(e.integer1, e.integer2, \'[)\') FROM %s e', ContainsIntegers::class),
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NumrangeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NumrangeTest.php
@@ -20,6 +20,7 @@ class NumrangeTest extends TestCase
     {
         return [
             'SELECT numrange(c0_.decimal1, c0_.decimal2) AS sclr_0 FROM ContainsDecimals c0_',
+            'SELECT numrange(c0_.decimal1, c0_.decimal2, \'[)\') AS sclr_0 FROM ContainsDecimals c0_',
         ];
     }
 
@@ -27,6 +28,7 @@ class NumrangeTest extends TestCase
     {
         return [
             \sprintf('SELECT NUMRANGE(e.decimal1, e.decimal2) FROM %s e', ContainsDecimals::class),
+            \sprintf('SELECT NUMRANGE(e.decimal1, e.decimal2, \'[)\') FROM %s e', ContainsDecimals::class),
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TsrangeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TsrangeTest.php
@@ -20,6 +20,7 @@ class TsrangeTest extends TestCase
     {
         return [
             'SELECT tsrange(c0_.datetime1, c0_.datetime2) AS sclr_0 FROM ContainsDates c0_',
+            'SELECT tsrange(c0_.datetime1, c0_.datetime2, \'[)\') AS sclr_0 FROM ContainsDates c0_',
         ];
     }
 
@@ -27,6 +28,7 @@ class TsrangeTest extends TestCase
     {
         return [
             \sprintf('SELECT TSRANGE(e.datetime1, e.datetime2) FROM %s e', ContainsDates::class),
+            \sprintf('SELECT TSRANGE(e.datetime1, e.datetime2, \'[)\') FROM %s e', ContainsDates::class),
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TstzrangeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TstzrangeTest.php
@@ -20,6 +20,7 @@ class TstzrangeTest extends TestCase
     {
         return [
             'SELECT tstzrange(c0_.datetimetz1, c0_.datetimetz2) AS sclr_0 FROM ContainsDates c0_',
+            'SELECT tstzrange(c0_.datetimetz1, c0_.datetimetz2, \'[)\') AS sclr_0 FROM ContainsDates c0_',
         ];
     }
 
@@ -27,6 +28,7 @@ class TstzrangeTest extends TestCase
     {
         return [
             \sprintf('SELECT TSTZRANGE(e.datetimetz1, e.datetimetz2) FROM %s e', ContainsDates::class),
+            \sprintf('SELECT TSTZRANGE(e.datetimetz1, e.datetimetz2, \'[)\') FROM %s e', ContainsDates::class),
         ];
     }
 }


### PR DESCRIPTION
I'm really missing the ability to create a range with non-default bounds, so here is a PR that should add it.

See https://www.postgresql.org/docs/17/rangetypes.html#RANGETYPES-CONSTRUCT for PostgreSQL details.

TL;DR: We can now pass the third argument to the range functions. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to include details about supported PostgreSQL range functions and types.

- **New Features**
  - Enhanced support for PostgreSQL range functions, including arithmetic and date/time range types, with improved handling of optional range bounds.

- **Tests**
  - Expanded test coverage for all supported range functions to verify correct behavior with and without optional bounds parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->