### PR TITLE
chore: remove `setAccessible` reflection method calls, that do nothing in test

### DIFF
--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionTestCase.php
@@ -37,7 +37,6 @@ abstract class BaseVariadicFunctionTestCase extends TestCase
         $baseVariadicFunction = $this->createFixture();
 
         $reflectionMethod = new \ReflectionMethod($baseVariadicFunction::class, 'feedParserWithNodesForNodeMappingPattern');
-        $reflectionMethod->setAccessible(true);
         $reflectionMethod->invoke($baseVariadicFunction, $parser, 'ArithmeticPrimary');
     }
 
@@ -68,7 +67,6 @@ abstract class BaseVariadicFunctionTestCase extends TestCase
         $this->expectException(InvalidArgumentForVariadicFunctionException::class);
         $reflectionClass = new \ReflectionClass($function);
         $reflectionMethod = $reflectionClass->getMethod('validateArguments');
-        $reflectionMethod->setAccessible(true);
 
         $node = $this->createMock(Node::class);
         $reflectionMethod->invoke($function, $node); // 1 argument when min 2 are required
@@ -101,7 +99,6 @@ abstract class BaseVariadicFunctionTestCase extends TestCase
         $this->expectException(InvalidArgumentForVariadicFunctionException::class);
         $reflectionClass = new \ReflectionClass($function);
         $reflectionMethod = $reflectionClass->getMethod('validateArguments');
-        $reflectionMethod->setAccessible(true);
 
         $node = $this->createMock(Node::class);
         $reflectionMethod->invoke($function, $node, $node, $node); // 3 arguments when max 2 are required


### PR DESCRIPTION

Since PHP 8.1, `setAccessible()` reflection methods have no effect. The CI fails on `rector` `RemoveReflectionSetAccessibleCallsRector` rule.

This pull request remove the `setAccessible()`  calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined unit tests by removing redundant reflective access overrides and simplifying invocation flow, reducing brittleness and improving maintainability.
  * Clarified test intent without altering production behavior.
  * No changes to public APIs or user-facing functionality; existing features remain unaffected.
  * Improves the resilience of the test suite against future refactors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->