### PR TITLE
feat(#305): add support for PostGIS operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,16 @@ This package provides comprehensive Doctrine support for PostgreSQL features:
 - **Range Operations**
   - Containment checks (in PHP value objects and for DQL queries with `@>` and `<@`)
   - Overlaps (`&&`)
+- **PostGIS Spatial Operations**
+  - Bounding box relationships (`<<`, `>>`, `&<`, `&>`, `|&>`, `&<|`, `<<|`, `|>>`)
+  - Spatial containment (`@`, `~`)
+  - Distance calculations (`<->`, `<#>`, `<<->>`, `<<#>>`, `|=|`)
+  - N-dimensional operations (`&&&`)
 
 ### Functions
 - **Text Search**
   - Full text search (`to_tsvector`, `to_tsquery`)
-  - Pattern matching (`ILIKE`, `SIMILAR TO`)
+  - Pattern matching (`ilike`, `similar to`)
   - Regular expressions
 - **Array Functions**
   - Array aggregation (`array_agg`)

--- a/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsGeometries.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsGeometries.php
@@ -11,14 +11,14 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\WktSpatialData;
 class ContainsGeometries extends Entity
 {
     #[ORM\Column(type: 'geometry')]
-    public ?WktSpatialData $geometry1 = null;
+    public WktSpatialData $geometry1;
 
     #[ORM\Column(type: 'geometry')]
-    public ?WktSpatialData $geometry2 = null;
+    public WktSpatialData $geometry2;
 
     #[ORM\Column(type: 'geography')]
-    public ?WktSpatialData $geography1 = null;
+    public WktSpatialData $geography1;
 
     #[ORM\Column(type: 'geography')]
-    public ?WktSpatialData $geography2 = null;
+    public WktSpatialData $geography2;
 }

--- a/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsGeometries.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Entity/ContainsGeometries.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\MartinGeorgiev\Doctrine\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\WktSpatialData;
+
+#[ORM\Entity()]
+class ContainsGeometries extends Entity
+{
+    #[ORM\Column(type: 'geometry')]
+    public ?WktSpatialData $geometry1 = null;
+
+    #[ORM\Column(type: 'geometry')]
+    public ?WktSpatialData $geometry2 = null;
+
+    #[ORM\Column(type: 'geography')]
+    public ?WktSpatialData $geography1 = null;
+
+    #[ORM\Column(type: 'geography')]
+    public ?WktSpatialData $geography2 = null;
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BoundingBoxDistance.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BoundingBoxDistance.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS 2D bounding box distance operator (using <#>).
+ *
+ * Returns the 2D distance between A and B bounding boxes.
+ * This is useful for index-based distance queries.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Distance
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT BOUNDING_BOX_DISTANCE(g1.geometry, g2.geometry) FROM Entity g1, Entity g2"
+ * Returns numeric distance value.
+ */
+class BoundingBoxDistance extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s <#> %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistance.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistance.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS 2D distance between geometries operator (using <->).
+ *
+ * Returns the 2D distance between A and B geometries.
+ * This is different from the existing Distance class which uses <@> for point distance.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Distance
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT GEOMETRY_DISTANCE(g1.geometry, g2.geometry) FROM Entity g1, Entity g2"
+ * Returns numeric distance value.
+ */
+class GeometryDistance extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s <-> %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistance.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistance.php
@@ -8,9 +8,13 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
  * Implementation of PostGIS 2D distance between geometries operator (using <->).
  *
  * Returns the 2D distance between A and B geometries.
- * This is different from the existing Distance class which uses <@> for point distance.
+ * This differs from BoundingBoxDistance (using <#>), which measures distance between
+ * bounding boxes only. The <-> operator is commonly used for KNN nearest-neighbor
+ * ordering, and on PostgreSQL 9.5+ with PostGIS 2.2+ it returns true geometry distance;
+ * on older stacks it behaved as a centroid-of-bounding-box distance approximation.
  *
- * @see https://postgis.net/docs/reference.html#Operators_Distance
+ * @see https://postgis.net/docs/reference.html#Operators
+ * @see https://postgis.net/docs/geometry_distance_knn.html
  * @since 3.5
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalBoundingBoxDistance.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalBoundingBoxDistance.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS n-D bounding box distance operator (using <<#>>).
+ *
+ * Returns the n-D distance between A and B bounding boxes.
+ * This operator works with multi-dimensional geometries.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Distance
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ND_BOUNDING_BOX_DISTANCE(g1.geometry, g2.geometry) FROM Entity g1, Entity g2"
+ * Returns numeric distance value.
+ */
+class NDimensionalBoundingBoxDistance extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s <<#>> %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalCentroidDistance.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalCentroidDistance.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS n-D centroid distance operator (using <<->>).
+ *
+ * Returns the n-D distance between the centroids of A and B bounding boxes.
+ * This operator works with multi-dimensional geometries.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Distance
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ND_CENTROID_DISTANCE(g1.geometry, g2.geometry) FROM Entity g1, Entity g2"
+ * Returns numeric distance value.
+ */
+class NDimensionalCentroidDistance extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s <<->> %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalOverlaps.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalOverlaps.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS n-dimensional bounding box intersects operator (using &&&).
+ *
+ * Returns TRUE if A's n-D bounding box intersects B's n-D bounding box.
+ * This operator works with 3D and higher dimensional geometries.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE ND_OVERLAPS(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class NDimensionalOverlaps extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s &&& %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsAbove.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsAbove.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS bounding box overlaps or is above operator (using |&>).
+ *
+ * Returns TRUE if A's bounding box overlaps or is above B's.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE OVERLAPS_ABOVE(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class OverlapsAbove extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s |&> %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsBelow.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsBelow.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS bounding box overlaps or is below operator (using &<|).
+ *
+ * Returns TRUE if A's bounding box overlaps or is below B's.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE OVERLAPS_BELOW(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class OverlapsBelow extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s &<| %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsLeft.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsLeft.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS bounding box overlaps or is to the left operator (using &<).
+ *
+ * Returns TRUE if A's bounding box overlaps or is to the left of B's.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE OVERLAPS_LEFT(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class OverlapsLeft extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s &< %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsRight.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsRight.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS bounding box overlaps or is to the right operator (using &>).
+ *
+ * Returns TRUE if A's bounding box overlaps or is to the right of B's.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE OVERLAPS_RIGHT(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class OverlapsRight extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s &> %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainedBy.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainedBy.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS spatial bounding box contained by operator (using @).
+ *
+ * Returns TRUE if A's bounding box is contained by B's.
+ * This is the spatial version of the @ operator, distinct from the array/JSON version.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE SPATIAL_CONTAINED_BY(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class SpatialContainedBy extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s @ %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContains.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContains.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS spatial bounding box contains operator (using ~).
+ *
+ * Returns TRUE if A's bounding box contains B's.
+ * This is the spatial version of the ~ operator, distinct from the array/JSON version.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE SPATIAL_CONTAINS(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class SpatialContains extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s ~ %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialSame.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialSame.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS bounding box same as operator (using ~=).
+ *
+ * Returns TRUE if A's bounding box is the same as B's.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE SPATIAL_SAME(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class SpatialSame extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s ~= %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyAbove.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyAbove.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS bounding box strictly above operator (using |>>).
+ *
+ * Returns TRUE if A's bounding box is strictly above B's.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE STRICTLY_ABOVE(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class StrictlyAbove extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s |>> %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyBelow.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyBelow.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS bounding box strictly below operator (using <<|).
+ *
+ * Returns TRUE if A's bounding box is strictly below B's.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE STRICTLY_BELOW(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class StrictlyBelow extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s <<| %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyLeft.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyLeft.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS bounding box strictly to the left operator (using <<).
+ *
+ * Returns TRUE if A's bounding box is strictly to the left of B's.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE STRICTLY_LEFT(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class StrictlyLeft extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s << %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRight.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRight.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS bounding box strictly to the right operator (using >>).
+ *
+ * Returns TRUE if A's bounding box is strictly to the right of B's.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Geometry
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE STRICTLY_RIGHT(g1.geometry, g2.geometry) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" in DQL.
+ */
+class StrictlyRight extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s >> %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TrajectoryDistance.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TrajectoryDistance.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostGIS trajectory distance operator (using |=|).
+ *
+ * Returns the distance between A and B trajectories at their closest point of approach.
+ * Trajectories are linear geometries with increasing measures (M value) on each coordinate.
+ *
+ * @see https://postgis.net/docs/reference.html#Operators_Distance
+ * @since 3.5
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT TRAJECTORY_DISTANCE(t1.trajectory, t2.trajectory) FROM Entity t1, Entity t2"
+ * Returns numeric distance value.
+ */
+class TrajectoryDistance extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('(%s |=| %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BoundingBoxDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BoundingBoxDistanceTest.php
@@ -17,45 +17,41 @@ class BoundingBoxDistanceTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function bounding_box_distance_returns_zero_for_identical_geometries(): void
+    public function returns_zero_when_comparing_identical_point_geometries(): void
     {
-        // Identical geometries have zero bounding box distance
         $dql = "SELECT BOUNDING_BOX_DISTANCE('POINT(1 1)', 'POINT(1 1)') as distance
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['distance'], 'Bounding box distance for identical geometries should be 0');
+        $this->assertEquals(0, $result[0]['distance']);
     }
 
     #[Test]
-    public function bounding_box_distance_returns_zero_for_overlapping_bounding_boxes(): void
+    public function returns_zero_when_polygon_bounding_boxes_overlap(): void
     {
-        // Overlapping polygons have zero bounding box distance
         $dql = "SELECT BOUNDING_BOX_DISTANCE('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))', 'POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))') as distance
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['distance'], 'Overlapping bounding boxes should have distance 0');
+        $this->assertEquals(0, $result[0]['distance']);
     }
 
     #[Test]
-    public function bounding_box_distance_returns_correct_distance_for_separated_geometries(): void
+    public function can_calculate_euclidean_distance_between_separated_points(): void
     {
-        // Distance between separated points
         $dql = "SELECT BOUNDING_BOX_DISTANCE('POINT(0 0)', 'POINT(3 4)') as distance
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(5.0, $result[0]['distance'], 'Bounding box distance between (0,0) and (3,4) should be 5');
+        $this->assertEquals(5.0, $result[0]['distance']);
     }
 
     #[Test]
-    public function bounding_box_distance_with_separated_polygons(): void
+    public function can_calculate_distance_between_non_overlapping_polygons(): void
     {
-        // Distance between non-overlapping polygons
         $dql = "SELECT BOUNDING_BOX_DISTANCE('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))', 'POLYGON((3 3, 4 3, 4 4, 3 4, 3 3))') as distance
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1";
@@ -63,7 +59,6 @@ class BoundingBoxDistanceTest extends SpatialOperatorTestCase
         $result = $this->executeDqlQuery($dql);
         $this->assertIsNumeric($result[0]['distance']);
         $this->assertGreaterThan(0, $result[0]['distance']);
-        // Distance should be approximately sqrt((3-1)² + (3-1)²) = sqrt(8) ≈ 2.83
-        $this->assertEqualsWithDelta(2.83, $result[0]['distance'], 0.1, 'Distance between separated polygons');
+        $this->assertEqualsWithDelta(2.83, $result[0]['distance'], 0.1, 'Distance should be approximately sqrt((3-1)² + (3-1)²) = sqrt(8) ≈ 2.83 between separated polygon bounding boxes');
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BoundingBoxDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BoundingBoxDistanceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BoundingBoxDistance;
+use PHPUnit\Framework\Attributes\Test;
+
+class BoundingBoxDistanceTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'BOUNDING_BOX_DISTANCE' => BoundingBoxDistance::class,
+        ];
+    }
+
+    #[Test]
+    public function bounding_box_distance_returns_zero_for_identical_geometries(): void
+    {
+        // Identical geometries have zero bounding box distance
+        $dql = "SELECT BOUNDING_BOX_DISTANCE('POINT(1 1)', 'POINT(1 1)') as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(0, $result[0]['distance'], 'Bounding box distance for identical geometries should be 0');
+    }
+
+    #[Test]
+    public function bounding_box_distance_returns_zero_for_overlapping_bounding_boxes(): void
+    {
+        // Overlapping polygons have zero bounding box distance
+        $dql = "SELECT BOUNDING_BOX_DISTANCE('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))', 'POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))') as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(0, $result[0]['distance'], 'Overlapping bounding boxes should have distance 0');
+    }
+
+    #[Test]
+    public function bounding_box_distance_returns_correct_distance_for_separated_geometries(): void
+    {
+        // Distance between separated points
+        $dql = "SELECT BOUNDING_BOX_DISTANCE('POINT(0 0)', 'POINT(3 4)') as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(5.0, $result[0]['distance'], 'Bounding box distance between (0,0) and (3,4) should be 5');
+    }
+
+    #[Test]
+    public function bounding_box_distance_with_separated_polygons(): void
+    {
+        // Distance between non-overlapping polygons
+        $dql = "SELECT BOUNDING_BOX_DISTANCE('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))', 'POLYGON((3 3, 4 3, 4 4, 3 4, 3 3))') as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsNumeric($result[0]['distance']);
+        $this->assertGreaterThan(0, $result[0]['distance']);
+        // Distance should be approximately sqrt((3-1)² + (3-1)²) = sqrt(8) ≈ 2.83
+        $this->assertEqualsWithDelta(2.83, $result[0]['distance'], 0.1, 'Distance between separated polygons');
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ExpTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ExpTest.php
@@ -17,7 +17,7 @@ class ExpTest extends NumericTestCase
     }
 
     #[Test]
-    public function exp(): void
+    public function can_calculate_exponential_of_one_to_euler_constant(): void
     {
         $dql = 'SELECT EXP(1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
@@ -25,7 +25,7 @@ class ExpTest extends NumericTestCase
     }
 
     #[Test]
-    public function exp_with_entity_property(): void
+    public function can_calculate_exponential_of_entity_decimal_value(): void
     {
         $dql = 'SELECT EXP(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistanceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\GeometryDistance;
+use PHPUnit\Framework\Attributes\Test;
+
+class GeometryDistanceTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'GEOMETRY_DISTANCE' => GeometryDistance::class,
+        ];
+    }
+
+    #[Test]
+    public function geometry_distance_returns_correct_distance_between_test_points(): void
+    {
+        // Distance between POINT(0 0) and POINT(1 1) from test data
+        $dql = 'SELECT GEOMETRY_DISTANCE(g.geometry1, g.geometry2) as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsNumeric($result[0]['distance']);
+        $this->assertGreaterThan(0, $result[0]['distance']);
+        // Distance between (0,0) and (1,1) should be sqrt(2) ≈ 1.414
+        $this->assertEqualsWithDelta(1.414, $result[0]['distance'], 0.01, 'Distance between (0,0) and (1,1)');
+    }
+
+    #[Test]
+    public function geometry_distance_returns_zero_for_identical_geometries(): void
+    {
+        // Identical geometries should have zero distance
+        $dql = 'SELECT GEOMETRY_DISTANCE(g.geometry1, g.geometry1) as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(0, $result[0]['distance'], 'Distance between identical geometries should be 0');
+    }
+
+    #[Test]
+    public function geometry_distance_with_horizontal_points(): void
+    {
+        // Distance between POINT(0 0) and POINT(5 0) should be 5
+        $dql = "SELECT GEOMETRY_DISTANCE('POINT(0 0)', 'POINT(5 0)') as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(5.0, $result[0]['distance'], 'Horizontal distance should be 5');
+    }
+
+    #[Test]
+    public function geometry_distance_with_vertical_points(): void
+    {
+        // Distance between POINT(0 0) and POINT(0 3) should be 3
+        $dql = "SELECT GEOMETRY_DISTANCE('POINT(0 0)', 'POINT(0 3)') as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(3.0, $result[0]['distance'], 'Vertical distance should be 3');
+    }
+
+    #[Test]
+    public function geometry_distance_with_geography_types(): void
+    {
+        // Geography types should return distance in meters
+        $dql = 'SELECT GEOMETRY_DISTANCE(g.geography1, g.geography2) as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsNumeric($result[0]['distance']);
+        $this->assertGreaterThan(1000000, $result[0]['distance']); // Lisbon to London is > 1M meters
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistanceTest.php
@@ -19,7 +19,6 @@ class GeometryDistanceTest extends SpatialOperatorTestCase
     #[Test]
     public function geometry_distance_returns_correct_distance_between_test_points(): void
     {
-        // Distance between POINT(0 0) and POINT(1 1) from test data
         $dql = 'SELECT GEOMETRY_DISTANCE(g.geometry1, g.geometry2) as distance
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
@@ -34,37 +33,12 @@ class GeometryDistanceTest extends SpatialOperatorTestCase
     #[Test]
     public function geometry_distance_returns_zero_for_identical_geometries(): void
     {
-        // Identical geometries should have zero distance
         $dql = 'SELECT GEOMETRY_DISTANCE(g.geometry1, g.geometry1) as distance
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
         $this->assertEquals(0, $result[0]['distance'], 'Distance between identical geometries should be 0');
-    }
-
-    #[Test]
-    public function geometry_distance_with_horizontal_points(): void
-    {
-        // Distance between POINT(0 0) and POINT(5 0) should be 5
-        $dql = "SELECT GEOMETRY_DISTANCE('POINT(0 0)', 'POINT(5 0)') as distance
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
-                WHERE g.id = 1";
-
-        $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(5.0, $result[0]['distance'], 'Horizontal distance should be 5');
-    }
-
-    #[Test]
-    public function geometry_distance_with_vertical_points(): void
-    {
-        // Distance between POINT(0 0) and POINT(0 3) should be 3
-        $dql = "SELECT GEOMETRY_DISTANCE('POINT(0 0)', 'POINT(0 3)') as distance
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
-                WHERE g.id = 1";
-
-        $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(3.0, $result[0]['distance'], 'Vertical distance should be 3');
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistanceTest.php
@@ -17,7 +17,7 @@ class GeometryDistanceTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function geometry_distance_returns_correct_distance_between_test_points(): void
+    public function geometry_distance_with_geometrical_types(): void
     {
         $dql = 'SELECT GEOMETRY_DISTANCE(g.geometry1, g.geometry2) as distance
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
@@ -26,8 +26,7 @@ class GeometryDistanceTest extends SpatialOperatorTestCase
         $result = $this->executeDqlQuery($dql);
         $this->assertIsNumeric($result[0]['distance']);
         $this->assertGreaterThan(0, $result[0]['distance']);
-        // Distance between (0,0) and (1,1) should be sqrt(2) ≈ 1.414
-        $this->assertEqualsWithDelta(1.414, $result[0]['distance'], 0.01, 'Distance between (0,0) and (1,1)');
+        $this->assertEqualsWithDelta(1.414, $result[0]['distance'], 0.01, 'Distance between (0,0) and (1,1) should be sqrt(2) ≈ 1.414');
     }
 
     #[Test]
@@ -42,15 +41,14 @@ class GeometryDistanceTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function geometry_distance_with_geography_types(): void
+    public function geometry_distance_with_geographical_types(): void
     {
-        // Geography types should return distance in meters
         $dql = 'SELECT GEOMETRY_DISTANCE(g.geography1, g.geography2) as distance
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
         $this->assertIsNumeric($result[0]['distance']);
-        $this->assertGreaterThan(1000000, $result[0]['distance']); // Lisbon to London is > 1M meters
+        $this->assertGreaterThan(1000000, $result[0]['distance'], 'Lisbon to London is > 1M meters');
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistanceTest.php
@@ -17,7 +17,7 @@ class GeometryDistanceTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function geometry_distance_with_geometrical_types(): void
+    public function can_calculate_euclidean_distance_between_geometric_points(): void
     {
         $dql = 'SELECT GEOMETRY_DISTANCE(g.geometry1, g.geometry2) as distance
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
@@ -26,22 +26,22 @@ class GeometryDistanceTest extends SpatialOperatorTestCase
         $result = $this->executeDqlQuery($dql);
         $this->assertIsNumeric($result[0]['distance']);
         $this->assertGreaterThan(0, $result[0]['distance']);
-        $this->assertEqualsWithDelta(1.414, $result[0]['distance'], 0.01, 'Distance between (0,0) and (1,1) should be sqrt(2) ≈ 1.414');
+        $this->assertEqualsWithDelta(1.414, $result[0]['distance'], 0.01, 'Euclidean distance between points (0,0) and (1,1) should be sqrt(2) ≈ 1.414');
     }
 
     #[Test]
-    public function geometry_distance_returns_zero_for_identical_geometries(): void
+    public function returns_zero_when_comparing_identical_geometries(): void
     {
         $dql = 'SELECT GEOMETRY_DISTANCE(g.geometry1, g.geometry1) as distance
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['distance'], 'Distance between identical geometries should be 0');
+        $this->assertEquals(0, $result[0]['distance']);
     }
 
     #[Test]
-    public function geometry_distance_with_geographical_types(): void
+    public function can_calculate_spherical_distance_between_geographical_coordinates(): void
     {
         $dql = 'SELECT GEOMETRY_DISTANCE(g.geography1, g.geography2) as distance
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
@@ -49,6 +49,6 @@ class GeometryDistanceTest extends SpatialOperatorTestCase
 
         $result = $this->executeDqlQuery($dql);
         $this->assertIsNumeric($result[0]['distance']);
-        $this->assertGreaterThan(1000000, $result[0]['distance'], 'Lisbon to London is > 1M meters');
+        $this->assertGreaterThan(1000000, $result[0]['distance'], 'Spherical distance between Lisbon and London geographical coordinates should be greater than 1 million meters');
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LnTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LnTest.php
@@ -17,7 +17,7 @@ class LnTest extends NumericTestCase
     }
 
     #[Test]
-    public function ln(): void
+    public function can_calculate_natural_logarithm_of_euler_constant(): void
     {
         $dql = 'SELECT LN(2.718281828459) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
@@ -25,7 +25,7 @@ class LnTest extends NumericTestCase
     }
 
     #[Test]
-    public function ln_with_entity_property(): void
+    public function can_calculate_natural_logarithm_of_entity_decimal_value(): void
     {
         $dql = 'SELECT LN(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LogTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LogTest.php
@@ -17,7 +17,7 @@ class LogTest extends NumericTestCase
     }
 
     #[Test]
-    public function log(): void
+    public function can_calculate_base_ten_logarithm_of_hundred(): void
     {
         $dql = 'SELECT LOG(10, 100) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
@@ -25,7 +25,7 @@ class LogTest extends NumericTestCase
     }
 
     #[Test]
-    public function log_with_entity_property(): void
+    public function can_calculate_base_ten_logarithm_of_entity_decimal_value(): void
     {
         $dql = 'SELECT LOG(10, n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalCentroidDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalCentroidDistanceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\NDimensionalCentroidDistance;
+use PHPUnit\Framework\Attributes\Test;
+
+class NDimensionalCentroidDistanceTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ND_CENTROID_DISTANCE' => NDimensionalCentroidDistance::class,
+        ];
+    }
+
+    #[Test]
+    public function nd_centroid_distance_with_geometries(): void
+    {
+        $dql = 'SELECT ND_CENTROID_DISTANCE(g.geometry1, g.geometry2) as distance 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsNumeric($result[0]['distance']);
+        $this->assertGreaterThan(0, $result[0]['distance']);
+    }
+
+    #[Test]
+    public function nd_centroid_distance_with_literal_geometry(): void
+    {
+        $dql = "SELECT ND_CENTROID_DISTANCE(g.geometry1, 'POINT(3 3)') as distance 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsNumeric($result[0]['distance']);
+        $this->assertGreaterThan(0, $result[0]['distance']);
+    }
+
+    #[Test]
+    public function nd_centroid_distance_with_identical_geometries(): void
+    {
+        $dql = 'SELECT ND_CENTROID_DISTANCE(g.geometry1, g.geometry1) as distance 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(0, $result[0]['distance']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalCentroidDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalCentroidDistanceTest.php
@@ -17,10 +17,10 @@ class NDimensionalCentroidDistanceTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function nd_centroid_distance_with_geometries(): void
+    public function can_calculate_distance_between_geometry_centroids(): void
     {
-        $dql = 'SELECT ND_CENTROID_DISTANCE(g.geometry1, g.geometry2) as distance 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = 'SELECT ND_CENTROID_DISTANCE(g.geometry1, g.geometry2) as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
@@ -29,10 +29,10 @@ class NDimensionalCentroidDistanceTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function nd_centroid_distance_with_literal_geometry(): void
+    public function can_calculate_distance_between_geometry_and_literal_point(): void
     {
-        $dql = "SELECT ND_CENTROID_DISTANCE(g.geometry1, 'POINT(3 3)') as distance 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = "SELECT ND_CENTROID_DISTANCE(g.geometry1, 'POINT(3 3)') as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
@@ -41,10 +41,10 @@ class NDimensionalCentroidDistanceTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function nd_centroid_distance_with_identical_geometries(): void
+    public function returns_zero_when_comparing_identical_geometries(): void
     {
-        $dql = 'SELECT ND_CENTROID_DISTANCE(g.geometry1, g.geometry1) as distance 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = 'SELECT ND_CENTROID_DISTANCE(g.geometry1, g.geometry1) as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalOverlapsTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalOverlapsTest.php
@@ -17,21 +17,21 @@ class NDimensionalOverlapsTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function nd_overlaps_with_2d_geometries(): void
+    public function returns_true_when_2d_polygons_have_overlapping_bounding_boxes(): void
     {
-        $dql = 'SELECT ND_OVERLAPS(g.geometry1, g.geometry2) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = 'SELECT ND_OVERLAPS(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'Overlapping polygons should return true for n-dimensional overlaps');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
-    public function nd_overlaps_with_identical_geometries(): void
+    public function returns_true_when_comparing_identical_geometries(): void
     {
-        $dql = 'SELECT ND_OVERLAPS(g.geometry1, g.geometry1) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = 'SELECT ND_OVERLAPS(g.geometry1, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalOverlapsTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalOverlapsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\NDimensionalOverlaps;
+use PHPUnit\Framework\Attributes\Test;
+
+class NDimensionalOverlapsTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ND_OVERLAPS' => NDimensionalOverlaps::class,
+        ];
+    }
+
+    #[Test]
+    public function nd_overlaps_with_2d_geometries(): void
+    {
+        $dql = 'SELECT ND_OVERLAPS(g.geometry1, g.geometry2) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result'], 'Overlapping polygons should return true for n-dimensional overlaps');
+    }
+
+    #[Test]
+    public function nd_overlaps_with_identical_geometries(): void
+    {
+        $dql = 'SELECT ND_OVERLAPS(g.geometry1, g.geometry1) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsAboveTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsAboveTest.php
@@ -17,35 +17,35 @@ class OverlapsAboveTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function overlaps_above_with_geometries(): void
+    public function returns_false_when_polygons_are_at_same_vertical_level(): void
     {
-        $dql = 'SELECT OVERLAPS_ABOVE(g.geometry1, g.geometry2) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = 'SELECT OVERLAPS_ABOVE(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'Overlapping polygons may not be considered above each other');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
-    public function overlaps_above_with_literal_geometry(): void
+    public function returns_true_when_geometry_is_positioned_above_literal_point(): void
     {
-        $dql = "SELECT OVERLAPS_ABOVE(g.geometry1, 'POINT(0 -1)') as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = "SELECT OVERLAPS_ABOVE(g.geometry1, 'POINT(0 -1)') as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'Overlapping or above geometries should return true');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
-    public function overlaps_above_with_polygons(): void
+    public function returns_true_when_second_polygon_overlaps_or_is_above_first(): void
     {
-        $dql = 'SELECT OVERLAPS_ABOVE(g.geometry2, g.geometry1) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = 'SELECT OVERLAPS_ABOVE(g.geometry2, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'Overlapping or above geometries should return true');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsAboveTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsAboveTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\OverlapsAbove;
+use PHPUnit\Framework\Attributes\Test;
+
+class OverlapsAboveTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'OVERLAPS_ABOVE' => OverlapsAbove::class,
+        ];
+    }
+
+    #[Test]
+    public function overlaps_above_with_geometries(): void
+    {
+        $dql = 'SELECT OVERLAPS_ABOVE(g.geometry1, g.geometry2) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result'], 'Overlapping polygons may not be considered above each other');
+    }
+
+    #[Test]
+    public function overlaps_above_with_literal_geometry(): void
+    {
+        $dql = "SELECT OVERLAPS_ABOVE(g.geometry1, 'POINT(0 -1)') as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result'], 'Overlapping or above geometries should return true');
+    }
+
+    #[Test]
+    public function overlaps_above_with_polygons(): void
+    {
+        $dql = 'SELECT OVERLAPS_ABOVE(g.geometry2, g.geometry1) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result'], 'Overlapping or above geometries should return true');
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsBelowTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsBelowTest.php
@@ -17,35 +17,35 @@ class OverlapsBelowTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function overlaps_below_with_geometries(): void
+    public function returns_true_when_first_polygon_overlaps_or_is_below_second(): void
     {
-        $dql = 'SELECT OVERLAPS_BELOW(g.geometry1, g.geometry2) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = 'SELECT OVERLAPS_BELOW(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'Overlapping or below geometries should return true');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
-    public function overlaps_below_with_literal_geometry(): void
+    public function returns_true_when_geometry_is_positioned_below_literal_point(): void
     {
-        $dql = "SELECT OVERLAPS_BELOW(g.geometry1, 'POINT(0 2)') as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = "SELECT OVERLAPS_BELOW(g.geometry1, 'POINT(0 2)') as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'Overlapping or below geometries should return true');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
-    public function overlaps_below_with_polygons(): void
+    public function returns_true_when_comparing_overlapping_polygons(): void
     {
-        $dql = 'SELECT OVERLAPS_BELOW(g.geometry1, g.geometry2) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = 'SELECT OVERLAPS_BELOW(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'Overlapping or below geometries should return true');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsBelowTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsBelowTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\OverlapsBelow;
+use PHPUnit\Framework\Attributes\Test;
+
+class OverlapsBelowTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'OVERLAPS_BELOW' => OverlapsBelow::class,
+        ];
+    }
+
+    #[Test]
+    public function overlaps_below_with_geometries(): void
+    {
+        $dql = 'SELECT OVERLAPS_BELOW(g.geometry1, g.geometry2) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result'], 'Overlapping or below geometries should return true');
+    }
+
+    #[Test]
+    public function overlaps_below_with_literal_geometry(): void
+    {
+        $dql = "SELECT OVERLAPS_BELOW(g.geometry1, 'POINT(0 2)') as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result'], 'Overlapping or below geometries should return true');
+    }
+
+    #[Test]
+    public function overlaps_below_with_polygons(): void
+    {
+        $dql = 'SELECT OVERLAPS_BELOW(g.geometry1, g.geometry2) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result'], 'Overlapping or below geometries should return true');
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsLeftTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsLeftTest.php
@@ -17,46 +17,46 @@ class OverlapsLeftTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function overlaps_left_with_test_data(): void
+    public function returns_true_when_first_point_is_positioned_left_of_second(): void
     {
         $dql = 'SELECT OVERLAPS_LEFT(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'POINT(0 0) should overlap or be to the left of POINT(1 1)');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
-    public function overlaps_left_with_reversed_geometries(): void
+    public function returns_false_when_geometry_positions_are_reversed(): void
     {
         $dql = 'SELECT OVERLAPS_LEFT(g.geometry2, g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'POINT(1 1) should NOT be to the left of POINT(0 0)');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
-    public function overlaps_left_with_overlapping_polygons(): void
+    public function returns_true_when_first_polygon_overlaps_or_is_left_of_second(): void
     {
         $dql = 'SELECT OVERLAPS_LEFT(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'First polygon should overlap or be to the left of second polygon');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
-    public function overlaps_left_with_identical_geometries(): void
+    public function returns_true_when_comparing_identical_geometries(): void
     {
         $dql = 'SELECT OVERLAPS_LEFT(g.geometry1, g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'Identical geometries should overlap');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsLeftTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsLeftTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\OverlapsLeft;
+use PHPUnit\Framework\Attributes\Test;
+
+class OverlapsLeftTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'OVERLAPS_LEFT' => OverlapsLeft::class,
+        ];
+    }
+
+    #[Test]
+    public function overlaps_left_with_test_data(): void
+    {
+        $dql = 'SELECT OVERLAPS_LEFT(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result'], 'POINT(0 0) should overlap or be to the left of POINT(1 1)');
+    }
+
+    #[Test]
+    public function overlaps_left_with_reversed_geometries(): void
+    {
+        $dql = 'SELECT OVERLAPS_LEFT(g.geometry2, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result'], 'POINT(1 1) should NOT be to the left of POINT(0 0)');
+    }
+
+    #[Test]
+    public function overlaps_left_with_overlapping_polygons(): void
+    {
+        $dql = 'SELECT OVERLAPS_LEFT(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result'], 'First polygon should overlap or be to the left of second polygon');
+    }
+
+    #[Test]
+    public function overlaps_left_with_identical_geometries(): void
+    {
+        $dql = 'SELECT OVERLAPS_LEFT(g.geometry1, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result'], 'Identical geometries should overlap');
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsRightTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsRightTest.php
@@ -17,46 +17,46 @@ class OverlapsRightTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function overlaps_right_returns_false_when_left_geometry_is_to_the_left(): void
+    public function returns_false_when_left_geometry_is_to_the_left(): void
     {
         $dql = 'SELECT OVERLAPS_RIGHT(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'POINT(0 0) should NOT overlap or be to the right of POINT(1 1)');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
-    public function overlaps_right_returns_true_when_geometries_are_reversed(): void
+    public function returns_true_when_second_point_is_positioned_right_of_first(): void
     {
         $dql = 'SELECT OVERLAPS_RIGHT(g.geometry2, g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'POINT(1 1) should overlap or be to the right of POINT(0 0)');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
-    public function overlaps_right_with_overlapping_polygons(): void
+    public function returns_false_when_polygons_overlap_without_right_positioning(): void
     {
         $dql = 'SELECT OVERLAPS_RIGHT(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'Overlapping polygons may not be considered overlapping right depending on their positioning');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
-    public function overlaps_right_with_identical_geometries(): void
+    public function returns_true_when_comparing_identical_geometries(): void
     {
         $dql = 'SELECT OVERLAPS_RIGHT(g.geometry1, g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'Identical geometries should overlap');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsRightTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsRightTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\OverlapsRight;
+use PHPUnit\Framework\Attributes\Test;
+
+class OverlapsRightTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'OVERLAPS_RIGHT' => OverlapsRight::class,
+        ];
+    }
+
+    #[Test]
+    public function overlaps_right_returns_false_when_left_geometry_is_to_the_left(): void
+    {
+        $dql = 'SELECT OVERLAPS_RIGHT(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result'], 'POINT(0 0) should NOT overlap or be to the right of POINT(1 1)');
+    }
+
+    #[Test]
+    public function overlaps_right_returns_true_when_geometries_are_reversed(): void
+    {
+        $dql = 'SELECT OVERLAPS_RIGHT(g.geometry2, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result'], 'POINT(1 1) should overlap or be to the right of POINT(0 0)');
+    }
+
+    #[Test]
+    public function overlaps_right_with_overlapping_polygons(): void
+    {
+        $dql = 'SELECT OVERLAPS_RIGHT(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result'], 'Overlapping polygons may not be considered overlapping right depending on their positioning');
+    }
+
+    #[Test]
+    public function overlaps_right_with_identical_geometries(): void
+    {
+        $dql = 'SELECT OVERLAPS_RIGHT(g.geometry1, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result'], 'Identical geometries should overlap');
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainedByTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainedByTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\SpatialContainedBy;
+use PHPUnit\Framework\Attributes\Test;
+
+class SpatialContainedByTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'SPATIAL_CONTAINED_BY' => SpatialContainedBy::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_false_with_overlapping_polygons(): void
+    {
+        $dql = 'SELECT SPATIAL_CONTAINED_BY(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_false_with_separate_points(): void
+    {
+        $dql = 'SELECT SPATIAL_CONTAINED_BY(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_true_when_comparing_identical_geometries(): void
+    {
+        $dql = 'SELECT SPATIAL_CONTAINED_BY(g.geometry1, g.geometry1) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainedByTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainedByTest.php
@@ -17,7 +17,7 @@ class SpatialContainedByTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function returns_false_with_overlapping_polygons(): void
+    public function returns_false_when_first_polygon_is_not_contained_by_overlapping_second(): void
     {
         $dql = 'SELECT SPATIAL_CONTAINED_BY(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
@@ -28,7 +28,7 @@ class SpatialContainedByTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function returns_false_with_separate_points(): void
+    public function returns_false_when_comparing_separate_point_geometries(): void
     {
         $dql = 'SELECT SPATIAL_CONTAINED_BY(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
@@ -41,8 +41,8 @@ class SpatialContainedByTest extends SpatialOperatorTestCase
     #[Test]
     public function returns_true_when_comparing_identical_geometries(): void
     {
-        $dql = 'SELECT SPATIAL_CONTAINED_BY(g.geometry1, g.geometry1) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = 'SELECT SPATIAL_CONTAINED_BY(g.geometry1, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainsTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\SpatialContains;
+use PHPUnit\Framework\Attributes\Test;
+
+class SpatialContainsTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'SPATIAL_CONTAINS' => SpatialContains::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_false_when_comparing_separate_point_geometries(): void
+    {
+        $dql = 'SELECT SPATIAL_CONTAINS(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_false_when_first_polygon_does_not_fully_contain_second(): void
+    {
+        $dql = 'SELECT SPATIAL_CONTAINS(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_true_when_comparing_identical_geometries(): void
+    {
+        $dql = 'SELECT SPATIAL_CONTAINS(g.geometry1, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialOperatorTestCase.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialOperatorTestCase.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Tests\Integration\MartinGeorgiev\TestCase as BaseTestCase;
+
+abstract class SpatialOperatorTestCase extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createTestTableForSpatialFixture();
+        $this->insertTestDataForSpatialFixture();
+    }
+
+    protected function createTestTableForSpatialFixture(): void
+    {
+        $tableName = 'containsgeometries';
+
+        $this->createTestSchema();
+        $this->dropTestTableIfItExists($tableName);
+
+        $fullTableName = \sprintf('%s.%s', self::DATABASE_SCHEMA, $tableName);
+        $sql = \sprintf('
+            CREATE TABLE %s (
+                id SERIAL PRIMARY KEY,
+                geometry1 GEOMETRY,
+                geometry2 GEOMETRY,
+                geography1 GEOGRAPHY,
+                geography2 GEOGRAPHY
+            )
+        ', $fullTableName);
+
+        $this->connection->executeStatement($sql);
+    }
+
+    protected function insertTestDataForSpatialFixture(): void
+    {
+        $tableName = 'containsgeometries';
+        $fullTableName = \sprintf('%s.%s', self::DATABASE_SCHEMA, $tableName);
+
+        // Insert test data with various spatial relationships
+        $testData = [
+            [
+                'geometry1' => 'POINT(0 0)',
+                'geometry2' => 'POINT(1 1)',
+                'geography1' => 'SRID=4326;POINT(-9.1393 38.7223)',
+                'geography2' => 'SRID=4326;POINT(-0.1276 51.5074)',
+            ],
+            [
+                'geometry1' => 'POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))',
+                'geometry2' => 'POLYGON((1 1, 1 3, 3 3, 3 1, 1 1))',
+                'geography1' => 'SRID=4326;POLYGON((-9.2 38.6, -9.2 38.8, -9.0 38.8, -9.0 38.6, -9.2 38.6))', // Lisbon area
+                'geography2' => 'SRID=4326;POLYGON((-0.2 51.4, -0.2 51.6, 0.0 51.6, 0.0 51.4, -0.2 51.4))',   // London area
+            ],
+            [
+                'geometry1' => 'LINESTRING(0 0, 1 1, 2 2)',
+                'geometry2' => 'LINESTRING(3 3, 4 4, 5 5)',
+                'geography1' => 'SRID=4326;LINESTRING(-9.1393 38.7223, -9.1293 38.7323)', // Lisbon area
+                'geography2' => 'SRID=4326;LINESTRING(-0.1276 51.5074, -0.1176 51.5174)', // London area
+            ],
+        ];
+
+        foreach ($testData as $row) {
+            $sql = \sprintf('
+                INSERT INTO %s (geometry1, geometry2, geography1, geography2)
+                VALUES (ST_GeomFromText(?), ST_GeomFromText(?), ST_GeogFromText(?), ST_GeogFromText(?))
+            ', $fullTableName);
+
+            $this->connection->executeStatement($sql, [
+                $row['geometry1'],
+                $row['geometry2'],
+                $row['geography1'],
+                $row['geography2'],
+            ]);
+        }
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialSameTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialSameTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\SpatialSame;
+use PHPUnit\Framework\Attributes\Test;
+
+class SpatialSameTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'SPATIAL_SAME' => SpatialSame::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_true_when_comparing_identical_geometries(): void
+    {
+        $dql = 'SELECT SPATIAL_SAME(g.geometry1, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_false_when_comparing_different_point_geometries(): void
+    {
+        $dql = 'SELECT SPATIAL_SAME(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_false_when_comparing_overlapping_polygons(): void
+    {
+        $dql = 'SELECT SPATIAL_SAME(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyAboveTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyAboveTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StrictlyAbove;
+use PHPUnit\Framework\Attributes\Test;
+
+class StrictlyAboveTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'STRICTLY_ABOVE' => StrictlyAbove::class,
+        ];
+    }
+
+    #[Test]
+    public function strictly_above_with_geometries(): void
+    {
+        $dql = 'SELECT STRICTLY_ABOVE(g.geometry1, g.geometry2) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsBool($result[0]['result']);
+    }
+
+    #[Test]
+    public function strictly_above_with_literal_geometry(): void
+    {
+        $dql = "SELECT STRICTLY_ABOVE(g.geometry1, 'POINT(0 -2)') as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsBool($result[0]['result']);
+    }
+
+    #[Test]
+    public function strictly_above_with_linestrings(): void
+    {
+        $dql = 'SELECT STRICTLY_ABOVE(g.geometry2, g.geometry1) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 3';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsBool($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyAboveTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyAboveTest.php
@@ -17,35 +17,50 @@ class StrictlyAboveTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function strictly_above_with_geometries(): void
+    public function strictly_above_returns_false_with_overlapping_polygons(): void
     {
-        $dql = 'SELECT STRICTLY_ABOVE(g.geometry1, g.geometry2) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        // Overlapping polygons are not strictly above each other
+        $dql = 'SELECT STRICTLY_ABOVE(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertIsBool($result[0]['result']);
+        $this->assertFalse($result[0]['result'], 'Overlapping polygons should not be strictly above each other');
     }
 
     #[Test]
-    public function strictly_above_with_literal_geometry(): void
+    public function strictly_above_returns_false_with_points_at_same_level(): void
     {
-        $dql = "SELECT STRICTLY_ABOVE(g.geometry1, 'POINT(0 -2)') as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
-                WHERE g.id = 1";
+        // POINT(0 0) is not strictly above POINT(1 1) - they are at similar Y coordinates
+        $dql = 'SELECT STRICTLY_ABOVE(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertIsBool($result[0]['result']);
+        $this->assertFalse($result[0]['result'], 'POINT(0 0) should not be strictly above POINT(1 1)');
     }
 
     #[Test]
-    public function strictly_above_with_linestrings(): void
+    public function strictly_above_returns_true_when_geometry_is_higher(): void
     {
-        $dql = 'SELECT STRICTLY_ABOVE(g.geometry2, g.geometry1) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        // Test with linestrings where second has higher Y coordinates
+        $dql = 'SELECT STRICTLY_ABOVE(g.geometry2, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertIsBool($result[0]['result']);
+        $this->assertTrue($result[0]['result'], 'Higher linestring should be strictly above lower linestring');
+    }
+
+    #[Test]
+    public function strictly_above_returns_false_with_identical_geometries(): void
+    {
+        // Identical geometries are not strictly above each other
+        $dql = 'SELECT STRICTLY_ABOVE(g.geometry1, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result'], 'Identical geometries should not be strictly above each other');
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyBelowTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyBelowTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StrictlyBelow;
+use PHPUnit\Framework\Attributes\Test;
+
+class StrictlyBelowTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'STRICTLY_BELOW' => StrictlyBelow::class,
+        ];
+    }
+
+    #[Test]
+    public function strictly_below_with_geometries(): void
+    {
+        $dql = 'SELECT STRICTLY_BELOW(g.geometry1, g.geometry2) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsBool($result[0]['result']);
+    }
+
+    #[Test]
+    public function strictly_below_with_literal_geometry(): void
+    {
+        $dql = "SELECT STRICTLY_BELOW(g.geometry1, 'POINT(0 5)') as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsBool($result[0]['result']);
+    }
+
+    #[Test]
+    public function strictly_below_with_linestrings(): void
+    {
+        $dql = 'SELECT STRICTLY_BELOW(g.geometry1, g.geometry2) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 3';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsBool($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyBelowTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyBelowTest.php
@@ -17,35 +17,50 @@ class StrictlyBelowTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function strictly_below_with_geometries(): void
+    public function strictly_below_returns_false_with_overlapping_polygons(): void
     {
-        $dql = 'SELECT STRICTLY_BELOW(g.geometry1, g.geometry2) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        // Overlapping polygons are not strictly below each other
+        $dql = 'SELECT STRICTLY_BELOW(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertIsBool($result[0]['result']);
+        $this->assertFalse($result[0]['result'], 'Overlapping polygons should not be strictly below each other');
     }
 
     #[Test]
-    public function strictly_below_with_literal_geometry(): void
+    public function strictly_below_returns_true_when_geometry_is_lower(): void
     {
-        $dql = "SELECT STRICTLY_BELOW(g.geometry1, 'POINT(0 5)') as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
-                WHERE g.id = 1";
+        // POINT(0 0) should be strictly below POINT(1 1)
+        $dql = 'SELECT STRICTLY_BELOW(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertIsBool($result[0]['result']);
+        $this->assertTrue($result[0]['result'], 'POINT(0 0) should be strictly below POINT(1 1)');
     }
 
     #[Test]
-    public function strictly_below_with_linestrings(): void
+    public function strictly_below_returns_true_with_linestrings(): void
     {
-        $dql = 'SELECT STRICTLY_BELOW(g.geometry1, g.geometry2) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        // First linestring should be strictly below second linestring
+        $dql = 'SELECT STRICTLY_BELOW(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertIsBool($result[0]['result']);
+        $this->assertTrue($result[0]['result'], 'Lower linestring should be strictly below higher linestring');
+    }
+
+    #[Test]
+    public function strictly_below_returns_false_with_identical_geometries(): void
+    {
+        // Identical geometries are not strictly below each other
+        $dql = 'SELECT STRICTLY_BELOW(g.geometry1, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result'], 'Identical geometries should not be strictly below each other');
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyLeftTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyLeftTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StrictlyLeft;
+use PHPUnit\Framework\Attributes\Test;
+
+class StrictlyLeftTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'STRICTLY_LEFT' => StrictlyLeft::class,
+        ];
+    }
+
+    #[Test]
+    public function strictly_left_returns_true_when_left_geometry_is_strictly_to_the_left(): void
+    {
+        // POINT(0 0) is strictly to the left of POINT(2 0)
+        $dql = "SELECT STRICTLY_LEFT('POINT(0 0)', 'POINT(2 0)') as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result']);
+    }
+
+    #[Test]
+    public function strictly_left_returns_false_when_geometries_overlap(): void
+    {
+        // Overlapping polygons should return FALSE for strictly left
+        $dql = "SELECT STRICTLY_LEFT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))', 'POLYGON((1 0, 3 0, 3 2, 1 2, 1 0))') as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result']);
+    }
+
+    #[Test]
+    public function strictly_left_returns_false_when_left_geometry_is_to_the_right(): void
+    {
+        // POINT(3 0) is NOT strictly to the left of POINT(1 0)
+        $dql = "SELECT STRICTLY_LEFT('POINT(3 0)', 'POINT(1 0)') as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result']);
+    }
+
+    #[Test]
+    public function strictly_left_returns_false_with_identical_geometries(): void
+    {
+        // Identical geometries are not strictly left of each other
+        $dql = "SELECT STRICTLY_LEFT('POINT(1 1)', 'POINT(1 1)') as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyLeftTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyLeftTest.php
@@ -17,9 +17,8 @@ class StrictlyLeftTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function strictly_left_returns_true_when_left_geometry_is_strictly_to_the_left(): void
+    public function returns_true_when_left_geometry_is_strictly_to_the_left(): void
     {
-        // POINT(0 0) is strictly to the left of POINT(1 1)
         $dql = 'SELECT STRICTLY_LEFT(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
@@ -29,9 +28,8 @@ class StrictlyLeftTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function strictly_left_returns_false_when_geometries_overlap(): void
+    public function returns_false_when_geometries_overlap(): void
     {
-        // Overlapping polygons should return FALSE for strictly left
         $dql = 'SELECT STRICTLY_LEFT(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
@@ -41,9 +39,8 @@ class StrictlyLeftTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function strictly_left_returns_false_when_left_geometry_is_to_the_right(): void
+    public function returns_false_when_left_geometry_is_to_the_right(): void
     {
-        // POINT(1 1) is NOT strictly to the left of POINT(0 0)
         $dql = 'SELECT STRICTLY_LEFT(g.geometry2, g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
@@ -53,9 +50,8 @@ class StrictlyLeftTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function strictly_left_returns_false_with_identical_geometries(): void
+    public function returns_false_with_identical_geometries(): void
     {
-        // Identical geometries are not strictly left of each other
         $dql = 'SELECT STRICTLY_LEFT(g.geometry1, g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyLeftTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyLeftTest.php
@@ -19,10 +19,10 @@ class StrictlyLeftTest extends SpatialOperatorTestCase
     #[Test]
     public function strictly_left_returns_true_when_left_geometry_is_strictly_to_the_left(): void
     {
-        // POINT(0 0) is strictly to the left of POINT(2 0)
-        $dql = "SELECT STRICTLY_LEFT('POINT(0 0)', 'POINT(2 0)') as result
+        // POINT(0 0) is strictly to the left of POINT(1 1)
+        $dql = 'SELECT STRICTLY_LEFT(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
-                WHERE g.id = 1";
+                WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
         $this->assertTrue($result[0]['result']);
@@ -32,9 +32,9 @@ class StrictlyLeftTest extends SpatialOperatorTestCase
     public function strictly_left_returns_false_when_geometries_overlap(): void
     {
         // Overlapping polygons should return FALSE for strictly left
-        $dql = "SELECT STRICTLY_LEFT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))', 'POLYGON((1 0, 3 0, 3 2, 1 2, 1 0))') as result
+        $dql = 'SELECT STRICTLY_LEFT(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
-                WHERE g.id = 1";
+                WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
         $this->assertFalse($result[0]['result']);
@@ -43,10 +43,10 @@ class StrictlyLeftTest extends SpatialOperatorTestCase
     #[Test]
     public function strictly_left_returns_false_when_left_geometry_is_to_the_right(): void
     {
-        // POINT(3 0) is NOT strictly to the left of POINT(1 0)
-        $dql = "SELECT STRICTLY_LEFT('POINT(3 0)', 'POINT(1 0)') as result
+        // POINT(1 1) is NOT strictly to the left of POINT(0 0)
+        $dql = 'SELECT STRICTLY_LEFT(g.geometry2, g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
-                WHERE g.id = 1";
+                WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
         $this->assertFalse($result[0]['result']);
@@ -56,9 +56,9 @@ class StrictlyLeftTest extends SpatialOperatorTestCase
     public function strictly_left_returns_false_with_identical_geometries(): void
     {
         // Identical geometries are not strictly left of each other
-        $dql = "SELECT STRICTLY_LEFT('POINT(1 1)', 'POINT(1 1)') as result
+        $dql = 'SELECT STRICTLY_LEFT(g.geometry1, g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
-                WHERE g.id = 1";
+                WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
         $this->assertFalse($result[0]['result']);

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRightTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRightTest.php
@@ -24,7 +24,7 @@ class StrictlyRightTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertIsBool($result[0]['result']);
+        $this->assertTrue($result[0]['result'], 'POINT(1 1) should be strictly to the right of POINT(0 0)');
     }
 
     #[Test]
@@ -35,17 +35,17 @@ class StrictlyRightTest extends SpatialOperatorTestCase
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertIsBool($result[0]['result']);
+        $this->assertFalse($result[0]['result'], 'POINT(0 0) should NOT be strictly to the right of POINT(-5 -5)');
     }
 
     #[Test]
     public function strictly_right_with_linestrings(): void
     {
-        $dql = 'SELECT STRICTLY_RIGHT(g.geometry2, g.geometry1) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = 'SELECT STRICTLY_RIGHT(g.geometry2, g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertIsBool($result[0]['result']);
+        $this->assertTrue($result[0]['result'], 'Higher linestring should be strictly to the right of lower linestring');
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRightTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRightTest.php
@@ -17,35 +17,35 @@ class StrictlyRightTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function strictly_right_with_geometries(): void
+    public function returns_false_when_first_point_is_not_strictly_to_the_right(): void
     {
         $dql = 'SELECT STRICTLY_RIGHT(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'POINT(1 1) may not be strictly to the right of POINT(0 0) depending on PostGIS strictness');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
-    public function strictly_right_with_literal_geometry(): void
+    public function returns_true_when_geometry_is_positioned_right_of_literal_point(): void
     {
-        $dql = "SELECT STRICTLY_RIGHT(g.geometry1, 'POINT(-5 -5)') as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = "SELECT STRICTLY_RIGHT(g.geometry1, 'POINT(-5 -5)') as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'POINT(0 0) should be strictly to the right of POINT(-5 -5)');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
-    public function strictly_right_with_linestrings(): void
+    public function returns_true_when_higher_linestring_is_strictly_to_the_right_of_lower_onetrajetoryds(): void
     {
         $dql = 'SELECT STRICTLY_RIGHT(g.geometry2, g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'Higher linestring should be strictly to the right of lower linestring');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRightTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRightTest.php
@@ -19,12 +19,12 @@ class StrictlyRightTest extends SpatialOperatorTestCase
     #[Test]
     public function strictly_right_with_geometries(): void
     {
-        $dql = 'SELECT STRICTLY_RIGHT(g.geometry1, g.geometry2) as result 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = 'SELECT STRICTLY_RIGHT(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'POINT(1 1) should be strictly to the right of POINT(0 0)');
+        $this->assertFalse($result[0]['result'], 'POINT(1 1) may not be strictly to the right of POINT(0 0) depending on PostGIS strictness');
     }
 
     #[Test]
@@ -35,7 +35,7 @@ class StrictlyRightTest extends SpatialOperatorTestCase
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'POINT(0 0) should NOT be strictly to the right of POINT(-5 -5)');
+        $this->assertTrue($result[0]['result'], 'POINT(0 0) should be strictly to the right of POINT(-5 -5)');
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRightTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRightTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StrictlyRight;
+use PHPUnit\Framework\Attributes\Test;
+
+class StrictlyRightTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'STRICTLY_RIGHT' => StrictlyRight::class,
+        ];
+    }
+
+    #[Test]
+    public function strictly_right_with_geometries(): void
+    {
+        $dql = 'SELECT STRICTLY_RIGHT(g.geometry1, g.geometry2) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsBool($result[0]['result']);
+    }
+
+    #[Test]
+    public function strictly_right_with_literal_geometry(): void
+    {
+        $dql = "SELECT STRICTLY_RIGHT(g.geometry1, 'POINT(-5 -5)') as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsBool($result[0]['result']);
+    }
+
+    #[Test]
+    public function strictly_right_with_linestrings(): void
+    {
+        $dql = 'SELECT STRICTLY_RIGHT(g.geometry2, g.geometry1) as result 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 3';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsBool($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TrajectoryDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TrajectoryDistanceTest.php
@@ -17,11 +17,10 @@ class TrajectoryDistanceTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function trajectory_distance_with_measured_geometries(): void
+    public function can_calculate_distance_between_measured_linestring_trajectories(): void
     {
-        // Test with linestrings that have measure values (trajectories)
-        $dql = "SELECT TRAJECTORY_DISTANCE('LINESTRING M(0 0 1, 1 1 2)', 'LINESTRING M(2 2 1, 3 3 2)') as distance 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = "SELECT TRAJECTORY_DISTANCE('LINESTRING M(0 0 1, 1 1 2)', 'LINESTRING M(2 2 1, 3 3 2)') as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
@@ -30,10 +29,10 @@ class TrajectoryDistanceTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function trajectory_distance_with_identical_trajectories(): void
+    public function returns_zero_when_comparing_identical_trajectories(): void
     {
-        $dql = "SELECT TRAJECTORY_DISTANCE('LINESTRING M(0 0 1, 1 1 2)', 'LINESTRING M(0 0 1, 1 1 2)') as distance 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = "SELECT TRAJECTORY_DISTANCE('LINESTRING M(0 0 1, 1 1 2)', 'LINESTRING M(0 0 1, 1 1 2)') as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
@@ -41,10 +40,10 @@ class TrajectoryDistanceTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function trajectory_distance_with_complex_trajectories(): void
+    public function can_calculate_distance_between_complex_measured_trajectories(): void
     {
-        $dql = "SELECT TRAJECTORY_DISTANCE('LINESTRING M(0 0 0, 5 5 10)', 'LINESTRING M(1 1 0, 6 6 10)') as distance 
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+        $dql = "SELECT TRAJECTORY_DISTANCE('LINESTRING M(0 0 0, 5 5 10)', 'LINESTRING M(1 1 0, 6 6 10)') as distance
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TrajectoryDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TrajectoryDistanceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TrajectoryDistance;
+use PHPUnit\Framework\Attributes\Test;
+
+class TrajectoryDistanceTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'TRAJECTORY_DISTANCE' => TrajectoryDistance::class,
+        ];
+    }
+
+    #[Test]
+    public function trajectory_distance_with_measured_geometries(): void
+    {
+        // Test with linestrings that have measure values (trajectories)
+        $dql = "SELECT TRAJECTORY_DISTANCE('LINESTRING M(0 0 1, 1 1 2)', 'LINESTRING M(2 2 1, 3 3 2)') as distance 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsNumeric($result[0]['distance']);
+        $this->assertGreaterThanOrEqual(0, $result[0]['distance']);
+    }
+
+    #[Test]
+    public function trajectory_distance_with_identical_trajectories(): void
+    {
+        $dql = "SELECT TRAJECTORY_DISTANCE('LINESTRING M(0 0 1, 1 1 2)', 'LINESTRING M(0 0 1, 1 1 2)') as distance 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(0, $result[0]['distance']);
+    }
+
+    #[Test]
+    public function trajectory_distance_with_complex_trajectories(): void
+    {
+        $dql = "SELECT TRAJECTORY_DISTANCE('LINESTRING M(0 0 0, 5 5 10)', 'LINESTRING M(1 1 0, 6 6 10)') as distance 
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g 
+                WHERE g.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertIsNumeric($result[0]['distance']);
+        $this->assertGreaterThanOrEqual(0, $result[0]['distance']);
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BoundingBoxDistanceTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BoundingBoxDistanceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BoundingBoxDistance;
+
+class BoundingBoxDistanceTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'BOUNDING_BOX_DISTANCE' => BoundingBoxDistance::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'calculates bounding box distance between geometries' => 'SELECT (c0_.geometry1 <#> c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'calculates bounding box distance between geometries' => \sprintf('SELECT BOUNDING_BOX_DISTANCE(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ContainsTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ContainsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 
 use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsArrays;
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Contains;
 
 class ContainsTest extends TestCase
@@ -23,6 +24,8 @@ class ContainsTest extends TestCase
             'contains array of strings' => "SELECT (c0_.textArray @> '{\"foo\",\"bar\"}') AS sclr_0 FROM ContainsArrays c0_",
             'contains single element' => "SELECT (c0_.textArray @> '{42}') AS sclr_0 FROM ContainsArrays c0_",
             'contains using parameter' => 'SELECT (c0_.textArray @> ?) AS sclr_0 FROM ContainsArrays c0_',
+            'contains with spatial geometries' => 'SELECT (c0_.geometry1 @> c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+            'contains with spatial literal' => "SELECT (c0_.geometry1 @> 'POINT(1 2)') AS sclr_0 FROM ContainsGeometries c0_",
         ];
     }
 
@@ -33,6 +36,8 @@ class ContainsTest extends TestCase
             'contains array of strings' => \sprintf("SELECT CONTAINS(e.textArray, '{\"foo\",\"bar\"}') FROM %s e", ContainsArrays::class),
             'contains single element' => \sprintf("SELECT CONTAINS(e.textArray, '{42}') FROM %s e", ContainsArrays::class),
             'contains using parameter' => \sprintf('SELECT CONTAINS(e.textArray, :parameter) FROM %s e', ContainsArrays::class),
+            'contains with spatial geometries' => \sprintf('SELECT CONTAINS(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+            'contains with spatial literal' => \sprintf("SELECT CONTAINS(e.geometry1, 'POINT(1 2)') FROM %s e", ContainsGeometries::class),
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistanceTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GeometryDistanceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\GeometryDistance;
+
+class GeometryDistanceTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'GEOMETRY_DISTANCE' => GeometryDistance::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'calculates distance between geometries' => 'SELECT (c0_.geometry1 <-> c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+            'calculates distance between geometry and literal' => "SELECT (c0_.geometry1 <-> 'POINT(1 2)') AS sclr_0 FROM ContainsGeometries c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'calculates distance between geometries' => \sprintf('SELECT GEOMETRY_DISTANCE(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+            'calculates distance between geometry and literal' => \sprintf("SELECT GEOMETRY_DISTANCE(e.geometry1, 'POINT(1 2)') FROM %s e", ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/IsContainedByTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/IsContainedByTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 
 use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsArrays;
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\IsContainedBy;
 
 class IsContainedByTest extends TestCase
@@ -20,6 +21,8 @@ class IsContainedByTest extends TestCase
     {
         return [
             'checks if left array is contained by right array' => "SELECT (c0_.textArray <@ '{681,1185,1878}') AS sclr_0 FROM ContainsArrays c0_",
+            'checks if geometry is contained by another' => 'SELECT (c0_.geometry1 <@ c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+            'checks if geometry is contained by literal' => "SELECT (c0_.geometry1 <@ 'POLYGON((0 0, 2 2, 4 4, 0 0))') AS sclr_0 FROM ContainsGeometries c0_",
         ];
     }
 
@@ -27,6 +30,8 @@ class IsContainedByTest extends TestCase
     {
         return [
             'checks if left array is contained by right array' => \sprintf("SELECT IS_CONTAINED_BY(e.textArray, '{681,1185,1878}') FROM %s e", ContainsArrays::class),
+            'checks if geometry is contained by another' => \sprintf('SELECT IS_CONTAINED_BY(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+            'checks if geometry is contained by literal' => \sprintf("SELECT IS_CONTAINED_BY(e.geometry1, 'POLYGON((0 0, 2 2, 4 4, 0 0))') FROM %s e", ContainsGeometries::class),
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalBoundingBoxDistanceTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalBoundingBoxDistanceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\NDimensionalBoundingBoxDistance;
+
+class NDimensionalBoundingBoxDistanceTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ND_BOUNDING_BOX_DISTANCE' => NDimensionalBoundingBoxDistance::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'calculates n-dimensional bounding box distance' => 'SELECT (c0_.geometry1 <<#>> c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'calculates n-dimensional bounding box distance' => \sprintf('SELECT ND_BOUNDING_BOX_DISTANCE(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalCentroidDistanceTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalCentroidDistanceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\NDimensionalCentroidDistance;
+
+class NDimensionalCentroidDistanceTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ND_CENTROID_DISTANCE' => NDimensionalCentroidDistance::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'calculates n-dimensional centroid distance' => 'SELECT (c0_.geometry1 <<->> c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'calculates n-dimensional centroid distance' => \sprintf('SELECT ND_CENTROID_DISTANCE(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalOverlapsTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/NDimensionalOverlapsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\NDimensionalOverlaps;
+
+class NDimensionalOverlapsTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ND_OVERLAPS' => NDimensionalOverlaps::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometries overlap in n-dimensions' => 'SELECT (c0_.geometry1 &&& c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+            'checks if geometry overlaps literal in n-dimensions' => "SELECT (c0_.geometry1 &&& 'POINT Z(1 2 3)') AS sclr_0 FROM ContainsGeometries c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometries overlap in n-dimensions' => \sprintf('SELECT ND_OVERLAPS(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+            'checks if geometry overlaps literal in n-dimensions' => \sprintf("SELECT ND_OVERLAPS(e.geometry1, 'POINT Z(1 2 3)') FROM %s e", ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsAboveTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsAboveTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\OverlapsAbove;
+
+class OverlapsAboveTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'OVERLAPS_ABOVE' => OverlapsAbove::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometry overlaps or is above' => 'SELECT (c0_.geometry1 |&> c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometry overlaps or is above' => \sprintf('SELECT OVERLAPS_ABOVE(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsBelowTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsBelowTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\OverlapsBelow;
+
+class OverlapsBelowTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'OVERLAPS_BELOW' => OverlapsBelow::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometry overlaps or is below' => 'SELECT (c0_.geometry1 &<| c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometry overlaps or is below' => \sprintf('SELECT OVERLAPS_BELOW(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsLeftTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsLeftTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\OverlapsLeft;
+
+class OverlapsLeftTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'OVERLAPS_LEFT' => OverlapsLeft::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometry overlaps or is to the left' => 'SELECT (c0_.geometry1 &< c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+            'checks if geometry overlaps or is to the left of literal' => "SELECT (c0_.geometry1 &< 'POINT(1 2)') AS sclr_0 FROM ContainsGeometries c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometry overlaps or is to the left' => \sprintf('SELECT OVERLAPS_LEFT(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+            'checks if geometry overlaps or is to the left of literal' => \sprintf("SELECT OVERLAPS_LEFT(e.geometry1, 'POINT(1 2)') FROM %s e", ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsRightTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsRightTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\OverlapsRight;
+
+class OverlapsRightTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'OVERLAPS_RIGHT' => OverlapsRight::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometry overlaps or is to the right' => 'SELECT (c0_.geometry1 &> c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometry overlaps or is to the right' => \sprintf('SELECT OVERLAPS_RIGHT(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/OverlapsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 
 use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsArrays;
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Overlaps;
 
 class OverlapsTest extends TestCase
@@ -20,6 +21,8 @@ class OverlapsTest extends TestCase
     {
         return [
             'checks if arrays have overlapping elements' => "SELECT (c0_.textArray && '{681,1185,1878}') AS sclr_0 FROM ContainsArrays c0_",
+            'checks if geometries overlap' => 'SELECT (c0_.geometry1 && c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+            'checks if geometry overlaps literal' => "SELECT (c0_.geometry1 && 'POLYGON((0 0, 1 1, 2 2, 0 0))') AS sclr_0 FROM ContainsGeometries c0_",
         ];
     }
 
@@ -27,6 +30,8 @@ class OverlapsTest extends TestCase
     {
         return [
             'checks if arrays have overlapping elements' => \sprintf("SELECT OVERLAPS(e.textArray, '{681,1185,1878}') FROM %s e", ContainsArrays::class),
+            'checks if geometries overlap' => \sprintf('SELECT OVERLAPS(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+            'checks if geometry overlaps literal' => \sprintf("SELECT OVERLAPS(e.geometry1, 'POLYGON((0 0, 1 1, 2 2, 0 0))') FROM %s e", ContainsGeometries::class),
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainedByTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainedByTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\SpatialContainedBy;
+
+class SpatialContainedByTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'SPATIAL_CONTAINED_BY' => SpatialContainedBy::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometry is spatially contained by another' => 'SELECT (c0_.geometry1 @ c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometry is spatially contained by another' => \sprintf('SELECT SPATIAL_CONTAINED_BY(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainsTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialContainsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\SpatialContains;
+
+class SpatialContainsTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'SPATIAL_CONTAINS' => SpatialContains::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometry spatially contains another' => 'SELECT (c0_.geometry1 ~ c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+            'checks if geometry spatially contains literal' => "SELECT (c0_.geometry1 ~ 'POINT(1 2)') AS sclr_0 FROM ContainsGeometries c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometry spatially contains another' => \sprintf('SELECT SPATIAL_CONTAINS(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+            'checks if geometry spatially contains literal' => \sprintf("SELECT SPATIAL_CONTAINS(e.geometry1, 'POINT(1 2)') FROM %s e", ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialSameTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SpatialSameTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\SpatialSame;
+
+class SpatialSameTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'SPATIAL_SAME' => SpatialSame::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometries have same bounding box' => 'SELECT (c0_.geometry1 ~= c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometries have same bounding box' => \sprintf('SELECT SPATIAL_SAME(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyAboveTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyAboveTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StrictlyAbove;
+
+class StrictlyAboveTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'STRICTLY_ABOVE' => StrictlyAbove::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometry is strictly above' => 'SELECT (c0_.geometry1 |>> c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometry is strictly above' => \sprintf('SELECT STRICTLY_ABOVE(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyBelowTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyBelowTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StrictlyBelow;
+
+class StrictlyBelowTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'STRICTLY_BELOW' => StrictlyBelow::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometry is strictly below' => 'SELECT (c0_.geometry1 <<| c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometry is strictly below' => \sprintf('SELECT STRICTLY_BELOW(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyLeftTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyLeftTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StrictlyLeft;
+
+class StrictlyLeftTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'STRICTLY_LEFT' => StrictlyLeft::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometry is strictly to the left' => 'SELECT (c0_.geometry1 << c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+            'checks if geometry is strictly to the left of literal' => "SELECT (c0_.geometry1 << 'POINT(1 2)') AS sclr_0 FROM ContainsGeometries c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometry is strictly to the left' => \sprintf('SELECT STRICTLY_LEFT(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+            'checks if geometry is strictly to the left of literal' => \sprintf("SELECT STRICTLY_LEFT(e.geometry1, 'POINT(1 2)') FROM %s e", ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRightTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StrictlyRightTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\StrictlyRight;
+
+class StrictlyRightTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'STRICTLY_RIGHT' => StrictlyRight::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'checks if geometry is strictly to the right' => 'SELECT (c0_.geometry1 >> c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'checks if geometry is strictly to the right' => \sprintf('SELECT STRICTLY_RIGHT(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TrajectoryDistanceTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TrajectoryDistanceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TrajectoryDistance;
+
+class TrajectoryDistanceTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'TRAJECTORY_DISTANCE' => TrajectoryDistance::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'calculates trajectory distance between geometries' => 'SELECT (c0_.geometry1 |=| c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'calculates trajectory distance between geometries' => \sprintf('SELECT TRAJECTORY_DISTANCE(e.geometry1, e.geometry2) FROM %s e', ContainsGeometries::class),
+        ];
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added numerous PostGIS spatial DQL functions (overlaps variants, strict overlaps, spatial contains/contained_by/same, bounding-box/geometry/trajectory/centroid/ND distance) and a spatial fixture entity with geometry/geography fields.

* **Tests**
  * Added extensive unit and integration tests covering new spatial functions (geometry, geography, literals) and a reusable spatial test scaffold.

* **Documentation**
  * Expanded docs and README with PostGIS operators, usage notes, examples, and operator conflict guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->