### PR TITLE
chore: add devenv.sh development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+export DIRENV_WARN_TIMEOUT=20s
+
+eval "$(devenv direnvrc)"
+
+# The use_devenv function supports passing flags to the devenv command
+# For example: use devenv --impure --option services.postgres.enable:bool true
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,13 @@
 /var/
 /vendor/
 composer.lock
+
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,103 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1754597371,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "02729c6985a6a9ecd4bcb4ce1ab1ca80a229cfa2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754416808,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753719760,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "0f871fffdc0e5852ec25af99ea5f09ca7be9b632",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,185 @@
+{
+  pkgs,
+  lib,
+  config,
+  inputs,
+  ...
+}:
+
+{
+  name = "PostgreSQL for Doctrine";
+
+  # https://devenv.sh/basics/
+  env = {
+    POSTGRES_USER = "postgres";
+    POSTGRES_PASSWORD = "postgres";
+    POSTGRES_DB = "postgres_doctrine_test";
+    POSTGRES_PORT = 5432;
+  };
+
+  # https://devenv.sh/packages/
+  packages = with pkgs; [ git ];
+
+  # https://devenv.sh/languages/
+  languages.php = {
+    enable = true;
+    version = "8.1";
+    extensions = [
+      "dom"
+      # "xml"
+      "openssl"
+      "iconv"
+      "mbstring"
+      "filter"
+      "pdo_sqlite"
+      "pdo_pgsql"
+      "xdebug"
+      "xmlwriter"
+    ];
+    disableExtensions = [
+      "bcmath"
+      "calendar"
+      "json"
+      "ctype"
+      "curl"
+      "date"
+      "exif"
+      "fileinfo"
+      "ftp"
+      "gd"
+      "gettext"
+      "gmp"
+      "hash"
+      "imap"
+      "intl"
+      "ldap"
+      "libxml"
+      "mysqli"
+      "mysqlnd"
+      "pcntl"
+      "pcre"
+      "pdo_mysql"
+      "pdo_odbc"
+      "phar"
+      "posix"
+      "readline"
+      "reflection"
+      "session"
+      "simplexml"
+      "soap"
+      "sockets"
+      "sodium"
+      "spl"
+      "standard"
+      "sysvsem"
+      "xmlreader"
+      "opcache"
+      "zip"
+      "zlib"
+    ];
+
+    ini = lib.concatStringsSep "\n" [
+      "xdebug.mode = develop;"
+      "memory_limit = 256m;"
+    ];
+  };
+
+  # https://devenv.sh/processes/
+  # processes.cargo-watch.exec = "cargo-watch";
+
+  # https://devenv.sh/services/
+  services.postgres = {
+    enable = true;
+
+    listen_addresses = "127.0.0.1";
+    port = config.env.POSTGRES_PORT;
+
+    initialDatabases = [ { name = config.env.POSTGRES_DB; } ];
+
+    initialScript = ''
+      CREATE ROLE "${config.env.POSTGRES_USER}"
+        WITH SUPERUSER LOGIN PASSWORD '${config.env.POSTGRES_PASSWORD}';
+    '';
+  };
+
+  # https://devenv.sh/scripts/
+  scripts.php-modules.exec = ''
+    set -o 'errexit' -o 'pipefail'
+
+    echo 'Installed PHP modules'
+    echo '---------------------'
+
+    php -m |
+    command grep --invert-match --extended-regexp '^(|\[.*\])$' |
+    command tr '\n' ' ' |
+    command fold --spaces
+
+    printf '\n---------------------\n'
+  '';
+
+  enterShell = ''
+    git --version
+    composer  --version
+    php-modules
+    postgres --version
+    echo "Storage: ''${PGDATA}"
+    export PATH="${config.env.DEVENV_ROOT}/bin:$PATH"
+  '';
+
+  # https://devenv.sh/tasks/
+  # tasks = {
+  #   "myproj:setup".exec = "mytool build";
+  #   "devenv:enterShell".after = [ "myproj:setup" ];
+  # };
+
+  # https://devenv.sh/tests/
+  enterTest = ''
+    echo "Running tests"
+    git --version | grep --color=auto "${pkgs.git.version}"
+    php --version | grep --color=auto "${config.languages.php.package.version}"
+    composer check-code-style
+    composer run-static-analysis
+    composer run-all-tests
+  '';
+
+  # https://devenv.sh/git-hooks/
+  git-hooks.hooks = {
+    phpstan = rec {
+      enable = true;
+      name = "PHPStan";
+      inherit (config.languages.php) package;
+      pass_filenames = false;
+      entry = "${package}/bin/php '${config.env.DEVENV_ROOT}/bin/phpstan' 'analyse'";
+      args = [ "--configuration=${config.env.DEVENV_ROOT}/ci/phpstan/config.neon" ];
+    };
+
+    php-cs-fixer = rec {
+      enable = true;
+      name = "PHP Coding Standards Fixer";
+      inherit (config.languages.php) package;
+      files = ".*\.php$";
+      entry = "${package}/bin/php '${config.env.DEVENV_ROOT}/bin/php-cs-fixer' 'fix'";
+      args = [
+        "--dry-run"
+        "--config=${config.env.DEVENV_ROOT}/ci/php-cs-fixer/config.php"
+        "--show-progress=none"
+        "--no-interaction"
+      ];
+    };
+
+    rector = rec {
+      enable = true;
+      name = "Rector";
+      inherit (config.languages.php) package;
+      files = ".*\.php$";
+      pass_filenames = false;
+      entry = "${package}/bin/php '${config.env.DEVENV_ROOT}/bin/rector' 'process'";
+      args = [
+        "--dry-run"
+        "--config=${config.env.DEVENV_ROOT}/ci/rector/config.php"
+      ];
+    };
+  };
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+
+# If you're using non-OSS software, you can set allowUnfree to true.
+# allowUnfree: true
+
+# If you're willing to use a package that's vulnerable
+# permittedInsecurePackages:
+#  - "openssl-1.1.1w"
+
+# If you have more than one devenv you can merge them
+#imports:
+# - ./backend


### PR DESCRIPTION
add [devenv.sh](https://devenv.sh/) Nix-based development environment with:

- PHP 8.1 with the least possible enabled extensions.
- PostgreSQL server (not in a Docker container).
- [pre-commit](https://pre-commit.com/) commit hooks for PHP-CS-Fixer, PHPStan, and Rector.

This merge request aims to provide a standardized PHP 8.1 development environment for contributors.
It can help creating a dev container for this project.