### PR TITLE
Add support for infinity values

### DIFF
--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/NumericRangeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/NumericRangeTest.php
@@ -107,7 +107,9 @@ final class NumericRangeTest extends BaseRangeTestCase
         yield 'inclusive range' => ['[1,10]', new NumericRange(1, 10, true, true)];
         yield 'exclusive range' => ['(1,10)', new NumericRange(1, 10, false, false)];
         yield 'infinite lower' => ['[,10)', new NumericRange(null, 10)];
+        yield 'bounded infinite lower' => ['[-Infinity,10)', new NumericRange(null, 10)];
         yield 'infinite upper' => ['[1,)', new NumericRange(1, null)];
+        yield 'bounded infinite upper' => ['[1,Infinity)', new NumericRange(1, null)];
         yield 'empty range' => ['empty', NumericRange::empty()];
     }
 


### PR DESCRIPTION
This PR exists to trigger the unit tests referred to by a discussion https://github.com/martin-georgiev/postgresql-for-doctrine/discussions/522. It is not meant to be a valid pull request at this stage. 

Github Actions are configured to run the unit tests on specific branches, including `main`, so I created a draft PR to get the Actions run. 

Please see the discussion for more information. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to validate parsing of numeric ranges with infinite bounds (negative infinity with finite upper bound and positive infinity with finite lower bound).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->