### PR TITLE
fix(#424): address unintentional loss of string data type when retrieving PHP array item values from a stored `TextArray` value

### DIFF
--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTypeTest.php
@@ -20,6 +20,7 @@ class TextArrayTypeTest extends ArrayTypeTestCase
     }
 
     #[DataProvider('provideValidTransformations')]
+    #[DataProvider('provideGithubIssue424TestCases')]
     #[Test]
     public function can_handle_array_values(string $testName, array $arrayValue): void
     {
@@ -29,12 +30,57 @@ class TextArrayTypeTest extends ArrayTypeTestCase
     public static function provideValidTransformations(): array
     {
         return [
-            'simple text array' => ['simple text array', ['foo', 'bar', 'baz']],
-            'text array with special chars' => ['text array with special chars', ['foo"bar', 'baz\qux', 'with,comma']],
-            'text array with empty strings' => ['text array with empty strings', ['', 'not empty', '']],
-            'text array with unicode' => ['text array with unicode', ['café', 'naïve', 'résumé']],
-            'text array with numbers as strings' => ['text array with numbers as strings', ['123', '456', '789']],
-            'text array with null elements' => ['text array with null elements', ['foo', null, 'baz']],
+            'simple text array' => [
+                'simple text array',
+                ['foo', 'bar', 'baz'],
+            ],
+            'text array with special chars' => [
+                'text array with special chars',
+                ['foo"bar', 'baz\qux', 'with,comma'],
+            ],
+            'text array with empty strings' => [
+                'text array with empty strings',
+                ['', 'not empty', ''],
+            ],
+            'text array with unicode' => [
+                'text array with unicode',
+                ['café', 'naïve', 'résumé'],
+            ],
+            'text array with numbers as strings' => [
+                'text array with numbers as strings',
+                ['123', '456', '789'],
+            ],
+            'text array with null element as string' => [
+                'text array with null elements',
+                ['foo', 'null', 'baz'],
+            ],
+        ];
+    }
+
+    /**
+     * This test scenarios specifically verify the scenarios from GitHub issue #424
+     * where PostgreSQL optimizes {"1","test"} to {1,test} and we have to ensure
+     * that TextArray correctly preserves string types when converted back for PHP.
+     */
+    public static function provideGithubIssue424TestCases(): array
+    {
+        return [
+            'numeric values' => [
+                'Numeric values should be preserved as strings',
+                ['1', 'test'],
+            ],
+            'mixed values' => [
+                'Mixed numeric values should be preserved as strings',
+                ['1', '2.5', '3.14', 'test', 'true', ''],
+            ],
+            'boolean values' => [
+                'Boolean values should be converted to strings',
+                ['1', '', '1', ''],
+            ],
+            'null values' => [
+                'Null values should be converted to strings',
+                ['', 'null', 'NULL'],
+            ],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
@@ -166,6 +166,10 @@ class PostgresArrayToPHPArrayTransformerTest extends TestCase
                 'phpValue' => ['  foo  '],
                 'postgresValue' => '{"  foo  "}',
             ],
+            'github #424 regression: numeric strings should be preserved as strings when unquoted' => [
+                'phpValue' => ['1', 'test', 'true'],
+                'postgresValue' => '{1,test,true}',
+            ],
         ];
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures all elements from PostgreSQL text[] arrays are returned as strings, including numeric, boolean-like, and null values. Resolves inconsistent typing when reading text arrays.

- Tests
  - Added integration and unit tests covering scenarios for string preservation across mixed, numeric, boolean-like, and null inputs, including regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->