### PR TITLE
Update TextArray.php: Making `TYPE_NAME` `public`

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/TextArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/TextArray.php
@@ -21,7 +21,7 @@ class TextArray extends BaseType
     /**
      * @var string
      */
-    protected const TYPE_NAME = 'text[]';
+    public const TYPE_NAME = 'text[]';
 
     /**
      * Converts a value from its PHP representation to its database representation of the type.


### PR DESCRIPTION
If those name `const`s were public, people could use them in their mappings:
```php
#[ORM\Column(type: TextArray::TYPE_NAME)]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated access level of the text array type identifier to allow broader external access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->