### PR TITLE
fix(#351): remove invalid or non-PostgreSQL-compliant test cases; ensure edge cases for backslashes, quotes, special characters, and NULL handling are covered

### DIFF
--- a/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
@@ -142,6 +142,26 @@ class PostgresArrayToPHPArrayTransformerTest extends TestCase
                 'phpValue' => ['', ''],
                 'postgresValue' => '{"",""}',
             ],
+            'github #351 regression: string with special characters and backslash' => [
+                'phpValue' => ["!@#\\$%^&*()_+=-}{[]|\":;'\\?><,./"],
+                'postgresValue' => '{"!@#\$%^&*()_+=-}{[]|\":;\'\?><,./"}',
+            ],
+            'backslash before backslash' => [
+                'phpValue' => ['a\b'],
+                'postgresValue' => '{"a\\\b"}', // a\\b
+            ],
+            'single backslash before non-escape char' => [
+                'phpValue' => ['a\$b'],
+                'postgresValue' => '{"a\$b"}', // a\$b
+            ],
+            'element with curly braces and comma' => [
+                'phpValue' => ['{foo,bar}'],
+                'postgresValue' => '{"{foo,bar}"}',
+            ],
+            'element with whitespace' => [
+                'phpValue' => ['  foo  '],
+                'postgresValue' => '{"  foo  "}',
+            ],
         ];
     }
 
@@ -198,7 +218,7 @@ class PostgresArrayToPHPArrayTransformerTest extends TestCase
     public function can_transform_escaped_quotes_with_backslashes(): void
     {
         $postgresArray = '{"\\\"quoted\\\""}';
-        self::assertSame(['\\\"quoted\\\"'], PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray));
+        self::assertSame(['\"quoted\"'], PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray));
     }
 
     #[Test]


### PR DESCRIPTION
Aiming to address issue #351, here I fixed test cases and coverage for PostgreSQL array unescaping:
- Updated existing test expectations and added more scenarios to ensure compliance with [PostgreSQL’s documented array string literal parsing rules](https://www.postgresql.org/docs/18/arrays.html).
- Fixed cases where test expectations incorrectly assumed PHP-style escaping or Unicode handling.
- Attempted to address that edge cases for backslashes, quotes, and special characters are covered and match real PostgreSQL behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of escaped characters for more accurate transformation of Postgres arrays to PHP arrays.

- **Tests**
  - Expanded test coverage with additional cases for special characters, backslashes, and whitespace.
  - Updated expected output in a test to reflect improved unescaping logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->