### PR TITLE
fix(#616): add length/dimension support to pgvector types' SQL declaration

### DIFF
--- a/.ai-tools/rules/testing-and-iteration.md
+++ b/.ai-tools/rules/testing-and-iteration.md
@@ -1,5 +1,5 @@
 ---
-description: "Testing: version checks, targeted test runs, 3-attempt failure limit, WKB geometry assertions"
+description: "Testing: version checks, targeted test runs, 3-attempt failure limit, WKB geometry assertions, getSQLDeclaration blind spot"
 alwaysApply: true
 trigger: always_on
 applyTo: "**"
@@ -53,6 +53,27 @@ When tests fail after your changes:
 bin/phpunit --filter "ST_HasZ" --configuration ci/phpunit/config-integration.xml
 ```
 instead of running the full integration test suite.
+
+## DBAL Types: `getSQLDeclaration()` Is Not Tested by Integration Tests
+
+Integration tests create tables with raw SQL (e.g., `CREATE TABLE ... (col VECTOR(3))`) and test PHP↔DB value conversion. They **never call `getSQLDeclaration()`**. Schema generation bugs — where a type emits `VECTOR` instead of `VECTOR(1024)` — are completely invisible to them.
+
+**Every DBAL type that maps to a parameterised PostgreSQL type must override `getSQLDeclaration()` and have unit tests for it.**
+
+Common PostgreSQL parameterisation patterns:
+
+| Pattern | Examples |
+|---------|---------|
+| `TYPE(n)` — length / dimensions | `BIT(n)`, `VARCHAR(n)`, `VECTOR(n)`, `HALFVEC(n)`, `SPARSEVEC(n)` |
+| `TYPE(p, s)` — precision + scale | `NUMERIC(p, s)`, `DECIMAL(p, s)` |
+| `TYPE(p)` — fractional-second precision | `TIMESTAMP(p)`, `TIMESTAMPTZ(p)`, `TIME(p)` |
+| `TYPE(subtype, srid)` — PostGIS | `GEOMETRY(type, srid)`, `GEOGRAPHY(type, srid)` |
+
+For `TYPE(n)` cases use the existing `LengthAwareSQLDeclarationTrait` (`src/.../Types/Traits/`) via `fieldDeclaration['length']`. For other parameterisations write a custom override reading the relevant `$fieldDeclaration` keys (`'precision'`, `'scale'`, `'srid'`, etc.).
+
+Required unit tests for any override:
+1. No parameters → bare type name
+2. Parameters provided → correct parameterised form (e.g. `VECTOR(1024)`)
 
 ## PostGIS Geometry Result Assertions
 PostGIS functions that return geometry types produce WKB (Well-Known Binary) hex format in query results, not WKT text. Do NOT assert directly on geometry string content.

--- a/.ai-tools/rules/testing-and-iteration.md
+++ b/.ai-tools/rules/testing-and-iteration.md
@@ -58,7 +58,7 @@ instead of running the full integration test suite.
 
 Integration tests create tables with raw SQL (e.g., `CREATE TABLE ... (col VECTOR(3))`) and test PHP↔DB value conversion. They **never call `getSQLDeclaration()`**. Schema generation bugs — where a type emits `VECTOR` instead of `VECTOR(1024)` — are completely invisible to them.
 
-**Every DBAL type that maps to a parameterised PostgreSQL type must override `getSQLDeclaration()` and have unit tests for it.**
+**Every DBAL type that maps to a parameterised PostgreSQL type must provide a proper SQL declaration and have unit tests for it.**
 
 Common PostgreSQL parameterisation patterns:
 
@@ -69,7 +69,8 @@ Common PostgreSQL parameterisation patterns:
 | `TYPE(p)` — fractional-second precision | `TIMESTAMP(p)`, `TIMESTAMPTZ(p)`, `TIME(p)` |
 | `TYPE(subtype, srid)` — PostGIS | `GEOMETRY(type, srid)`, `GEOGRAPHY(type, srid)` |
 
-For `TYPE(n)` cases use the existing `LengthAwareSQLDeclarationTrait` (`src/.../Types/Traits/`) via `fieldDeclaration['length']`. For other parameterisations write a custom override reading the relevant `$fieldDeclaration` keys (`'precision'`, `'scale'`, `'srid'`, etc.).
+- **`TYPE(n)` cases**: use `LengthAwareSQLDeclarationTrait` (`src/.../Types/Traits/`) — it reads `fieldDeclaration['length']` and fulfils the override requirement without writing the method manually.
+- **Other parameterisations** (precision/scale, SRID, etc.): override `getSQLDeclaration()` directly and read the appropriate `$fieldDeclaration` keys (`'precision'`, `'scale'`, `'srid'`, etc.).
 
 Required unit tests for any override:
 1. No parameters → bare type name

--- a/.claude/commands/new-dbal-type.md
+++ b/.claude/commands/new-dbal-type.md
@@ -57,6 +57,8 @@ Both unit AND integration tests are **required** for every new type. Before writ
 
 Cover: type name, null handling, valid round-trips (data provider), invalid types, invalid formats. Array types also: `isValidArrayItemForDatabase()`, `transformArrayItemForPHP()`.
 
+If the PostgreSQL type accepts parameters (length, dimensions, precision, scale, SRID, etc.) also test `getSQLDeclaration()`: once with no parameters (bare type name) and once with parameters (e.g. `VECTOR(1024)`). Integration tests never call `getSQLDeclaration()` — without these unit tests schema generation bugs are invisible. For `TYPE(n)` types use `LengthAwareSQLDeclarationTrait`; other parameterisations need a custom override.
+
 Reference by group: `XmlTest`/`XmlArrayTest` (string-based), `MoneyTest`/`MoneyArrayTest`, `MacaddrTest`/`MacaddrArrayTest` (network), `PointTest`/`PointArrayTest` (geometric), `BaseRangeTestCase` (range), `BaseFloatArrayTestCase`/`BaseIntegerArrayTestCase` (numeric arrays).
 
 ### Integration tests → `tests/Integration/.../Types/`

--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -82,9 +82,9 @@
 | xml | xml | `MartinGeorgiev\Doctrine\DBAL\Types\Xml` |
 | xml[] | _xml | `MartinGeorgiev\Doctrine\DBAL\Types\XmlArray` |
 |---|---|---|
-| halfvec | halfvec | `MartinGeorgiev\Doctrine\DBAL\Types\Halfvec` (see [note](#pgvector-types) |
-| sparsevec | sparsevec | `MartinGeorgiev\Doctrine\DBAL\Types\Sparsevec` (see [note](#pgvector-types) |
-| vector | vector | `MartinGeorgiev\Doctrine\DBAL\Types\Vector` (see [note](#pgvector-types) |
+| halfvec | halfvec | `MartinGeorgiev\Doctrine\DBAL\Types\Halfvec` (see [note](#pgvector-types)) |
+| sparsevec | sparsevec | `MartinGeorgiev\Doctrine\DBAL\Types\Sparsevec` (see [note](#pgvector-types)) |
+| vector | vector | `MartinGeorgiev\Doctrine\DBAL\Types\Vector` (see [note](#pgvector-types)) |
 
 ## pgvector Types
 

--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -82,9 +82,36 @@
 | xml | xml | `MartinGeorgiev\Doctrine\DBAL\Types\Xml` |
 | xml[] | _xml | `MartinGeorgiev\Doctrine\DBAL\Types\XmlArray` |
 |---|---|---|
-| halfvec | halfvec | `MartinGeorgiev\Doctrine\DBAL\Types\Halfvec` |
-| sparsevec | sparsevec | `MartinGeorgiev\Doctrine\DBAL\Types\Sparsevec` |
-| vector | vector | `MartinGeorgiev\Doctrine\DBAL\Types\Vector` |
+| halfvec | halfvec | `MartinGeorgiev\Doctrine\DBAL\Types\Halfvec` (see [note](#pgvector-types) |
+| sparsevec | sparsevec | `MartinGeorgiev\Doctrine\DBAL\Types\Sparsevec` (see [note](#pgvector-types) |
+| vector | vector | `MartinGeorgiev\Doctrine\DBAL\Types\Vector` (see [note](#pgvector-types) |
+
+## pgvector Types
+
+The `vector`, `halfvec`, and `sparsevec` types use the `length` column option to specify the number of dimensions:
+
+```php
+use Doctrine\ORM\Mapping as ORM;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Sparsevec;
+
+#[ORM\Entity]
+class Embedding
+{
+    // VECTOR(1536) — fixed 1536-dimensional float vector
+    #[ORM\Column(type: 'vector', length: 1536)]
+    private array $embedding;
+
+    // HALFVEC(1024) — half-precision float vector
+    #[ORM\Column(type: 'halfvec', length: 1024)]
+    private array $smallEmbedding;
+
+    // SPARSEVEC(4096) — sparse vector with up to 4096 dimensions
+    #[ORM\Column(type: 'sparsevec', length: 4096)]
+    private Sparsevec $sparseEmbedding;
+}
+```
+
+**Important:** Omitting `length` produces a dimensionless column (`VECTOR` with no size), which is valid DDL but cannot be indexed with HNSW or IVFFlat indexes. Always specify `length` for production use.
 
 ---
 

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseVector.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseVector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\LengthAwareSQLDeclarationTrait;
 
 /**
  * Shared implementation for pgvector dense float vector types (VECTOR, HALFVEC).
@@ -16,6 +17,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 abstract class BaseVector extends BaseType
 {
+    use LengthAwareSQLDeclarationTrait;
+
     abstract protected function throwInvalidTypeForDatabase(mixed $value): never;
 
     abstract protected function throwInvalidItemTypeForDatabase(mixed $value): never;

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseVector.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseVector.php
@@ -10,6 +10,9 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Traits\LengthAwareSQLDeclarationTrait;
 /**
  * Shared implementation for pgvector dense float vector types (VECTOR, HALFVEC).
  *
+ * Use the `length` column option to specify the number of dimensions (e.g. `length: 1024`).
+ * Omitting `length` produces a dimensionless column, which is valid DDL but cannot be indexed.
+ *
  * @see https://github.com/pgvector/pgvector
  * @since 4.4
  *

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Bit.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Bit.php
@@ -9,6 +9,7 @@ use MartinGeorgiev\Doctrine\DBAL\Type;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBitForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBitForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Traits\BitValidationTrait;
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\LengthAwareSQLDeclarationTrait;
 
 /**
  * Implementation of PostgreSQL BIT data type.
@@ -21,22 +22,12 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Traits\BitValidationTrait;
 final class Bit extends BaseType
 {
     use BitValidationTrait;
+    use LengthAwareSQLDeclarationTrait;
 
     /**
      * @var string
      */
     protected const TYPE_NAME = Type::BIT;
-
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
-    {
-        $length = $fieldDeclaration['length'] ?? null;
-
-        if (\is_int($length)) {
-            return \sprintf('%s(%d)', \strtoupper(self::TYPE_NAME), $length);
-        }
-
-        return \strtoupper(self::TYPE_NAME);
-    }
 
     public function convertToPHPValue($value, AbstractPlatform $platform): ?string
     {

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BitVarying.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BitVarying.php
@@ -9,6 +9,7 @@ use MartinGeorgiev\Doctrine\DBAL\Type;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBitVaryingForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBitVaryingForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Traits\BitValidationTrait;
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\LengthAwareSQLDeclarationTrait;
 
 /**
  * Implementation of PostgreSQL BIT VARYING data type.
@@ -21,22 +22,12 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Traits\BitValidationTrait;
 final class BitVarying extends BaseType
 {
     use BitValidationTrait;
+    use LengthAwareSQLDeclarationTrait;
 
     /**
      * @var string
      */
     protected const TYPE_NAME = Type::BIT_VARYING;
-
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
-    {
-        $length = $fieldDeclaration['length'] ?? null;
-
-        if (\is_int($length)) {
-            return \sprintf('%s(%d)', \strtoupper(self::TYPE_NAME), $length);
-        }
-
-        return \strtoupper(self::TYPE_NAME);
-    }
 
     public function convertToPHPValue($value, AbstractPlatform $platform): ?string
     {

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Sparsevec.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Sparsevec.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use MartinGeorgiev\Doctrine\DBAL\Type;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidSparsevecForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidSparsevecForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\LengthAwareSQLDeclarationTrait;
 use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Sparsevec as SparsevecValueObject;
 
 /**
@@ -22,6 +23,8 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Sparsevec as SparsevecValueOb
  */
 class Sparsevec extends BaseType
 {
+    use LengthAwareSQLDeclarationTrait;
+
     /**
      * @var string
      */

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Sparsevec.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Sparsevec.php
@@ -15,6 +15,8 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Sparsevec as SparsevecValueOb
  * Implementation of the pgvector SPARSEVEC data type.
  *
  * Stores a sparse vector using the format `{index:value,...}/dimensions`.
+ * Use the `length` column option to specify the number of dimensions (e.g. `length: 1024`).
+ * Omitting `length` produces a dimensionless column, which is valid DDL but cannot be indexed.
  *
  * @see https://github.com/pgvector/pgvector
  * @since 4.4

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LengthAwareSQLDeclarationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LengthAwareSQLDeclarationTrait.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * Adds length-aware SQL declaration for types that support a dimension/length parameter.
- * Generates `TYPE(n)` when `fieldDeclaration['length']` is set, otherwise bare `TYPE`.
+ * Generates `TYPE(n)` when `fieldDeclaration['length']` is a positive integer, otherwise bare `TYPE`.
  */
 trait LengthAwareSQLDeclarationTrait
 {
@@ -16,7 +16,7 @@ trait LengthAwareSQLDeclarationTrait
     {
         $length = $fieldDeclaration['length'] ?? null;
 
-        if (\is_int($length)) {
+        if (\is_int($length) && $length > 0) {
             return \sprintf('%s(%d)', \strtoupper(static::TYPE_NAME), $length);
         }
 

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LengthAwareSQLDeclarationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LengthAwareSQLDeclarationTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Traits;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * Adds length-aware SQL declaration for types that support a dimension/length parameter.
+ * Generates `TYPE(n)` when `fieldDeclaration['length']` is set, otherwise bare `TYPE`.
+ */
+trait LengthAwareSQLDeclarationTrait
+{
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        $length = $fieldDeclaration['length'] ?? null;
+
+        if (\is_int($length)) {
+            return \sprintf('%s(%d)', \strtoupper(static::TYPE_NAME), $length);
+        }
+
+        return \strtoupper(static::TYPE_NAME);
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseVectorTypeTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseVectorTypeTestCase.php
@@ -71,6 +71,9 @@ abstract class BaseVectorTypeTestCase extends TestCase
         ];
     }
 
+    /**
+     * @param array<string, mixed> $fieldDeclaration
+     */
     #[DataProvider('provideFieldDeclarationsReturningBareType')]
     #[Test]
     public function returns_bare_type_for_invalid_or_missing_length(array $fieldDeclaration): void

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseVectorTypeTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseVectorTypeTestCase.php
@@ -49,19 +49,47 @@ abstract class BaseVectorTypeTestCase extends TestCase
         $this->assertSame($this->getExpectedTypeName(), $this->fixture->getName());
     }
 
+    #[DataProvider('provideFieldDeclarationsWithDimensions')]
     #[Test]
-    public function returns_type_without_length_by_default(): void
-    {
-        $this->assertSame($this->getExpectedSQLTypeName(), $this->fixture->getSQLDeclaration([], $this->platform));
-    }
-
-    #[Test]
-    public function returns_type_with_length_when_specified(): void
+    public function returns_type_with_dimensions_when_positive_length_specified(int $length): void
     {
         $this->assertSame(
-            $this->getExpectedSQLTypeName().'(1024)',
-            $this->fixture->getSQLDeclaration(['length' => 1024], $this->platform),
+            $this->getExpectedSQLTypeName().'('.$length.')',
+            $this->fixture->getSQLDeclaration(['length' => $length], $this->platform),
         );
+    }
+
+    /**
+     * @return array<string, array{int}>
+     */
+    public static function provideFieldDeclarationsWithDimensions(): array
+    {
+        return [
+            '1 dimension' => [1],
+            '3 dimensions' => [3],
+            '1024 dimensions' => [1024],
+        ];
+    }
+
+    #[DataProvider('provideFieldDeclarationsReturningBareType')]
+    #[Test]
+    public function returns_bare_type_for_invalid_or_missing_length(array $fieldDeclaration): void
+    {
+        $this->assertSame($this->getExpectedSQLTypeName(), $this->fixture->getSQLDeclaration($fieldDeclaration, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{array<string, mixed>}>
+     */
+    public static function provideFieldDeclarationsReturningBareType(): array
+    {
+        return [
+            'no length key' => [[]],
+            'null length' => [['length' => null]],
+            'non-integer length' => [['length' => 'abc']],
+            'zero length' => [['length' => 0]],
+            'negative length' => [['length' => -1]],
+        ];
     }
 
     #[DataProvider('provideValidPHPToDatabase')]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseVectorTypeTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseVectorTypeTestCase.php
@@ -23,6 +23,8 @@ abstract class BaseVectorTypeTestCase extends TestCase
 
     abstract protected function getExpectedTypeName(): string;
 
+    abstract protected function getExpectedSQLTypeName(): string;
+
     abstract protected function createFixture(): BaseType;
 
     /**
@@ -45,6 +47,21 @@ abstract class BaseVectorTypeTestCase extends TestCase
     public function has_name(): void
     {
         $this->assertSame($this->getExpectedTypeName(), $this->fixture->getName());
+    }
+
+    #[Test]
+    public function returns_type_without_length_by_default(): void
+    {
+        $this->assertSame($this->getExpectedSQLTypeName(), $this->fixture->getSQLDeclaration([], $this->platform));
+    }
+
+    #[Test]
+    public function returns_type_with_length_when_specified(): void
+    {
+        $this->assertSame(
+            $this->getExpectedSQLTypeName().'(1024)',
+            $this->fixture->getSQLDeclaration(['length' => 1024], $this->platform),
+        );
     }
 
     #[DataProvider('provideValidPHPToDatabase')]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/HalfvecTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/HalfvecTest.php
@@ -15,6 +15,11 @@ final class HalfvecTest extends BaseVectorTypeTestCase
         return 'halfvec';
     }
 
+    protected function getExpectedSQLTypeName(): string
+    {
+        return 'HALFVEC';
+    }
+
     protected function createFixture(): Halfvec
     {
         return new Halfvec();

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/SparsevecTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/SparsevecTest.php
@@ -54,6 +54,9 @@ final class SparsevecTest extends TestCase
         ];
     }
 
+    /**
+     * @param array<string, mixed> $fieldDeclaration
+     */
     #[DataProvider('provideFieldDeclarationsReturningBareType')]
     #[Test]
     public function returns_bare_type_for_invalid_or_missing_length(array $fieldDeclaration): void

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/SparsevecTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/SparsevecTest.php
@@ -36,6 +36,18 @@ final class SparsevecTest extends TestCase
     }
 
     #[Test]
+    public function returns_type_without_length_by_default(): void
+    {
+        $this->assertSame('SPARSEVEC', $this->fixture->getSQLDeclaration([], $this->platform));
+    }
+
+    #[Test]
+    public function returns_type_with_length_when_specified(): void
+    {
+        $this->assertSame('SPARSEVEC(1024)', $this->fixture->getSQLDeclaration(['length' => 1024], $this->platform));
+    }
+
+    #[Test]
     public function can_transform_null_to_database_value(): void
     {
         $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/SparsevecTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/SparsevecTest.php
@@ -35,16 +35,44 @@ final class SparsevecTest extends TestCase
         $this->assertSame('sparsevec', $this->fixture->getName());
     }
 
+    #[DataProvider('provideFieldDeclarationsWithDimensions')]
     #[Test]
-    public function returns_type_without_length_by_default(): void
+    public function returns_type_with_dimensions_when_positive_length_specified(int $length): void
     {
-        $this->assertSame('SPARSEVEC', $this->fixture->getSQLDeclaration([], $this->platform));
+        $this->assertSame(\sprintf('SPARSEVEC(%d)', $length), $this->fixture->getSQLDeclaration(['length' => $length], $this->platform));
     }
 
-    #[Test]
-    public function returns_type_with_length_when_specified(): void
+    /**
+     * @return array<string, array{int}>
+     */
+    public static function provideFieldDeclarationsWithDimensions(): array
     {
-        $this->assertSame('SPARSEVEC(1024)', $this->fixture->getSQLDeclaration(['length' => 1024], $this->platform));
+        return [
+            '1 dimension' => [1],
+            '3 dimensions' => [3],
+            '1024 dimensions' => [1024],
+        ];
+    }
+
+    #[DataProvider('provideFieldDeclarationsReturningBareType')]
+    #[Test]
+    public function returns_bare_type_for_invalid_or_missing_length(array $fieldDeclaration): void
+    {
+        $this->assertSame('SPARSEVEC', $this->fixture->getSQLDeclaration($fieldDeclaration, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{array<string, mixed>}>
+     */
+    public static function provideFieldDeclarationsReturningBareType(): array
+    {
+        return [
+            'no length key' => [[]],
+            'null length' => [['length' => null]],
+            'non-integer length' => [['length' => 'abc']],
+            'zero length' => [['length' => 0]],
+            'negative length' => [['length' => -1]],
+        ];
     }
 
     #[Test]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/VectorTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/VectorTest.php
@@ -15,6 +15,11 @@ final class VectorTest extends BaseVectorTypeTestCase
         return 'vector';
     }
 
+    protected function getExpectedSQLTypeName(): string
+    {
+        return 'VECTOR';
+    }
+
     protected function createFixture(): Vector
     {
         return new Vector();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized SQL declaration behavior for length-parameterized types so TYPE and TYPE(n) are generated consistently.

* **Tests**
  * Added unit tests validating SQL declaration for positive length and for missing/invalid length across vector-like types.

* **Documentation**
  * Clarified testing requirements and contribution guidance; documented length column option, behavior when omitted, and indexing implications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->