### PR TITLE
feat(#456): add convenience factory methods to `WktSpatialData`

### DIFF
--- a/docs/SPATIAL-TYPES.md
+++ b/docs/SPATIAL-TYPES.md
@@ -27,6 +27,77 @@ Two enums drive normalization so the code and docs remain consistent:
 
 Regex patterns for geometry type detection and dimensional modifier handling are built from these enums instead of hardcoded strings.
 
+## Creating Spatial Data
+
+The `WktSpatialData` value object provides multiple ways to create spatial data:
+
+### From WKT String (Traditional)
+```php
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\WktSpatialData;
+
+// Parse complete WKT/EWKT strings
+$point = WktSpatialData::fromWkt('POINT(1 2)');
+$pointWithSrid = WktSpatialData::fromWkt('SRID=4326;POINT(-122.4194 37.7749)');
+$line = WktSpatialData::fromWkt('LINESTRING(0 0, 1 1, 2 2)');
+```
+
+### From Components (Programmatic)
+```php
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\WktSpatialData;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\GeometryType;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DimensionalModifier;
+
+// Build from individual components
+$point = WktSpatialData::fromComponents(
+    GeometryType::POINT,
+    '1 2'
+);
+
+// With SRID
+$pointWithSrid = WktSpatialData::fromComponents(
+    GeometryType::POINT,
+    '-122.4194 37.7749',
+    4326
+);
+
+// With dimensional modifier
+$line3d = WktSpatialData::fromComponents(
+    GeometryType::LINESTRING,
+    '0 0 1, 1 1 2, 2 2 3',
+    null,
+    DimensionalModifier::Z
+);
+
+// With all parameters
+$polygon4d = WktSpatialData::fromComponents(
+    GeometryType::POLYGON,
+    '0 0 0 1, 0 1 0 1, 1 1 0 1, 1 0 0 1, 0 0 0 1',
+    4326,
+    DimensionalModifier::ZM
+);
+```
+
+### Convenience Methods for Points
+```php
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\WktSpatialData;
+
+// Simple 2D point
+$point = WktSpatialData::point(1, 2);
+// Result: POINT(1 2)
+
+// Point with SRID (common for geographic coordinates)
+$location = WktSpatialData::point(-122.4194, 37.7749, 4326);
+// Result: SRID=4326;POINT(-122.4194 37.7749)
+
+// 3D point with elevation
+$point3d = WktSpatialData::point3d(-122.4194, 37.7749, 100);
+// Result: POINT Z(-122.4194 37.7749 100)
+
+// 3D point with SRID
+$location3d = WktSpatialData::point3d(-122.4194, 37.7749, 100, 4326);
+// Result: SRID=4326;POINT Z(-122.4194 37.7749 100)
+```
+
 ## Supported Geometry Types
 
 The library supports all PostGIS geometry types through the `GeometryType` enum:

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/WktSpatialData.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/WktSpatialData.php
@@ -87,6 +87,67 @@ final class WktSpatialData implements \Stringable
         return new self($srid, $geometryType, $body, $dimensionalModifier);
     }
 
+    /**
+     * Create spatial data from individual components.
+     *
+     * This is a convenience method for programmatically building spatial data
+     * without manually constructing WKT strings.
+     *
+     * @param GeometryType $geometryType The geometry type (e.g., POINT, LINESTRING)
+     * @param string $coordinates The coordinate data (e.g., "1 2" for a point, "0 0, 1 1" for a line)
+     * @param int|null $srid Optional spatial reference system identifier
+     * @param DimensionalModifier|null $dimensionalModifier Optional dimensional modifier (Z, M, or ZM)
+     *
+     * @throws InvalidWktSpatialDataException If coordinates are empty
+     */
+    public static function fromComponents(
+        GeometryType $geometryType,
+        string $coordinates,
+        ?int $srid = null,
+        ?DimensionalModifier $dimensionalModifier = null
+    ): self {
+        $coordinates = \trim($coordinates);
+        if ($coordinates === '') {
+            throw InvalidWktSpatialDataException::forEmptyCoordinateSection();
+        }
+
+        return new self($srid, $geometryType, $coordinates, $dimensionalModifier);
+    }
+
+    /**
+     * Create a POINT geometry from longitude and latitude.
+     *
+     * Convenience method for the most common use case: creating geographic points.
+     *
+     * @param float|int|string $longitude The longitude (X coordinate)
+     * @param float|int|string $latitude The latitude (Y coordinate)
+     * @param int|null $srid Optional SRID (commonly 4326 for WGS84)
+     */
+    public static function point(
+        float|int|string $longitude,
+        float|int|string $latitude,
+        ?int $srid = null
+    ): self {
+        return new self($srid, GeometryType::POINT, \sprintf('%s %s', $longitude, $latitude));
+    }
+
+    /**
+     * Create a 3D POINT geometry with elevation.
+     *
+     * @param float|int|string $longitude The longitude (X coordinate)
+     * @param float|int|string $latitude The latitude (Y coordinate)
+     * @param float|int|string $elevation The elevation (Z coordinate)
+     * @param int|null $srid Optional SRID (commonly 4326 for WGS84)
+     */
+    public static function point3d(
+        float|int|string $longitude,
+        float|int|string $latitude,
+        float|int|string $elevation,
+        ?int $srid = null
+    ): self {
+        return new self($srid, GeometryType::POINT, \sprintf('%s %s %s', $longitude, $latitude, $elevation), DimensionalModifier::Z);
+    }
+
     public function getSrid(): ?int
     {
         return $this->srid;


### PR DESCRIPTION
Addresses issue #456 by providing a clean API for creating spatial data without manual WKT string construction while maintaining validation and type safety through enums:

- Add fromComponents() for type-safe programmatic construction
- Add point() for simple 2D geographic points
- Add point3d() for 3D points with elevation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added helper methods to programmatically create spatial data from components without manual string assembly.
  * Introduced convenience methods for creating 2D and 3D point geometries with optional SRID support.

* **Documentation**
  * Expanded Spatial Types documentation with comprehensive creation methods guide and geometry examples.

* **Tests**
  * Added extensive test coverage for new spatial data creation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->