### PR TITLE
feat: add support for `bytea` DBAL type and its array variation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ $query = $em->createQuery('
   - Boolean arrays (`bool[]`)
   - Date arrays (`date[]`, `timestamp[]`, `timestamptz[]`)
   - JSONB arrays (`jsonb[]`)
+- **Binary Types**
+  - Raw binary data (`bytea`, `bytea[]`)
 - **Bit String Types**
   - Fixed-length bit strings (`bit`, `bit[]`)
   - Variable-length bit strings (`bit varying`, `bit varying[]`)

--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -2,6 +2,9 @@
 
 | PostgreSQL type in practical use | PostgreSQL internal system catalogue name | Implemented by |
 |---|---|---|
+| bytea | bytea | `MartinGeorgiev\Doctrine\DBAL\Types\Bytea` |
+| bytea[] | _bytea | `MartinGeorgiev\Doctrine\DBAL\Types\ByteaArray` |
+|---|---|---|
 | bit | bit | `MartinGeorgiev\Doctrine\DBAL\Types\Bit` (see [note](#bit-string-types) |
 | bit[] | _bit | `MartinGeorgiev\Doctrine\DBAL\Types\BitArray` |
 | bit varying | varbit | `MartinGeorgiev\Doctrine\DBAL\Types\BitVarying` (see [note](#bit-string-types) |

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -11,6 +11,10 @@ Register the DBAL types you plan to use. The **full set** of available types can
 
 use Doctrine\DBAL\Types\Type;
 
+// Binary types
+Type::addType('bytea', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Bytea");
+Type::addType('bytea[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\ByteaArray");
+
 // Bit types
 Type::addType('bit', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Bit");
 Type::addType('bit[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\BitArray");

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -32,6 +32,11 @@ return [
             // ... other configuration
 
             'type_mappings' => [
+                // Binary type mappings
+                'bytea' => 'bytea',
+                'bytea[]' => 'bytea[]',
+                '_bytea' => 'bytea[]',
+
                 // Bit type mappings
                 'bit' => 'bit',
                 'bit[]' => 'bit[]',
@@ -168,6 +173,10 @@ return [
     ],
 
     'custom_types' => [
+        // Binary types
+        'bytea' => MartinGeorgiev\Doctrine\DBAL\Types\Bytea::class,
+        'bytea[]' => MartinGeorgiev\Doctrine\DBAL\Types\ByteaArray::class,
+
         // Bit types
         'bit' => MartinGeorgiev\Doctrine\DBAL\Types\Bit::class,
         'bit[]' => MartinGeorgiev\Doctrine\DBAL\Types\BitArray::class,

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -11,6 +11,10 @@ Register the DBAL types you plan to use. The full set of available types can be 
 doctrine:
     dbal:
         types:
+            # Binary types
+            bytea: MartinGeorgiev\Doctrine\DBAL\Types\Bytea
+            'bytea[]': MartinGeorgiev\Doctrine\DBAL\Types\ByteaArray
+
             # Bit types
             bit: MartinGeorgiev\Doctrine\DBAL\Types\Bit
             'bit[]': MartinGeorgiev\Doctrine\DBAL\Types\BitArray
@@ -122,6 +126,11 @@ doctrine:
         connections:
             default:
                 mapping_types:
+                    # Binary type mappings
+                    bytea: !php/const MartinGeorgiev\Doctrine\DBAL\Type::BYTEA
+                    'bytea[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::BYTEA_ARRAY
+                    _bytea: !php/const MartinGeorgiev\Doctrine\DBAL\Type::BYTEA_ARRAY
+
                     # Bit type mappings
                     bit: !php/const MartinGeorgiev\Doctrine\DBAL\Type::BIT
                     'bit[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::BIT_ARRAY

--- a/src/MartinGeorgiev/Doctrine/DBAL/Type.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Type.php
@@ -49,6 +49,16 @@ final class Type
     /**
      * @var string
      */
+    public const BYTEA = 'bytea';
+
+    /**
+     * @var string
+     */
+    public const BYTEA_ARRAY = 'bytea[]';
+
+    /**
+     * @var string
+     */
     public const CIDR = 'cidr';
 
     /**

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Bytea.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Bytea.php
@@ -54,12 +54,16 @@ final class Bytea extends BaseType
             throw InvalidBytesForPHPException::forInvalidType($value);
         }
 
-        if (\str_starts_with($value, '\\x')) {
-            $decoded = \hex2bin(\substr($value, 2));
-
-            return $decoded !== false ? $decoded : $value;
+        if (!\str_starts_with($value, '\\x')) {
+            throw InvalidBytesForPHPException::forInvalidFormat($value);
         }
 
-        return $value;
+        $decoded = @\hex2bin(\substr($value, 2));
+
+        if ($decoded === false) {
+            throw InvalidBytesForPHPException::forInvalidFormat($value);
+        }
+
+        return $decoded;
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Bytea.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Bytea.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBytesForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBytesForPHPException;
+
+/**
+ * Implementation of PostgreSQL bytea binary data type.
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-binary.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class Bytea extends BaseType
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::BYTEA;
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidBytesForDatabaseException::forInvalidType($value);
+        }
+
+        return '\\x'.\bin2hex($value);
+    }
+
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (\is_resource($value)) {
+            \rewind($value);
+            $content = \stream_get_contents($value);
+
+            return $content !== false && $content !== '' ? $content : null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidBytesForPHPException::forInvalidType($value);
+        }
+
+        if (\str_starts_with($value, '\\x')) {
+            $decoded = \hex2bin(\substr($value, 2));
+
+            return $decoded !== false ? $decoded : $value;
+        }
+
+        return $value;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ByteaArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ByteaArray.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBytesArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBytesArrayItemForPHPException;
+
+/**
+ * Implementation of PostgreSQL bytea[] data type.
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-binary.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class ByteaArray extends BaseStringArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::BYTEA_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        return $item === null || \is_string($item);
+    }
+
+    protected function transformArrayItemForPostgres(mixed $item): string
+    {
+        if ($item === null) {
+            return 'NULL';
+        }
+
+        \assert(\is_string($item));
+
+        return '"\\\\x'.\bin2hex($item).'"';
+    }
+
+    public function transformArrayItemForPHP(mixed $item): ?string
+    {
+        $result = parent::transformArrayItemForPHP($item);
+
+        if ($result === null) {
+            return null;
+        }
+
+        if (\str_starts_with($result, '\\x')) {
+            $decoded = \hex2bin(\substr($result, 2));
+
+            return $decoded !== false ? $decoded : $result;
+        }
+
+        return $result;
+    }
+
+    protected function createInvalidTypeExceptionForPHP(mixed $item): InvalidBytesArrayItemForPHPException
+    {
+        return InvalidBytesArrayItemForPHPException::forInvalidType($item);
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidBytesArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidBytesArrayItemForDatabaseException::forInvalidFormat($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ByteaArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ByteaArray.php
@@ -47,13 +47,17 @@ class ByteaArray extends BaseStringArray
             return null;
         }
 
-        if (\str_starts_with($result, '\\x')) {
-            $decoded = \hex2bin(\substr($result, 2));
-
-            return $decoded !== false ? $decoded : $result;
+        if (!\str_starts_with($result, '\\x')) {
+            throw InvalidBytesArrayItemForPHPException::forInvalidFormat($result);
         }
 
-        return $result;
+        $decoded = @\hex2bin(\substr($result, 2));
+
+        if ($decoded === false) {
+            throw InvalidBytesArrayItemForPHPException::forInvalidFormat($result);
+        }
+
+        return $decoded;
     }
 
     protected function createInvalidTypeExceptionForPHP(mixed $item): InvalidBytesArrayItemForPHPException

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidBytesArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid binary string in array: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesArrayItemForPHPException.php
@@ -27,4 +27,9 @@ class InvalidBytesArrayItemForPHPException extends ConversionException
     {
         return self::create('Value must be an array, %s given', $value);
     }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Array values must be hex-encoded bytea strings starting with \\x, %s given', $value);
+    }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesArrayItemForPHPException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidBytesArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array values must be strings, %s given', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidBytesForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Database value must be a string, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesForPHPException.php
@@ -22,4 +22,9 @@ class InvalidBytesForPHPException extends ConversionException
     {
         return self::create('Value must be a string, %s given', $value);
     }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Value must be a hex-encoded bytea string starting with \\x, %s given', $value);
+    }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBytesForPHPException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidBytesForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Value must be a string, %s given', $value);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ByteaArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ByteaArrayTypeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+class ByteaArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'bytea[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, string|null>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'array of ascii strings' => [['hello', 'world']],
+            'array with null item' => [['hello', null, 'world']],
+            'array with binary data' => [["binary\x00data", "\xFF\xFE"]],
+            'array with empty string' => [['']],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ByteaTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ByteaTypeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+class ByteaTypeTest extends ScalarTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'bytea';
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_from_php_value(string $testValue): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $testValue);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'simple ascii string' => ['hello world'],
+            'binary with null byte and high byte' => ["binary\x00data\xFF"],
+            'deadbeef bytes' => ["\xDE\xAD\xBE\xEF"],
+        ];
+    }
+
+    #[Test]
+    public function can_handle_empty_bytea_as_null(): void
+    {
+        $this->runDbalBindingRoundTripExpectingDifferentRetrievedValue(
+            $this->getTypeName(),
+            $this->getPostgresTypeName(),
+            '',
+            null
+        );
+    }
+
+    #[Test]
+    public function can_read_raw_hex_bytea_inserted_directly(): void
+    {
+        $columnType = $this->getPostgresTypeName();
+        [$tableName, $columnName] = $this->prepareTestTable($columnType);
+
+        try {
+            $this->connection->executeStatement(
+                \sprintf(
+                    "INSERT INTO %s.%s (\"%s\") VALUES ('\\x68656c6c6f')",
+                    self::DATABASE_SCHEMA,
+                    $tableName,
+                    $columnName
+                )
+            );
+
+            $retrieved = $this->fetchConvertedValue($this->getTypeName(), $tableName, $columnName);
+            $this->assertSame('hello', $retrieved);
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ByteaTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ByteaTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
+use Doctrine\DBAL\ParameterType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -56,11 +57,13 @@ class ByteaTypeTest extends ScalarTypeTestCase
         try {
             $this->connection->executeStatement(
                 \sprintf(
-                    "INSERT INTO %s.%s (\"%s\") VALUES ('\\x68656c6c6f')",
+                    'INSERT INTO %s.%s ("%s") VALUES (?)',
                     self::DATABASE_SCHEMA,
                     $tableName,
                     $columnName
-                )
+                ),
+                [\hex2bin('68656c6c6f')],
+                [ParameterType::BINARY]
             );
 
             $retrieved = $this->fetchConvertedValue($this->getTypeName(), $tableName, $columnName);

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TestCase.php
@@ -93,7 +93,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function runDbalBindingRoundTripExpectingDifferentRetrievedValue(string $typeName, string $columnType, mixed $inputValue, mixed $expectedValue): void
     {
-        $this->assertNotEquals($inputValue, $expectedValue);
+        $this->assertNotSame($inputValue, $expectedValue);
 
         [$tableName, $columnName] = $this->prepareTestTable($columnType);
 

--- a/tests/Integration/MartinGeorgiev/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/TestCase.php
@@ -21,6 +21,8 @@ use MartinGeorgiev\Doctrine\DBAL\Types\BitVaryingArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\BooleanArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Box;
 use MartinGeorgiev\Doctrine\DBAL\Types\BoxArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Bytea;
+use MartinGeorgiev\Doctrine\DBAL\Types\ByteaArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Cidr;
 use MartinGeorgiev\Doctrine\DBAL\Types\CidrArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Circle;
@@ -266,6 +268,8 @@ abstract class TestCase extends BaseTestCase
             'bool[]' => BooleanArray::class,
             'box' => Box::class,
             'box[]' => BoxArray::class,
+            'bytea' => Bytea::class,
+            'bytea[]' => ByteaArray::class,
             'cidr' => Cidr::class,
             'circle' => Circle::class,
             'circle[]' => CircleArray::class,

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ByteaArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ByteaArrayTest.php
@@ -177,4 +177,24 @@ class ByteaArrayTest extends TestCase
             'boolean' => [true],
         ];
     }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(string $postgresValue): void
+    {
+        $this->expectException(InvalidBytesArrayItemForPHPException::class);
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'non-string item' => ['{42}'],
+            'without hex prefix' => ['{"hello"}'],
+            'invalid hex content' => ['{"\\\\xZZZZ"}'],
+        ];
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ByteaArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ByteaArrayTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\ByteaArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBytesArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBytesArrayItemForPHPException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ByteaArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private ByteaArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new ByteaArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('bytea[]', $this->fixture->getName());
+    }
+
+    /**
+     * @param array<int, string|null>|null $phpValue
+     */
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    /**
+     * @param array<int, string|null>|null $phpValue
+     */
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array<int, string|null>|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'simple ascii string' => [
+                'phpValue' => ['hello'],
+                'postgresValue' => '{"\\\\x68656c6c6f"}',
+            ],
+            'multiple strings' => [
+                'phpValue' => ['hello', 'world'],
+                'postgresValue' => '{"\\\\x68656c6c6f","\\\\x776f726c64"}',
+            ],
+            'null item in array' => [
+                'phpValue' => ['hello', null, 'world'],
+                'postgresValue' => '{"\\\\x68656c6c6f",NULL,"\\\\x776f726c64"}',
+            ],
+            'empty string item' => [
+                'phpValue' => [''],
+                'postgresValue' => '{"\\\\x"}',
+            ],
+            'binary data with null byte and high byte' => [
+                'phpValue' => ["\x00\xFF"],
+                'postgresValue' => '{"\\\\x00ff"}',
+            ],
+            'mixed binary and ascii' => [
+                'phpValue' => ['hello', "\xDE\xAD\xBE\xEF"],
+                'postgresValue' => '{"\\\\x68656c6c6f","\\\\xdeadbeef"}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidBytesArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'integer item' => [[123]],
+            'float item' => [[3.14]],
+            'object item' => [[new \stdClass()]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidBytesArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+            'integer instead of array' => [42],
+        ];
+    }
+
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'ascii string' => ['binary string'],
+            'empty string' => [''],
+            'binary string with null byte' => ["\x00\xFF"],
+            'null value' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'integer' => [123],
+            'float' => [3.14],
+            'object' => [new \stdClass()],
+            'array' => [[]],
+            'boolean' => [true],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ByteaTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ByteaTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Bytea;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBytesForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBytesForPHPException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ByteaTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private Bytea $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new Bytea();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('bytea', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function converts_empty_string_from_database_to_null(): void
+    {
+        $this->assertNull($this->fixture->convertToPHPValue('', $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_from_php_value(?string $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_to_php_value(?string $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{phpValue: string|null, postgresValue: string|null}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'simple ascii string' => [
+                'phpValue' => 'hello',
+                'postgresValue' => '\\x68656c6c6f',
+            ],
+            'binary data with null byte and high byte' => [
+                'phpValue' => "\x00\xFF",
+                'postgresValue' => '\\x00ff',
+            ],
+            'deadbeef bytes' => [
+                'phpValue' => "\xDE\xAD\xBE\xEF",
+                'postgresValue' => '\\xdeadbeef',
+            ],
+            'single null byte' => [
+                'phpValue' => "\x00",
+                'postgresValue' => '\\x00',
+            ],
+        ];
+    }
+
+    #[Test]
+    public function converts_resource_to_binary_string(): void
+    {
+        $stream = \fopen('php://memory', 'r+');
+        \assert(\is_resource($stream));
+        \fwrite($stream, 'hello');
+        \rewind($stream);
+
+        $this->assertSame('hello', $this->fixture->convertToPHPValue($stream, $this->platform));
+
+        \fclose($stream);
+    }
+
+    #[Test]
+    public function converts_empty_resource_to_null(): void
+    {
+        $stream = \fopen('php://memory', 'r+');
+        \assert(\is_resource($stream));
+
+        $this->assertNull($this->fixture->convertToPHPValue($stream, $this->platform));
+
+        \fclose($stream);
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $value): void
+    {
+        $this->expectException(InvalidBytesForDatabaseException::class);
+
+        $this->fixture->convertToDatabaseValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'integer input' => [42],
+            'array input' => [['not', 'a', 'string']],
+            'object input' => [new \stdClass()],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(mixed $value): void
+    {
+        $this->expectException(InvalidBytesForPHPException::class);
+
+        $this->fixture->convertToPHPValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'integer input' => [42],
+            'float input' => [3.14],
+            'array input' => [['not', 'a', 'string']],
+            'object input' => [new \stdClass()],
+            'boolean input' => [true],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ByteaTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ByteaTest.php
@@ -148,6 +148,8 @@ class ByteaTest extends TestCase
             'array input' => [['not', 'a', 'string']],
             'object input' => [new \stdClass()],
             'boolean input' => [true],
+            'string without hex prefix' => ['hello'],
+            'string with invalid hex content' => ['\\xZZZZ'],
         ];
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for PostgreSQL binary types (bytea and bytea[]) with automatic encoding/decoding, stream support, and validation; empty binary values are treated as null.

* **Documentation**
  * README and integration guides (Doctrine, Laravel, Symfony) updated with examples and type mappings for the binary types.

* **Tests**
  * New unit and integration tests covering conversions, edge cases, and validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-georgiev/postgresql-for-doctrine/pull/630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->