### PR TITLE
(test) Enable native lazy objects on PHP 8.4 in base test cases

### DIFF
--- a/tests/Integration/MartinGeorgiev/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/TestCase.php
@@ -77,6 +77,10 @@ abstract class TestCase extends BaseTestCase
         $configuration->setProxyDir(self::FIXTURES_DIRECTORY.'/Proxies');
         $configuration->setProxyNamespace(self::FIXTURE_NAMESPACE.'\Proxy');
         $configuration->setAutoGenerateProxyClasses(true);
+        if (\PHP_VERSION_ID >= 80400 && \method_exists($configuration, 'enableNativeLazyObjects')) {
+            // @phpstan-ignore-next-line
+            $configuration->enableNativeLazyObjects(true);
+        }
         $this->setConfigurationCache($configuration);
 
         // Register the entity namespace for DQL short aliases

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TestCase.php
@@ -28,6 +28,10 @@ abstract class TestCase extends BaseTestCase
         $configuration->setProxyDir(static::FIXTURES_DIRECTORY.'/Proxies');
         $configuration->setProxyNamespace('Fixtures\MartinGeorgiev\Doctrine\Entity\Proxy');
         $configuration->setAutoGenerateProxyClasses(true);
+        if (\PHP_VERSION_ID >= 80400 && \method_exists($configuration, 'enableNativeLazyObjects')) {
+            // @phpstan-ignore-next-line
+            $configuration->enableNativeLazyObjects(true);
+        }
         $this->setConfigurationCache($configuration);
 
         $this->configuration = $configuration;


### PR DESCRIPTION
I've been getting a ton of false-positive failures when running `composer phpunit:unit` directly on my PHP 8.4.x dev machine:

```
51) Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\JsonbPathQueryArrayTest::throws_exception_for_too_many_arguments
Failed asserting that exception of type "Doctrine\ORM\ORMInvalidArgumentException" matches expected exception "MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException". Message was: "Symfony LazyGhost is not available. Please install the "symfony/var-exporter" package version 6.4 or 7 to use this feature or enable PHP 8.4 native lazy objects." at
/Users/janklan/dev/postgresql-for-doctrine/vendor/doctrine/orm/src/ORMInvalidArgumentException.php:165
/Users/janklan/dev/postgresql-for-doctrine/vendor/doctrine/orm/src/Proxy/ProxyFactory.php:167
/Users/janklan/dev/postgresql-for-doctrine/vendor/doctrine/orm/src/EntityManager.php:140
/Users/janklan/dev/postgresql-for-doctrine/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TestCase.php:117
/Users/janklan/dev/postgresql-for-doctrine/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/JsonbPathQueryArrayTest.php:75
```

This small change enables the native lazy objects on PHP 8.4+ and fixes the problem for me. 

If it's not the right way to fix the problem, please advise. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test setup updated to enable native lazy objects when running on PHP 8.4+ and the capability is present, improving compatibility and accuracy of tests that rely on lazy object behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->