### PR TITLE
feat: add support for multirange array DBAL types

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ $query = $em->createQuery('
   - Date and time ranges (`daterange`, `tsrange`, `tstzrange`)
   - Numeric ranges (`numrange`, `int4range`, `int8range`)
   - Multiranges (`nummultirange`, `int4multirange`, `int8multirange`)
+  - Multirange arrays (`datemultirange[]`, `int4multirange[]`, `int8multirange[]`, `nummultirange[]`, `tsmultirange[]`, `tstzmultirange[]`)
 - **Interval Types**
   - Time durations with `DateInterval` support (`interval`, `interval[]`)
 - **Text Search Types**

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ $query = $em->createQuery('
 - **Range Types**
   - Date and time ranges (`daterange`, `tsrange`, `tstzrange`)
   - Numeric ranges (`numrange`, `int4range`, `int8range`)
-  - Multiranges (`nummultirange`, `int4multirange`, `int8multirange`)
-  - Multirange arrays (`datemultirange[]`, `int4multirange[]`, `int8multirange[]`, `nummultirange[]`, `tsmultirange[]`, `tstzmultirange[]`)
+  - Multirange arrays (`datemultirange`, `datemultirange[]`, `int4multirange`, `int4multirange[]`, `int8multirange`, `int8multirange[]`, `nummultirange`, `nummultirange[]`, `tsmultirange`, `tsmultirange[]`, `tstzmultirange`, `tstzmultirange[]`)
 - **Interval Types**
   - Time durations with `DateInterval` support (`interval`, `interval[]`)
 - **Text Search Types**

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $query = $em->createQuery('
 - **Range Types**
   - Date and time ranges (`daterange`, `tsrange`, `tstzrange`)
   - Numeric ranges (`numrange`, `int4range`, `int8range`)
-  - Multirange arrays (`datemultirange`, `datemultirange[]`, `int4multirange`, `int4multirange[]`, `int8multirange`, `int8multirange[]`, `nummultirange`, `nummultirange[]`, `tsmultirange`, `tsmultirange[]`, `tstzmultirange`, `tstzmultirange[]`)
+  - Multiranges (`datemultirange`, `datemultirange[]`, `int4multirange`, `int4multirange[]`, `int8multirange`, `int8multirange[]`, `nummultirange`, `nummultirange[]`, `tsmultirange`, `tsmultirange[]`, `tstzmultirange`, `tstzmultirange[]`)
 - **Interval Types**
   - Time durations with `DateInterval` support (`interval`, `interval[]`)
 - **Text Search Types**

--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -56,6 +56,13 @@
 | tsmultirange | tsmultirange | `MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange` |
 | tstzmultirange | tstzmultirange | `MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirange` |
 |---|---|---|
+| datemultirange[] | _datemultirange | `MartinGeorgiev\Doctrine\DBAL\Types\DateMultirangeArray` |
+| int4multirange[] | _int4multirange | `MartinGeorgiev\Doctrine\DBAL\Types\Int4MultirangeArray` |
+| int8multirange[] | _int8multirange | `MartinGeorgiev\Doctrine\DBAL\Types\Int8MultirangeArray` |
+| nummultirange[] | _nummultirange | `MartinGeorgiev\Doctrine\DBAL\Types\NumMultirangeArray` |
+| tsmultirange[] | _tsmultirange | `MartinGeorgiev\Doctrine\DBAL\Types\TsMultirangeArray` |
+| tstzmultirange[] | _tstzmultirange | `MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirangeArray` |
+|---|---|---|
 | box | box | `MartinGeorgiev\Doctrine\DBAL\Types\Box` |
 | box[] | _box | `MartinGeorgiev\Doctrine\DBAL\Types\BoxArray` |
 | circle | circle | `MartinGeorgiev\Doctrine\DBAL\Types\Circle` |

--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -50,17 +50,16 @@
 | tstzrange | tstzrange | `MartinGeorgiev\Doctrine\DBAL\Types\TstzRange` |
 |---|---|---|
 | datemultirange | datemultirange | `MartinGeorgiev\Doctrine\DBAL\Types\DateMultirange` |
-| int4multirange | int4multirange | `MartinGeorgiev\Doctrine\DBAL\Types\Int4Multirange` |
-| int8multirange | int8multirange | `MartinGeorgiev\Doctrine\DBAL\Types\Int8Multirange` |
-| nummultirange | nummultirange | `MartinGeorgiev\Doctrine\DBAL\Types\NumMultirange` |
-| tsmultirange | tsmultirange | `MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange` |
-| tstzmultirange | tstzmultirange | `MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirange` |
-|---|---|---|
 | datemultirange[] | _datemultirange | `MartinGeorgiev\Doctrine\DBAL\Types\DateMultirangeArray` |
+| int4multirange | int4multirange | `MartinGeorgiev\Doctrine\DBAL\Types\Int4Multirange` |
 | int4multirange[] | _int4multirange | `MartinGeorgiev\Doctrine\DBAL\Types\Int4MultirangeArray` |
+| int8multirange | int8multirange | `MartinGeorgiev\Doctrine\DBAL\Types\Int8Multirange` |
 | int8multirange[] | _int8multirange | `MartinGeorgiev\Doctrine\DBAL\Types\Int8MultirangeArray` |
+| nummultirange | nummultirange | `MartinGeorgiev\Doctrine\DBAL\Types\NumMultirange` |
 | nummultirange[] | _nummultirange | `MartinGeorgiev\Doctrine\DBAL\Types\NumMultirangeArray` |
+| tsmultirange | tsmultirange | `MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange` |
 | tsmultirange[] | _tsmultirange | `MartinGeorgiev\Doctrine\DBAL\Types\TsMultirangeArray` |
+| tstzmultirange | tstzmultirange | `MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirange` |
 | tstzmultirange[] | _tstzmultirange | `MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirangeArray` |
 |---|---|---|
 | box | box | `MartinGeorgiev\Doctrine\DBAL\Types\Box` |

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -90,6 +90,14 @@ Type::addType('nummultirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\NumMultir
 Type::addType('tsmultirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TsMultirange");
 Type::addType('tstzmultirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TstzMultirange");
 
+// Multirange array types
+Type::addType('datemultirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\DateMultirangeArray");
+Type::addType('int4multirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Int4MultirangeArray");
+Type::addType('int8multirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Int8MultirangeArray");
+Type::addType('nummultirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\NumMultirangeArray");
+Type::addType('tsmultirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TsMultirangeArray");
+Type::addType('tstzmultirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TstzMultirangeArray");
+
 // Text search types
 Type::addType('tsquery', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Tsquery");
 Type::addType('tsquery[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TsqueryArray");
@@ -471,6 +479,20 @@ $platform->registerDoctrineTypeMapping('int8multirange', 'int8multirange');
 $platform->registerDoctrineTypeMapping('nummultirange', 'nummultirange');
 $platform->registerDoctrineTypeMapping('tsmultirange', 'tsmultirange');
 $platform->registerDoctrineTypeMapping('tstzmultirange', 'tstzmultirange');
+
+// Multirange array type mappings
+$platform->registerDoctrineTypeMapping('datemultirange[]', 'datemultirange[]');
+$platform->registerDoctrineTypeMapping('_datemultirange', 'datemultirange[]');
+$platform->registerDoctrineTypeMapping('int4multirange[]', 'int4multirange[]');
+$platform->registerDoctrineTypeMapping('_int4multirange', 'int4multirange[]');
+$platform->registerDoctrineTypeMapping('int8multirange[]', 'int8multirange[]');
+$platform->registerDoctrineTypeMapping('_int8multirange', 'int8multirange[]');
+$platform->registerDoctrineTypeMapping('nummultirange[]', 'nummultirange[]');
+$platform->registerDoctrineTypeMapping('_nummultirange', 'nummultirange[]');
+$platform->registerDoctrineTypeMapping('tsmultirange[]', 'tsmultirange[]');
+$platform->registerDoctrineTypeMapping('_tsmultirange', 'tsmultirange[]');
+$platform->registerDoctrineTypeMapping('tstzmultirange[]', 'tstzmultirange[]');
+$platform->registerDoctrineTypeMapping('_tstzmultirange', 'tstzmultirange[]');
 
 // Text search type mappings
 $platform->registerDoctrineTypeMapping('tsquery', 'tsquery');

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -84,18 +84,16 @@ Type::addType('tstzrange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TstzRange");
 
 // Multirange types
 Type::addType('datemultirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\DateMultirange");
-Type::addType('int4multirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Int4Multirange");
-Type::addType('int8multirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Int8Multirange");
-Type::addType('nummultirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\NumMultirange");
-Type::addType('tsmultirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TsMultirange");
-Type::addType('tstzmultirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TstzMultirange");
-
-// Multirange array types
 Type::addType('datemultirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\DateMultirangeArray");
+Type::addType('int4multirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Int4Multirange");
 Type::addType('int4multirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Int4MultirangeArray");
+Type::addType('int8multirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Int8Multirange");
 Type::addType('int8multirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Int8MultirangeArray");
+Type::addType('nummultirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\NumMultirange");
 Type::addType('nummultirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\NumMultirangeArray");
+Type::addType('tsmultirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TsMultirange");
 Type::addType('tsmultirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TsMultirangeArray");
+Type::addType('tstzmultirange', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TstzMultirange");
 Type::addType('tstzmultirange[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TstzMultirangeArray");
 
 // Text search types
@@ -474,23 +472,21 @@ $platform->registerDoctrineTypeMapping('tstzrange', 'tstzrange');
 
 // Multirange type mappings
 $platform->registerDoctrineTypeMapping('datemultirange', 'datemultirange');
-$platform->registerDoctrineTypeMapping('int4multirange', 'int4multirange');
-$platform->registerDoctrineTypeMapping('int8multirange', 'int8multirange');
-$platform->registerDoctrineTypeMapping('nummultirange', 'nummultirange');
-$platform->registerDoctrineTypeMapping('tsmultirange', 'tsmultirange');
-$platform->registerDoctrineTypeMapping('tstzmultirange', 'tstzmultirange');
-
-// Multirange array type mappings
-$platform->registerDoctrineTypeMapping('datemultirange[]', 'datemultirange[]');
 $platform->registerDoctrineTypeMapping('_datemultirange', 'datemultirange[]');
+$platform->registerDoctrineTypeMapping('datemultirange[]', 'datemultirange[]');
+$platform->registerDoctrineTypeMapping('int4multirange', 'int4multirange');
 $platform->registerDoctrineTypeMapping('int4multirange[]', 'int4multirange[]');
 $platform->registerDoctrineTypeMapping('_int4multirange', 'int4multirange[]');
+$platform->registerDoctrineTypeMapping('int8multirange', 'int8multirange');
 $platform->registerDoctrineTypeMapping('int8multirange[]', 'int8multirange[]');
 $platform->registerDoctrineTypeMapping('_int8multirange', 'int8multirange[]');
+$platform->registerDoctrineTypeMapping('nummultirange', 'nummultirange');
 $platform->registerDoctrineTypeMapping('nummultirange[]', 'nummultirange[]');
 $platform->registerDoctrineTypeMapping('_nummultirange', 'nummultirange[]');
+$platform->registerDoctrineTypeMapping('tsmultirange', 'tsmultirange');
 $platform->registerDoctrineTypeMapping('tsmultirange[]', 'tsmultirange[]');
 $platform->registerDoctrineTypeMapping('_tsmultirange', 'tsmultirange[]');
+$platform->registerDoctrineTypeMapping('tstzmultirange', 'tstzmultirange');
 $platform->registerDoctrineTypeMapping('tstzmultirange[]', 'tstzmultirange[]');
 $platform->registerDoctrineTypeMapping('_tstzmultirange', 'tstzmultirange[]');
 

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -141,6 +141,20 @@ return [
                 'tsmultirange' => 'tsmultirange',
                 'tstzmultirange' => 'tstzmultirange',
 
+                // Multirange array type mappings
+                'datemultirange[]' => 'datemultirange[]',
+                '_datemultirange' => 'datemultirange[]',
+                'int4multirange[]' => 'int4multirange[]',
+                '_int4multirange' => 'int4multirange[]',
+                'int8multirange[]' => 'int8multirange[]',
+                '_int8multirange' => 'int8multirange[]',
+                'nummultirange[]' => 'nummultirange[]',
+                '_nummultirange' => 'nummultirange[]',
+                'tsmultirange[]' => 'tsmultirange[]',
+                '_tsmultirange' => 'tsmultirange[]',
+                'tstzmultirange[]' => 'tstzmultirange[]',
+                '_tstzmultirange' => 'tstzmultirange[]',
+
                 // Text search type mappings
                 'tsquery' => 'tsquery',
                 'tsquery[]' => 'tsquery[]',
@@ -256,6 +270,14 @@ return [
         'nummultirange' => MartinGeorgiev\Doctrine\DBAL\Types\NumMultirange::class,
         'tsmultirange' => MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange::class,
         'tstzmultirange' => MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirange::class,
+
+        // Multirange array types
+        'datemultirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\DateMultirangeArray::class,
+        'int4multirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\Int4MultirangeArray::class,
+        'int8multirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\Int8MultirangeArray::class,
+        'nummultirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\NumMultirangeArray::class,
+        'tsmultirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\TsMultirangeArray::class,
+        'tstzmultirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirangeArray::class,
 
         // Text search types
         'tsquery' => MartinGeorgiev\Doctrine\DBAL\Types\Tsquery::class,

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -135,23 +135,21 @@ return [
 
                 // Multirange type mappings
                 'datemultirange' => 'datemultirange',
-                'int4multirange' => 'int4multirange',
-                'int8multirange' => 'int8multirange',
-                'nummultirange' => 'nummultirange',
-                'tsmultirange' => 'tsmultirange',
-                'tstzmultirange' => 'tstzmultirange',
-
-                // Multirange array type mappings
                 'datemultirange[]' => 'datemultirange[]',
                 '_datemultirange' => 'datemultirange[]',
+                'int4multirange' => 'int4multirange',
                 'int4multirange[]' => 'int4multirange[]',
                 '_int4multirange' => 'int4multirange[]',
+                'int8multirange' => 'int8multirange',
                 'int8multirange[]' => 'int8multirange[]',
                 '_int8multirange' => 'int8multirange[]',
+                'nummultirange' => 'nummultirange',
                 'nummultirange[]' => 'nummultirange[]',
                 '_nummultirange' => 'nummultirange[]',
+                'tsmultirange' => 'tsmultirange',
                 'tsmultirange[]' => 'tsmultirange[]',
                 '_tsmultirange' => 'tsmultirange[]',
+                'tstzmultirange' => 'tstzmultirange',
                 'tstzmultirange[]' => 'tstzmultirange[]',
                 '_tstzmultirange' => 'tstzmultirange[]',
 
@@ -265,18 +263,16 @@ return [
 
         // Multirange types
         'datemultirange' => MartinGeorgiev\Doctrine\DBAL\Types\DateMultirange::class,
-        'int4multirange' => MartinGeorgiev\Doctrine\DBAL\Types\Int4Multirange::class,
-        'int8multirange' => MartinGeorgiev\Doctrine\DBAL\Types\Int8Multirange::class,
-        'nummultirange' => MartinGeorgiev\Doctrine\DBAL\Types\NumMultirange::class,
-        'tsmultirange' => MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange::class,
-        'tstzmultirange' => MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirange::class,
-
-        // Multirange array types
         'datemultirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\DateMultirangeArray::class,
+        'int4multirange' => MartinGeorgiev\Doctrine\DBAL\Types\Int4Multirange::class,
         'int4multirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\Int4MultirangeArray::class,
+        'int8multirange' => MartinGeorgiev\Doctrine\DBAL\Types\Int8Multirange::class,
         'int8multirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\Int8MultirangeArray::class,
+        'nummultirange' => MartinGeorgiev\Doctrine\DBAL\Types\NumMultirange::class,
         'nummultirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\NumMultirangeArray::class,
+        'tsmultirange' => MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange::class,
         'tsmultirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\TsMultirangeArray::class,
+        'tstzmultirange' => MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirange::class,
         'tstzmultirange[]' => MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirangeArray::class,
 
         // Text search types

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -90,6 +90,14 @@ doctrine:
             tsmultirange: MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange
             tstzmultirange: MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirange
 
+            # Multirange array types
+            'datemultirange[]': MartinGeorgiev\Doctrine\DBAL\Types\DateMultirangeArray
+            'int4multirange[]': MartinGeorgiev\Doctrine\DBAL\Types\Int4MultirangeArray
+            'int8multirange[]': MartinGeorgiev\Doctrine\DBAL\Types\Int8MultirangeArray
+            'nummultirange[]': MartinGeorgiev\Doctrine\DBAL\Types\NumMultirangeArray
+            'tsmultirange[]': MartinGeorgiev\Doctrine\DBAL\Types\TsMultirangeArray
+            'tstzmultirange[]': MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirangeArray
+
             # Text search types
             tsquery: MartinGeorgiev\Doctrine\DBAL\Types\Tsquery
             'tsquery[]': MartinGeorgiev\Doctrine\DBAL\Types\TsqueryArray
@@ -240,6 +248,20 @@ doctrine:
                     nummultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::NUMMULTIRANGE
                     tsmultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSMULTIRANGE
                     tstzmultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSTZMULTIRANGE
+
+                    # Multirange array type mappings
+                    'datemultirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::DATEMULTIRANGE_ARRAY
+                    _datemultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::DATEMULTIRANGE_ARRAY
+                    'int4multirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT4MULTIRANGE_ARRAY
+                    _int4multirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT4MULTIRANGE_ARRAY
+                    'int8multirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT8MULTIRANGE_ARRAY
+                    _int8multirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT8MULTIRANGE_ARRAY
+                    'nummultirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::NUMMULTIRANGE_ARRAY
+                    _nummultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::NUMMULTIRANGE_ARRAY
+                    'tsmultirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSMULTIRANGE_ARRAY
+                    _tsmultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSMULTIRANGE_ARRAY
+                    'tstzmultirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSTZMULTIRANGE_ARRAY
+                    _tstzmultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSTZMULTIRANGE_ARRAY
 
                     # Text search type mappings
                     tsquery: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSQUERY

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -84,18 +84,16 @@ doctrine:
 
             # Multirange types
             datemultirange: MartinGeorgiev\Doctrine\DBAL\Types\DateMultirange
-            int4multirange: MartinGeorgiev\Doctrine\DBAL\Types\Int4Multirange
-            int8multirange: MartinGeorgiev\Doctrine\DBAL\Types\Int8Multirange
-            nummultirange: MartinGeorgiev\Doctrine\DBAL\Types\NumMultirange
-            tsmultirange: MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange
-            tstzmultirange: MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirange
-
-            # Multirange array types
             'datemultirange[]': MartinGeorgiev\Doctrine\DBAL\Types\DateMultirangeArray
+            int4multirange: MartinGeorgiev\Doctrine\DBAL\Types\Int4Multirange
             'int4multirange[]': MartinGeorgiev\Doctrine\DBAL\Types\Int4MultirangeArray
+            int8multirange: MartinGeorgiev\Doctrine\DBAL\Types\Int8Multirange
             'int8multirange[]': MartinGeorgiev\Doctrine\DBAL\Types\Int8MultirangeArray
+            nummultirange: MartinGeorgiev\Doctrine\DBAL\Types\NumMultirange
             'nummultirange[]': MartinGeorgiev\Doctrine\DBAL\Types\NumMultirangeArray
+            tsmultirange: MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange
             'tsmultirange[]': MartinGeorgiev\Doctrine\DBAL\Types\TsMultirangeArray
+            tstzmultirange: MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirange
             'tstzmultirange[]': MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirangeArray
 
             # Text search types
@@ -243,23 +241,21 @@ doctrine:
 
                     # Multirange type mappings
                     datemultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::DATEMULTIRANGE
-                    int4multirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT4MULTIRANGE
-                    int8multirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT8MULTIRANGE
-                    nummultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::NUMMULTIRANGE
-                    tsmultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSMULTIRANGE
-                    tstzmultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSTZMULTIRANGE
-
-                    # Multirange array type mappings
-                    'datemultirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::DATEMULTIRANGE_ARRAY
                     _datemultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::DATEMULTIRANGE_ARRAY
+                    'datemultirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::DATEMULTIRANGE_ARRAY
+                    int4multirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT4MULTIRANGE
                     'int4multirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT4MULTIRANGE_ARRAY
                     _int4multirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT4MULTIRANGE_ARRAY
+                    int8multirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT8MULTIRANGE
                     'int8multirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT8MULTIRANGE_ARRAY
                     _int8multirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INT8MULTIRANGE_ARRAY
+                    nummultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::NUMMULTIRANGE
                     'nummultirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::NUMMULTIRANGE_ARRAY
                     _nummultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::NUMMULTIRANGE_ARRAY
+                    tsmultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSMULTIRANGE
                     'tsmultirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSMULTIRANGE_ARRAY
                     _tsmultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSMULTIRANGE_ARRAY
+                    tstzmultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSTZMULTIRANGE
                     'tstzmultirange[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSTZMULTIRANGE_ARRAY
                     _tstzmultirange: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TSTZMULTIRANGE_ARRAY
 

--- a/src/MartinGeorgiev/Doctrine/DBAL/Type.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Type.php
@@ -89,6 +89,11 @@ final class Type
     /**
      * @var string
      */
+    public const DATEMULTIRANGE_ARRAY = 'datemultirange[]';
+
+    /**
+     * @var string
+     */
     public const DATERANGE = 'daterange';
 
     /**
@@ -149,12 +154,22 @@ final class Type
     /**
      * @var string
      */
+    public const INT4MULTIRANGE_ARRAY = 'int4multirange[]';
+
+    /**
+     * @var string
+     */
     public const INT4RANGE = 'int4range';
 
     /**
      * @var string
      */
     public const INT8MULTIRANGE = 'int8multirange';
+
+    /**
+     * @var string
+     */
+    public const INT8MULTIRANGE_ARRAY = 'int8multirange[]';
 
     /**
      * @var string
@@ -254,6 +269,11 @@ final class Type
     /**
      * @var string
      */
+    public const NUMMULTIRANGE_ARRAY = 'nummultirange[]';
+
+    /**
+     * @var string
+     */
     public const NUMRANGE = 'numrange';
 
     /**
@@ -339,6 +359,11 @@ final class Type
     /**
      * @var string
      */
+    public const TSMULTIRANGE_ARRAY = 'tsmultirange[]';
+
+    /**
+     * @var string
+     */
     public const TSVECTOR = 'tsvector';
 
     /**
@@ -355,6 +380,11 @@ final class Type
      * @var string
      */
     public const TSTZMULTIRANGE = 'tstzmultirange';
+
+    /**
+     * @var string
+     */
+    public const TSTZMULTIRANGE_ARRAY = 'tstzmultirange[]';
 
     /**
      * @var string

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/DateMultirangeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/DateMultirangeArray.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidDateMultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidDateMultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateMultirange as DateMultirangeValueObject;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
+
+/**
+ * Implementation of PostgreSQL DATEMULTIRANGE[] data type.
+ *
+ * @see https://www.postgresql.org/docs/18/rangetypes.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class DateMultirangeArray extends BaseArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::DATEMULTIRANGE_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        return $item === null || $item instanceof DateMultirangeValueObject;
+    }
+
+    protected function transformArrayItemForPostgres(mixed $item): string
+    {
+        if ($item === null) {
+            return 'NULL';
+        }
+
+        if (!$item instanceof DateMultirangeValueObject) {
+            throw InvalidDateMultirangeArrayItemForDatabaseException::forInvalidType($item);
+        }
+
+        return $this->quoteAndEscapeArrayItem((string) $item);
+    }
+
+    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
+    {
+        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray);
+    }
+
+    public function transformArrayItemForPHP(mixed $item): ?DateMultirangeValueObject
+    {
+        if ($item === null) {
+            return null;
+        }
+
+        if (!\is_string($item)) {
+            throw InvalidDateMultirangeArrayItemForPHPException::forInvalidType($item);
+        }
+
+        try {
+            return DateMultirangeValueObject::fromString($item);
+        } catch (\InvalidArgumentException) {
+            throw InvalidDateMultirangeArrayItemForPHPException::forInvalidFormat($item);
+        }
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidDateMultirangeArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidDateMultirangeArrayItemForDatabaseException::forInvalidType($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidDateMultirangeArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidDateMultirangeArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidDateMultirangeArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be DateMultirange instances, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidDateMultirangeArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidDateMultirangeArrayItemForPHPException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidDateMultirangeArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array values must be strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid datemultirange format in array: %s', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInt4MultirangeArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInt4MultirangeArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidInt4MultirangeArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be Int4Multirange instances, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInt4MultirangeArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInt4MultirangeArrayItemForPHPException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidInt4MultirangeArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array values must be strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid int4multirange format in array: %s', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInt8MultirangeArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInt8MultirangeArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidInt8MultirangeArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be Int8Multirange instances, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInt8MultirangeArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInt8MultirangeArrayItemForPHPException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidInt8MultirangeArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array values must be strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid int8multirange format in array: %s', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidNumMultirangeArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidNumMultirangeArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidNumMultirangeArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be NumericMultirange instances, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidNumMultirangeArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidNumMultirangeArrayItemForPHPException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidNumMultirangeArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array values must be strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid nummultirange format in array: %s', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTsMultirangeArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTsMultirangeArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTsMultirangeArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be TsMultirange instances, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTsMultirangeArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTsMultirangeArrayItemForPHPException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTsMultirangeArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array values must be strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid tsmultirange format in array: %s', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTstzMultirangeArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTstzMultirangeArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTstzMultirangeArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be TstzMultirange instances, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTstzMultirangeArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTstzMultirangeArrayItemForPHPException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTstzMultirangeArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array values must be strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid tstzmultirange format in array: %s', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Int4MultirangeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Int4MultirangeArray.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInt4MultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInt4MultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Int4Multirange as Int4MultirangeValueObject;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
+
+/**
+ * Implementation of PostgreSQL INT4MULTIRANGE[] data type.
+ *
+ * @see https://www.postgresql.org/docs/18/rangetypes.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class Int4MultirangeArray extends BaseArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::INT4MULTIRANGE_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        return $item === null || $item instanceof Int4MultirangeValueObject;
+    }
+
+    protected function transformArrayItemForPostgres(mixed $item): string
+    {
+        if ($item === null) {
+            return 'NULL';
+        }
+
+        if (!$item instanceof Int4MultirangeValueObject) {
+            throw InvalidInt4MultirangeArrayItemForDatabaseException::forInvalidType($item);
+        }
+
+        return $this->quoteAndEscapeArrayItem((string) $item);
+    }
+
+    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
+    {
+        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray);
+    }
+
+    public function transformArrayItemForPHP(mixed $item): ?Int4MultirangeValueObject
+    {
+        if ($item === null) {
+            return null;
+        }
+
+        if (!\is_string($item)) {
+            throw InvalidInt4MultirangeArrayItemForPHPException::forInvalidType($item);
+        }
+
+        try {
+            return Int4MultirangeValueObject::fromString($item);
+        } catch (\InvalidArgumentException) {
+            throw InvalidInt4MultirangeArrayItemForPHPException::forInvalidFormat($item);
+        }
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidInt4MultirangeArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidInt4MultirangeArrayItemForDatabaseException::forInvalidType($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Int8MultirangeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Int8MultirangeArray.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInt8MultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInt8MultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Int8Multirange as Int8MultirangeValueObject;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
+
+/**
+ * Implementation of PostgreSQL INT8MULTIRANGE[] data type.
+ *
+ * @see https://www.postgresql.org/docs/18/rangetypes.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class Int8MultirangeArray extends BaseArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::INT8MULTIRANGE_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        return $item === null || $item instanceof Int8MultirangeValueObject;
+    }
+
+    protected function transformArrayItemForPostgres(mixed $item): string
+    {
+        if ($item === null) {
+            return 'NULL';
+        }
+
+        if (!$item instanceof Int8MultirangeValueObject) {
+            throw InvalidInt8MultirangeArrayItemForDatabaseException::forInvalidType($item);
+        }
+
+        return $this->quoteAndEscapeArrayItem((string) $item);
+    }
+
+    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
+    {
+        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray);
+    }
+
+    public function transformArrayItemForPHP(mixed $item): ?Int8MultirangeValueObject
+    {
+        if ($item === null) {
+            return null;
+        }
+
+        if (!\is_string($item)) {
+            throw InvalidInt8MultirangeArrayItemForPHPException::forInvalidType($item);
+        }
+
+        try {
+            return Int8MultirangeValueObject::fromString($item);
+        } catch (\InvalidArgumentException) {
+            throw InvalidInt8MultirangeArrayItemForPHPException::forInvalidFormat($item);
+        }
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidInt8MultirangeArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidInt8MultirangeArrayItemForDatabaseException::forInvalidType($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/NumMultirangeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/NumMultirangeArray.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidNumMultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidNumMultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\NumericMultirange as NumericMultirangeValueObject;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
+
+/**
+ * Implementation of PostgreSQL NUMMULTIRANGE[] data type.
+ *
+ * @see https://www.postgresql.org/docs/18/rangetypes.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class NumMultirangeArray extends BaseArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::NUMMULTIRANGE_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        return $item === null || $item instanceof NumericMultirangeValueObject;
+    }
+
+    protected function transformArrayItemForPostgres(mixed $item): string
+    {
+        if ($item === null) {
+            return 'NULL';
+        }
+
+        if (!$item instanceof NumericMultirangeValueObject) {
+            throw InvalidNumMultirangeArrayItemForDatabaseException::forInvalidType($item);
+        }
+
+        return $this->quoteAndEscapeArrayItem((string) $item);
+    }
+
+    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
+    {
+        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray);
+    }
+
+    public function transformArrayItemForPHP(mixed $item): ?NumericMultirangeValueObject
+    {
+        if ($item === null) {
+            return null;
+        }
+
+        if (!\is_string($item)) {
+            throw InvalidNumMultirangeArrayItemForPHPException::forInvalidType($item);
+        }
+
+        try {
+            return NumericMultirangeValueObject::fromString($item);
+        } catch (\InvalidArgumentException) {
+            throw InvalidNumMultirangeArrayItemForPHPException::forInvalidFormat($item);
+        }
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidNumMultirangeArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidNumMultirangeArrayItemForDatabaseException::forInvalidType($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArray.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTsMultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTsMultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\TsMultirange as TsMultirangeValueObject;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
+
+/**
+ * Implementation of PostgreSQL TSMULTIRANGE[] data type.
+ *
+ * @see https://www.postgresql.org/docs/18/rangetypes.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class TsMultirangeArray extends BaseArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::TSMULTIRANGE_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        return $item === null || $item instanceof TsMultirangeValueObject;
+    }
+
+    protected function transformArrayItemForPostgres(mixed $item): string
+    {
+        if ($item === null) {
+            return 'NULL';
+        }
+
+        if (!$item instanceof TsMultirangeValueObject) {
+            throw InvalidTsMultirangeArrayItemForDatabaseException::forInvalidType($item);
+        }
+
+        return $this->quoteAndEscapeArrayItem((string) $item);
+    }
+
+    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
+    {
+        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray);
+    }
+
+    public function transformArrayItemForPHP(mixed $item): ?TsMultirangeValueObject
+    {
+        if ($item === null) {
+            return null;
+        }
+
+        if (!\is_string($item)) {
+            throw InvalidTsMultirangeArrayItemForPHPException::forInvalidType($item);
+        }
+
+        try {
+            return TsMultirangeValueObject::fromString($item);
+        } catch (\InvalidArgumentException) {
+            throw InvalidTsMultirangeArrayItemForPHPException::forInvalidFormat($item);
+        }
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidTsMultirangeArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidTsMultirangeArrayItemForDatabaseException::forInvalidType($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/TstzMultirangeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/TstzMultirangeArray.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTstzMultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTstzMultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\TstzMultirange as TstzMultirangeValueObject;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
+
+/**
+ * Implementation of PostgreSQL TSTZMULTIRANGE[] data type.
+ *
+ * @see https://www.postgresql.org/docs/18/rangetypes.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class TstzMultirangeArray extends BaseArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::TSTZMULTIRANGE_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        return $item === null || $item instanceof TstzMultirangeValueObject;
+    }
+
+    protected function transformArrayItemForPostgres(mixed $item): string
+    {
+        if ($item === null) {
+            return 'NULL';
+        }
+
+        if (!$item instanceof TstzMultirangeValueObject) {
+            throw InvalidTstzMultirangeArrayItemForDatabaseException::forInvalidType($item);
+        }
+
+        return $this->quoteAndEscapeArrayItem((string) $item);
+    }
+
+    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
+    {
+        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray);
+    }
+
+    public function transformArrayItemForPHP(mixed $item): ?TstzMultirangeValueObject
+    {
+        if ($item === null) {
+            return null;
+        }
+
+        if (!\is_string($item)) {
+            throw InvalidTstzMultirangeArrayItemForPHPException::forInvalidType($item);
+        }
+
+        try {
+            return TstzMultirangeValueObject::fromString($item);
+        } catch (\InvalidArgumentException) {
+            throw InvalidTstzMultirangeArrayItemForPHPException::forInvalidFormat($item);
+        }
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidTstzMultirangeArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidTstzMultirangeArrayItemForDatabaseException::forInvalidType($item);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/DateMultirangeArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/DateMultirangeArrayTypeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateMultirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateRange;
+
+class DateMultirangeArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'datemultirange[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, DateMultirange|null>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'single empty multirange' => [[new DateMultirange([])]],
+            'single multirange with one range' => [
+                [new DateMultirange([new DateRange(new \DateTimeImmutable('2024-01-01'), new \DateTimeImmutable('2024-06-30'))])],
+            ],
+            'array of two multiranges' => [
+                [
+                    new DateMultirange([new DateRange(new \DateTimeImmutable('2024-01-01'), new \DateTimeImmutable('2024-03-31'))]),
+                    new DateMultirange([
+                        new DateRange(new \DateTimeImmutable('2024-04-01'), new \DateTimeImmutable('2024-06-30')),
+                        new DateRange(new \DateTimeImmutable('2024-10-01'), new \DateTimeImmutable('2024-12-31')),
+                    ]),
+                ],
+            ],
+            'array with null item' => [
+                [new DateMultirange([new DateRange(new \DateTimeImmutable('2024-01-01'), new \DateTimeImmutable('2024-06-30'))]), null],
+            ],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/Int4MultirangeArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/Int4MultirangeArrayTypeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Int4Multirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Int4Range;
+
+class Int4MultirangeArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'int4multirange[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, Int4Multirange|null>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'single empty multirange' => [[new Int4Multirange([])]],
+            'single multirange with one range' => [[new Int4Multirange([new Int4Range(1, 10)])]],
+            'array of two multiranges' => [
+                [
+                    new Int4Multirange([new Int4Range(1, 5)]),
+                    new Int4Multirange([new Int4Range(10, 20), new Int4Range(30, 40)]),
+                ],
+            ],
+            'array with null item' => [[new Int4Multirange([new Int4Range(1, 5)]), null]],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/Int8MultirangeArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/Int8MultirangeArrayTypeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Int8Multirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Int8Range;
+
+class Int8MultirangeArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'int8multirange[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, Int8Multirange|null>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'single empty multirange' => [[new Int8Multirange([])]],
+            'single multirange with one range' => [[new Int8Multirange([new Int8Range(1, 1000000000)])]],
+            'array of two multiranges' => [
+                [
+                    new Int8Multirange([new Int8Range(1, 1000)]),
+                    new Int8Multirange([new Int8Range(2000, 3000), new Int8Range(5000, 6000)]),
+                ],
+            ],
+            'multirange with int64-only values' => [
+                [new Int8Multirange([new Int8Range(2147483648, 9223372036854775807)])],
+            ],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/NumMultirangeArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/NumMultirangeArrayTypeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\NumericMultirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\NumericRange;
+
+class NumMultirangeArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'nummultirange[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, NumericMultirange|null>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'single empty multirange' => [[new NumericMultirange([])]],
+            'single multirange with one range' => [[new NumericMultirange([new NumericRange(1.5, 10.5)])]],
+            'array of two multiranges' => [
+                [
+                    new NumericMultirange([new NumericRange(1, 5)]),
+                    new NumericMultirange([new NumericRange(10.5, 20.5), new NumericRange(30.0, 40.0)]),
+                ],
+            ],
+            'array with null item' => [[new NumericMultirange([new NumericRange(1.5, 10.5)]), null]],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArrayTypeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\TsMultirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\TsRange;
+
+class TsMultirangeArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'tsmultirange[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, TsMultirange|null>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'single empty multirange' => [[new TsMultirange([])]],
+            'single multirange with one range' => [
+                [new TsMultirange([new TsRange(new \DateTimeImmutable('2024-01-01 09:00:00'), new \DateTimeImmutable('2024-01-01 17:00:00'))])],
+            ],
+            'array of two multiranges' => [
+                [
+                    new TsMultirange([new TsRange(new \DateTimeImmutable('2024-01-01 09:00:00'), new \DateTimeImmutable('2024-01-01 12:00:00'))]),
+                    new TsMultirange([
+                        new TsRange(new \DateTimeImmutable('2024-01-02 09:00:00'), new \DateTimeImmutable('2024-01-02 12:00:00')),
+                        new TsRange(new \DateTimeImmutable('2024-01-02 14:00:00'), new \DateTimeImmutable('2024-01-02 17:00:00')),
+                    ]),
+                ],
+            ],
+            'array with null item' => [
+                [new TsMultirange([new TsRange(new \DateTimeImmutable('2024-01-01 09:00:00'), new \DateTimeImmutable('2024-01-01 17:00:00'))]), null],
+            ],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TstzMultirangeArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TstzMultirangeArrayTypeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\TstzMultirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\TstzRange;
+
+class TstzMultirangeArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'tstzmultirange[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, TstzMultirange|null>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'single empty multirange' => [[new TstzMultirange([])]],
+            'single multirange with one range' => [
+                [new TstzMultirange([new TstzRange(new \DateTimeImmutable('2024-01-01 09:00:00+00:00'), new \DateTimeImmutable('2024-01-01 17:00:00+00:00'))])],
+            ],
+            'array of two multiranges' => [
+                [
+                    new TstzMultirange([new TstzRange(new \DateTimeImmutable('2024-01-01 09:00:00+00:00'), new \DateTimeImmutable('2024-01-01 12:00:00+00:00'))]),
+                    new TstzMultirange([
+                        new TstzRange(new \DateTimeImmutable('2024-01-02 09:00:00+00:00'), new \DateTimeImmutable('2024-01-02 12:00:00+00:00')),
+                        new TstzRange(new \DateTimeImmutable('2024-01-02 14:00:00+00:00'), new \DateTimeImmutable('2024-01-02 17:00:00+00:00')),
+                    ]),
+                ],
+            ],
+            'array with null item' => [
+                [new TstzMultirange([new TstzRange(new \DateTimeImmutable('2024-01-01 09:00:00+00:00'), new \DateTimeImmutable('2024-01-01 17:00:00+00:00'))]), null],
+            ],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/TestCase.php
@@ -29,6 +29,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Circle;
 use MartinGeorgiev\Doctrine\DBAL\Types\CircleArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateMultirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\DateMultirangeArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateRange;
 use MartinGeorgiev\Doctrine\DBAL\Types\DoublePrecisionArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Geography;
@@ -40,8 +41,10 @@ use MartinGeorgiev\Doctrine\DBAL\Types\HstoreArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Inet;
 use MartinGeorgiev\Doctrine\DBAL\Types\InetArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Int4Multirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\Int4MultirangeArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Int4Range;
 use MartinGeorgiev\Doctrine\DBAL\Types\Int8Multirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\Int8MultirangeArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Int8Range;
 use MartinGeorgiev\Doctrine\DBAL\Types\IntegerArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Interval;
@@ -61,6 +64,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\MacaddrArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Money;
 use MartinGeorgiev\Doctrine\DBAL\Types\MoneyArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\NumMultirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\NumMultirangeArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\NumRange;
 use MartinGeorgiev\Doctrine\DBAL\Types\Path;
 use MartinGeorgiev\Doctrine\DBAL\Types\PathArray;
@@ -74,10 +78,12 @@ use MartinGeorgiev\Doctrine\DBAL\Types\TextArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\TsMultirangeArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Tsquery;
 use MartinGeorgiev\Doctrine\DBAL\Types\TsqueryArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TsRange;
 use MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirange;
+use MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirangeArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TstzRange;
 use MartinGeorgiev\Doctrine\DBAL\Types\Tsvector;
 use MartinGeorgiev\Doctrine\DBAL\Types\TsvectorArray;
@@ -279,6 +285,7 @@ abstract class TestCase extends BaseTestCase
             'date[]' => DateArray::class,
             'daterange' => DateRange::class,
             'datemultirange' => DateMultirange::class,
+            'datemultirange[]' => DateMultirangeArray::class,
             'double precision[]' => DoublePrecisionArray::class,
             'geography' => Geography::class,
             'geography[]' => GeographyArray::class,
@@ -302,7 +309,9 @@ abstract class TestCase extends BaseTestCase
             'ltree' => Ltree::class,
             'ltree[]' => LtreeArray::class,
             'int4multirange' => Int4Multirange::class,
+            'int4multirange[]' => Int4MultirangeArray::class,
             'int8multirange' => Int8Multirange::class,
+            'int8multirange[]' => Int8MultirangeArray::class,
             'macaddr' => Macaddr::class,
             'macaddr8' => Macaddr8::class,
             'macaddr8[]' => Macaddr8Array::class,
@@ -311,6 +320,7 @@ abstract class TestCase extends BaseTestCase
             'money[]' => MoneyArray::class,
             'numrange' => NumRange::class,
             'nummultirange' => NumMultirange::class,
+            'nummultirange[]' => NumMultirangeArray::class,
             'path' => Path::class,
             'path[]' => PathArray::class,
             'point' => Point::class,
@@ -323,10 +333,12 @@ abstract class TestCase extends BaseTestCase
             'timestamp[]' => TimestampArray::class,
             'timestamptz[]' => TimestampTzArray::class,
             'tsmultirange' => TsMultirange::class,
+            'tsmultirange[]' => TsMultirangeArray::class,
             'tsquery' => Tsquery::class,
             'tsquery[]' => TsqueryArray::class,
             'tsrange' => TsRange::class,
             'tstzmultirange' => TstzMultirange::class,
+            'tstzmultirange[]' => TstzMultirangeArray::class,
             'tstzrange' => TstzRange::class,
             'tsvector' => Tsvector::class,
             'tsvector[]' => TsvectorArray::class,

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DateMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DateMultirangeArrayTest.php
@@ -160,6 +160,51 @@ class DateMultirangeArrayTest extends TestCase
         ];
     }
 
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'empty multirange' => [new DateMultirangeValueObject([])],
+            'single range multirange' => [new DateMultirangeValueObject([new DateRange(new \DateTimeImmutable('2024-01-01'), new \DateTimeImmutable('2024-06-30'))])],
+            'null item' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'string' => ['not-a-multirange'],
+            'integer' => [42],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function can_transform_null_item_for_php(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
     #[Test]
     public function throws_exception_for_non_string_item_from_database(): void
     {

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DateMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DateMultirangeArrayTest.php
@@ -159,4 +159,11 @@ class DateMultirangeArrayTest extends TestCase
             'invalid format in array' => ['{"not-a-multirange"}'],
         ];
     }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidDateMultirangeArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(42);
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DateMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DateMultirangeArrayTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\DateMultirangeArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidDateMultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidDateMultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateMultirange as DateMultirangeValueObject;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateRange;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class DateMultirangeArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private DateMultirangeArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new DateMultirangeArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('datemultirange[]', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function converts_null_to_null(): void
+    {
+        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array<DateMultirangeValueObject|null>|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single multirange' => [
+                'phpValue' => [new DateMultirangeValueObject([new DateRange(new \DateTimeImmutable('2024-01-01'), new \DateTimeImmutable('2024-06-30'))])],
+                'postgresValue' => '{"{[2024-01-01,2024-06-30)}"}',
+            ],
+            'multirange with two ranges' => [
+                'phpValue' => [new DateMultirangeValueObject([
+                    new DateRange(new \DateTimeImmutable('2024-01-01'), new \DateTimeImmutable('2024-03-31')),
+                    new DateRange(new \DateTimeImmutable('2024-07-01'), new \DateTimeImmutable('2024-12-31')),
+                ])],
+                'postgresValue' => '{"{[2024-01-01,2024-03-31),[2024-07-01,2024-12-31)}"}',
+            ],
+            'empty multirange item' => [
+                'phpValue' => [new DateMultirangeValueObject([])],
+                'postgresValue' => '{"{}"}',
+            ],
+            'multiple multiranges' => [
+                'phpValue' => [
+                    new DateMultirangeValueObject([new DateRange(new \DateTimeImmutable('2024-01-01'), new \DateTimeImmutable('2024-03-31'))]),
+                    new DateMultirangeValueObject([new DateRange(new \DateTimeImmutable('2024-07-01'), new \DateTimeImmutable('2024-12-31'))]),
+                ],
+                'postgresValue' => '{"{[2024-01-01,2024-03-31)}","{[2024-07-01,2024-12-31)}"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [new DateMultirangeValueObject([new DateRange(new \DateTimeImmutable('2024-01-01'), new \DateTimeImmutable('2024-06-30'))]), null],
+                'postgresValue' => '{"{[2024-01-01,2024-06-30)}",NULL}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidDateMultirangeArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'array containing string' => [['not-a-multirange']],
+            'array containing integer' => [[42]],
+            'array containing object' => [[new \stdClass()]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidDateMultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+            'integer instead of array' => [42],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(string $postgresValue): void
+    {
+        $this->expectException(InvalidDateMultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'invalid format in array' => ['{"not-a-multirange"}'],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int4MultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int4MultirangeArrayTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInt4MultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInt4MultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Int4MultirangeArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Int4Multirange as Int4MultirangeValueObject;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Int4Range;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class Int4MultirangeArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private Int4MultirangeArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new Int4MultirangeArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('int4multirange[]', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function converts_null_to_null(): void
+    {
+        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array<Int4MultirangeValueObject|null>|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single multirange' => [
+                'phpValue' => [new Int4MultirangeValueObject([new Int4Range(1, 10)])],
+                'postgresValue' => '{"{[1,10)}"}',
+            ],
+            'multirange with two ranges' => [
+                'phpValue' => [new Int4MultirangeValueObject([new Int4Range(1, 5), new Int4Range(10, 20)])],
+                'postgresValue' => '{"{[1,5),[10,20)}"}',
+            ],
+            'empty multirange item' => [
+                'phpValue' => [new Int4MultirangeValueObject([])],
+                'postgresValue' => '{"{}"}',
+            ],
+            'multiple multiranges' => [
+                'phpValue' => [
+                    new Int4MultirangeValueObject([new Int4Range(1, 5)]),
+                    new Int4MultirangeValueObject([new Int4Range(10, 20)]),
+                ],
+                'postgresValue' => '{"{[1,5)}","{[10,20)}"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [new Int4MultirangeValueObject([new Int4Range(1, 5)]), null],
+                'postgresValue' => '{"{[1,5)}",NULL}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidInt4MultirangeArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'array containing string' => [['not-a-multirange']],
+            'array containing integer' => [[42]],
+            'array containing object' => [[new \stdClass()]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidInt4MultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+            'integer instead of array' => [42],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(string $postgresValue): void
+    {
+        $this->expectException(InvalidInt4MultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'invalid format in array' => ['{"not-a-multirange"}'],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int4MultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int4MultirangeArrayTest.php
@@ -156,4 +156,11 @@ class Int4MultirangeArrayTest extends TestCase
             'invalid format in array' => ['{"not-a-multirange"}'],
         ];
     }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidInt4MultirangeArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(42);
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int4MultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int4MultirangeArrayTest.php
@@ -157,6 +157,51 @@ class Int4MultirangeArrayTest extends TestCase
         ];
     }
 
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'empty multirange' => [new Int4MultirangeValueObject([])],
+            'single range multirange' => [new Int4MultirangeValueObject([new Int4Range(1, 10)])],
+            'null item' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'string' => ['not-a-multirange'],
+            'integer' => [42],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function can_transform_null_item_for_php(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
     #[Test]
     public function throws_exception_for_non_string_item_from_database(): void
     {

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int8MultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int8MultirangeArrayTest.php
@@ -157,6 +157,51 @@ class Int8MultirangeArrayTest extends TestCase
         ];
     }
 
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'empty multirange' => [new Int8MultirangeValueObject([])],
+            'single range multirange' => [new Int8MultirangeValueObject([new Int8Range(1, 100)])],
+            'null item' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'string' => ['not-a-multirange'],
+            'integer' => [42],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function can_transform_null_item_for_php(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
     #[Test]
     public function throws_exception_for_non_string_item_from_database(): void
     {

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int8MultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int8MultirangeArrayTest.php
@@ -156,4 +156,11 @@ class Int8MultirangeArrayTest extends TestCase
             'invalid format in array' => ['{"not-a-multirange"}'],
         ];
     }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidInt8MultirangeArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(42);
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int8MultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Int8MultirangeArrayTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInt8MultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInt8MultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Int8MultirangeArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Int8Multirange as Int8MultirangeValueObject;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Int8Range;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class Int8MultirangeArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private Int8MultirangeArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new Int8MultirangeArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('int8multirange[]', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function converts_null_to_null(): void
+    {
+        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array<Int8MultirangeValueObject|null>|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single multirange' => [
+                'phpValue' => [new Int8MultirangeValueObject([new Int8Range(1, 100)])],
+                'postgresValue' => '{"{[1,100)}"}',
+            ],
+            'multirange with two ranges' => [
+                'phpValue' => [new Int8MultirangeValueObject([new Int8Range(1, 50), new Int8Range(100, 200)])],
+                'postgresValue' => '{"{[1,50),[100,200)}"}',
+            ],
+            'empty multirange item' => [
+                'phpValue' => [new Int8MultirangeValueObject([])],
+                'postgresValue' => '{"{}"}',
+            ],
+            'multiple multiranges' => [
+                'phpValue' => [
+                    new Int8MultirangeValueObject([new Int8Range(1, 50)]),
+                    new Int8MultirangeValueObject([new Int8Range(100, 200)]),
+                ],
+                'postgresValue' => '{"{[1,50)}","{[100,200)}"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [new Int8MultirangeValueObject([new Int8Range(1, 50)]), null],
+                'postgresValue' => '{"{[1,50)}",NULL}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidInt8MultirangeArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'array containing string' => [['not-a-multirange']],
+            'array containing integer' => [[42]],
+            'array containing object' => [[new \stdClass()]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidInt8MultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+            'integer instead of array' => [42],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(string $postgresValue): void
+    {
+        $this->expectException(InvalidInt8MultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'invalid format in array' => ['{"not-a-multirange"}'],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/NumMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/NumMultirangeArrayTest.php
@@ -157,6 +157,51 @@ class NumMultirangeArrayTest extends TestCase
         ];
     }
 
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'empty multirange' => [new NumericMultirangeValueObject([])],
+            'single range multirange' => [new NumericMultirangeValueObject([new NumericRange(1, 10)])],
+            'null item' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'string' => ['not-a-multirange'],
+            'integer' => [42],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function can_transform_null_item_for_php(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
     #[Test]
     public function throws_exception_for_non_string_item_from_database(): void
     {

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/NumMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/NumMultirangeArrayTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidNumMultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidNumMultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\NumMultirangeArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\NumericMultirange as NumericMultirangeValueObject;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\NumericRange;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class NumMultirangeArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private NumMultirangeArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new NumMultirangeArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('nummultirange[]', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function converts_null_to_null(): void
+    {
+        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array<NumericMultirangeValueObject|null>|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single multirange' => [
+                'phpValue' => [new NumericMultirangeValueObject([new NumericRange(1.5, 10.5)])],
+                'postgresValue' => '{"{[1.5,10.5)}"}',
+            ],
+            'multirange with two ranges' => [
+                'phpValue' => [new NumericMultirangeValueObject([new NumericRange(1, 5), new NumericRange(10.5, 20.5)])],
+                'postgresValue' => '{"{[1,5),[10.5,20.5)}"}',
+            ],
+            'empty multirange item' => [
+                'phpValue' => [new NumericMultirangeValueObject([])],
+                'postgresValue' => '{"{}"}',
+            ],
+            'multiple multiranges' => [
+                'phpValue' => [
+                    new NumericMultirangeValueObject([new NumericRange(1, 5)]),
+                    new NumericMultirangeValueObject([new NumericRange(10.5, 20.5)]),
+                ],
+                'postgresValue' => '{"{[1,5)}","{[10.5,20.5)}"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [new NumericMultirangeValueObject([new NumericRange(1, 5)]), null],
+                'postgresValue' => '{"{[1,5)}",NULL}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidNumMultirangeArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'array containing string' => [['not-a-multirange']],
+            'array containing integer' => [[42]],
+            'array containing object' => [[new \stdClass()]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidNumMultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+            'integer instead of array' => [42],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(string $postgresValue): void
+    {
+        $this->expectException(InvalidNumMultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'invalid format in array' => ['{"not-a-multirange"}'],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/NumMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/NumMultirangeArrayTest.php
@@ -156,4 +156,11 @@ class NumMultirangeArrayTest extends TestCase
             'invalid format in array' => ['{"not-a-multirange"}'],
         ];
     }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidNumMultirangeArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(42);
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArrayTest.php
@@ -160,6 +160,51 @@ class TsMultirangeArrayTest extends TestCase
         ];
     }
 
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'empty multirange' => [new TsMultirangeValueObject([])],
+            'single range multirange' => [new TsMultirangeValueObject([new TsRange(new \DateTimeImmutable('2024-01-01 09:00:00'), new \DateTimeImmutable('2024-01-01 17:00:00'))])],
+            'null item' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'string' => ['not-a-multirange'],
+            'integer' => [42],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function can_transform_null_item_for_php(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
     #[Test]
     public function throws_exception_for_non_string_item_from_database(): void
     {

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArrayTest.php
@@ -93,6 +93,13 @@ class TsMultirangeArrayTest extends TestCase
                 'phpValue' => [new TsMultirangeValueObject([new TsRange(new \DateTimeImmutable('2024-01-01 09:00:00'), new \DateTimeImmutable('2024-01-01 17:00:00'))]), null],
                 'postgresValue' => '{"{[2024-01-01 09:00:00.000000,2024-01-01 17:00:00.000000)}",NULL}',
             ],
+            'multiple multiranges' => [
+                'phpValue' => [
+                    new TsMultirangeValueObject([new TsRange(new \DateTimeImmutable('2024-01-01 09:00:00'), new \DateTimeImmutable('2024-01-01 17:00:00'))]),
+                    new TsMultirangeValueObject([new TsRange(new \DateTimeImmutable('2024-01-02 10:00:00'), new \DateTimeImmutable('2024-01-02 18:00:00'))]),
+                ],
+                'postgresValue' => '{"{[2024-01-01 09:00:00.000000,2024-01-01 17:00:00.000000)}","{[2024-01-02 10:00:00.000000,2024-01-02 18:00:00.000000)}"}',
+            ],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArrayTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTsMultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTsMultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\TsMultirangeArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\TsMultirange as TsMultirangeValueObject;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\TsRange;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TsMultirangeArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private TsMultirangeArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new TsMultirangeArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('tsmultirange[]', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function converts_null_to_null(): void
+    {
+        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array<TsMultirangeValueObject|null>|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single multirange' => [
+                'phpValue' => [new TsMultirangeValueObject([new TsRange(new \DateTimeImmutable('2024-01-01 09:00:00'), new \DateTimeImmutable('2024-01-01 17:00:00'))])],
+                'postgresValue' => '{"{[2024-01-01 09:00:00.000000,2024-01-01 17:00:00.000000)}"}',
+            ],
+            'multirange with two ranges' => [
+                'phpValue' => [new TsMultirangeValueObject([
+                    new TsRange(new \DateTimeImmutable('2024-01-01 09:00:00'), new \DateTimeImmutable('2024-01-01 12:00:00')),
+                    new TsRange(new \DateTimeImmutable('2024-01-01 14:00:00'), new \DateTimeImmutable('2024-01-01 17:00:00')),
+                ])],
+                'postgresValue' => '{"{[2024-01-01 09:00:00.000000,2024-01-01 12:00:00.000000),[2024-01-01 14:00:00.000000,2024-01-01 17:00:00.000000)}"}',
+            ],
+            'empty multirange item' => [
+                'phpValue' => [new TsMultirangeValueObject([])],
+                'postgresValue' => '{"{}"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [new TsMultirangeValueObject([new TsRange(new \DateTimeImmutable('2024-01-01 09:00:00'), new \DateTimeImmutable('2024-01-01 17:00:00'))]), null],
+                'postgresValue' => '{"{[2024-01-01 09:00:00.000000,2024-01-01 17:00:00.000000)}",NULL}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidTsMultirangeArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'array containing string' => [['not-a-multirange']],
+            'array containing integer' => [[42]],
+            'array containing object' => [[new \stdClass()]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidTsMultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+            'integer instead of array' => [42],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(string $postgresValue): void
+    {
+        $this->expectException(InvalidTsMultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'invalid format in array' => ['{"not-a-multirange"}'],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TsMultirangeArrayTest.php
@@ -159,4 +159,11 @@ class TsMultirangeArrayTest extends TestCase
             'invalid format in array' => ['{"not-a-multirange"}'],
         ];
     }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidTsMultirangeArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(42);
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TstzMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TstzMultirangeArrayTest.php
@@ -153,6 +153,51 @@ class TstzMultirangeArrayTest extends TestCase
         ];
     }
 
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'empty multirange' => [new TstzMultirangeValueObject([])],
+            'single range multirange' => [new TstzMultirangeValueObject([new TstzRange(new \DateTimeImmutable('2024-01-01 09:00:00+00:00'), new \DateTimeImmutable('2024-01-01 17:00:00+00:00'))])],
+            'null item' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'string' => ['not-a-multirange'],
+            'integer' => [42],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function can_transform_null_item_for_php(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
     #[Test]
     public function throws_exception_for_non_string_item_from_database(): void
     {

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TstzMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TstzMultirangeArrayTest.php
@@ -152,4 +152,11 @@ class TstzMultirangeArrayTest extends TestCase
             'invalid format in array' => ['{"not-a-multirange"}'],
         ];
     }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidTstzMultirangeArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(42);
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TstzMultirangeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TstzMultirangeArrayTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTstzMultirangeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTstzMultirangeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirangeArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\TstzMultirange as TstzMultirangeValueObject;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\TstzRange;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TstzMultirangeArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private TstzMultirangeArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new TstzMultirangeArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('tstzmultirange[]', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function converts_null_to_null(): void
+    {
+        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array<TstzMultirangeValueObject|null>|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single multirange' => [
+                'phpValue' => [new TstzMultirangeValueObject([new TstzRange(new \DateTimeImmutable('2024-01-01 09:00:00+00:00'), new \DateTimeImmutable('2024-01-01 17:00:00+00:00'))])],
+                'postgresValue' => '{"{[2024-01-01 09:00:00.000000+00:00,2024-01-01 17:00:00.000000+00:00)}"}',
+            ],
+            'multirange with two ranges' => [
+                'phpValue' => [new TstzMultirangeValueObject([
+                    new TstzRange(new \DateTimeImmutable('2024-01-01 09:00:00+00:00'), new \DateTimeImmutable('2024-01-01 12:00:00+00:00')),
+                    new TstzRange(new \DateTimeImmutable('2024-01-01 14:00:00+00:00'), new \DateTimeImmutable('2024-01-01 17:00:00+00:00')),
+                ])],
+                'postgresValue' => '{"{[2024-01-01 09:00:00.000000+00:00,2024-01-01 12:00:00.000000+00:00),[2024-01-01 14:00:00.000000+00:00,2024-01-01 17:00:00.000000+00:00)}"}',
+            ],
+            'empty multirange item' => [
+                'phpValue' => [new TstzMultirangeValueObject([])],
+                'postgresValue' => '{"{}"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [new TstzMultirangeValueObject([new TstzRange(new \DateTimeImmutable('2024-01-01 09:00:00+00:00'), new \DateTimeImmutable('2024-01-01 17:00:00+00:00'))]), null],
+                'postgresValue' => '{"{[2024-01-01 09:00:00.000000+00:00,2024-01-01 17:00:00.000000+00:00)}",NULL}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidTstzMultirangeArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'array containing string' => [['not-a-multirange']],
+            'array containing integer' => [[42]],
+            'array containing object' => [[new \stdClass()]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidTstzMultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+            'integer instead of array' => [42],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(string $postgresValue): void
+    {
+        $this->expectException(InvalidTstzMultirangeArrayItemForPHPException::class);
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'invalid format in array' => ['{"not-a-multirange"}'],
+        ];
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for PostgreSQL multirange array types (datemultirange[], int4multirange[], int8multirange[], nummultirange[], tsmultirange[], tstzmultirange[]).

* **Documentation**
  * Expanded README and integration guides (Doctrine, Laravel, Symfony) with multirange array type mappings and registration examples.

* **Tests**
  * Added comprehensive unit and integration tests covering conversions, valid fixtures, null handling and error cases for multirange array types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-georgiev/postgresql-for-doctrine/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->