### PR TITLE
feat: add support for `timetz` DBAL type and its array variation

### DIFF
--- a/.ai-tools/rules/dbal-array-types.md
+++ b/.ai-tools/rules/dbal-array-types.md
@@ -1,0 +1,60 @@
+---
+description: "BaseArray subclass pattern: required methods, defensive guard, unit test methods, integration registration"
+alwaysApply: true
+trigger: always_on
+applyTo: "**"
+type: always_apply
+---
+
+# DBAL Array Types
+
+## Required Method Set for BaseArray Subclasses
+Every `BaseArray` subclass MUST implement all of these methods. Do NOT remove any of them to improve coverage or eliminate "dead code":
+
+```php
+public function isValidArrayItemForDatabase(mixed $item): bool
+protected function transformArrayItemForPostgres(mixed $item): string // guard inside is intentional
+public function transformArrayItemForPHP(mixed $item): ?ValueObject
+protected function transformPostgresArrayToPHPArray(string $postgresArray): array
+protected function throwInvalidTypeException(mixed $value): never
+protected function throwInvalidItemException(mixed $item): never
+```
+
+The guard (`if (!$item instanceof X)` throw) inside `transformArrayItemForPostgres` is **intentional defensive code**. `convertToDatabaseValue` pre-filters via `isValidArrayItemForDatabase` + `throwInvalidItemException`, so the guard is unreachable through normal flow. It exists to protect direct calls to the protected method. Do NOT remove `isValidArrayItemForDatabase` or `throwInvalidItemException` to make the guard reachable — that inverts the pattern.
+
+## Integration Test Registration
+Every new DBAL type MUST be registered in `tests/Integration/MartinGeorgiev/TestCase.php::registerCustomTypes()` or integration tests will fail with `UnknownColumnType`. Add both the `use` import and the `$typesMap` entry:
+
+```php
+use MartinGeorgiev\Doctrine\DBAL\Types\FooArray;
+// ...
+'foo[]' => FooArray::class,
+```
+
+## Required Unit Test Methods for Array Types
+When writing unit tests for a `BaseArray` subclass, include these methods (canonical names — do not rename):
+
+```php
+// covers isValidArrayItemForDatabase
+#[DataProvider('provideValidArrayItemsForDatabase')]
+public function can_validate_valid_array_item_for_database(mixed $value): void
+
+public static function provideValidArrayItemsForDatabase(): array  // include null, VO instances
+
+#[DataProvider('provideInvalidArrayItemsForDatabase')]
+public function can_validate_invalid_array_item_for_database(mixed $value): void
+
+public static function provideInvalidArrayItemsForDatabase(): array  // string, int, bool, stdClass
+
+// covers transformArrayItemForPHP null branch
+public function can_transform_null_item_for_php(): void
+
+// covers transformArrayItemForPHP non-string guard
+public function throws_exception_for_non_string_item_from_database(): void
+// calls $this->fixture->transformArrayItemForPHP(42) — direct call, not via convertToPHPValue
+```
+
+The guard in `transformArrayItemForPostgres` is the only line intentionally left uncovered. Do not write tests that try to reach it through protected method access.
+
+## PHPStan Ignore on convertToDatabaseValue Calls in Tests
+Direct calls to `convertToDatabaseValue($phpValue, $this->platform)` in unit tests require `// @phpstan-ignore-line` because PHPStan cannot verify the mixed-typed argument at level max.

--- a/.claude/commands/new-dbal-type.md
+++ b/.claude/commands/new-dbal-type.md
@@ -9,7 +9,7 @@ Each group has a distinct style. Pick the right group and use its reference — 
 | Network | `Inet`, `Cidr`, `Macaddr`, `Macaddr8` | via `BaseNetworkTypeArray` | Validation traits extending `NetworkAddressValidationTrait` |
 | Geometric | `Point`, `Box`, `Circle`, `Line`, `Lseg`, `Path`, `Polygon` | via `BaseGeometricArray` | Per-type value objects in `ValueObject/`; `;`-separated arrays |
 | Range | `Int4Range`, `Int8Range`, `NumRange`, `DateRange`, `TsRange`, `TstzRange` | — | `BaseRangeType` + value objects extending `Range` |
-| Multirange | `Int4Multirange`, `Int8Multirange`, `NumMultirange`, etc. | — | `BaseMultirangeType` + value objects extending `Multirange` |
+| Multirange | `Int4Multirange`, `Int8Multirange`, `NumMultirange`, etc. | `Int4MultirangeArray`, `Int8MultirangeArray`, etc. via `BaseArray` | `BaseMultirangeType` + value objects extending `Multirange`; arrays extend `BaseArray` directly |
 | PostGIS spatial | `Geometry`, `Geography` | via `SpatialDataArray` | `BaseSpatialType`, shared `WktSpatialData`, EWKB→EWKT SQL |
 | Vector (pgvector) | `Vector`, `Halfvec`, `Sparsevec` | — | `BaseVector`, PHP float arrays, finiteness checks |
 | Integer arrays | — | `IntegerArray`, `BigIntArray`, `SmallIntArray` | `BaseIntegerArray` with min/max bounds |
@@ -55,7 +55,7 @@ Both unit AND integration tests are **required** for every new type. Before writ
 
 ### Unit tests → `tests/Unit/.../Types/`
 
-Cover: type name, null handling, valid round-trips (data provider), invalid types, invalid formats. Array types also: `isValidArrayItemForDatabase()`, `transformArrayItemForPHP()`.
+Cover: type name, null handling, valid round-trips (data provider), invalid types, invalid formats. Array types also require these four canonical methods — see `.ai-tools/rules/dbal-array-types.md` for exact names and structure: `can_validate_valid_array_item_for_database`, `can_validate_invalid_array_item_for_database`, `can_transform_null_item_for_php`, `throws_exception_for_non_string_item_from_database`. Direct calls to `transformArrayItemForPHP()` require no `// @phpstan-ignore-line`; calls to `convertToDatabaseValue($val, $platform)` do.
 
 If the PostgreSQL type accepts parameters (length, dimensions, precision, scale, SRID, etc.) also test `getSQLDeclaration()`: once with no parameters (bare type name) and once with parameters (e.g. `VECTOR(1024)`). Integration tests never call `getSQLDeclaration()` — without these unit tests schema generation bugs are invisible. For `TYPE(n)` types use `LengthAwareSQLDeclarationTrait`; other parameterisations need a custom override.
 

--- a/.github/instructions/dbal-array-types.instructions.md
+++ b/.github/instructions/dbal-array-types.instructions.md
@@ -1,0 +1,1 @@
+../../.ai-tools/rules/dbal-array-types.md

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $query = $em->createQuery('
   - Float arrays (`real[]`, `double precision[]`)
   - Text arrays (`text[]`)
   - Boolean arrays (`bool[]`)
-  - Date arrays (`date[]`, `timestamp[]`, `timestamptz[]`, `timetz`, `timetz[]`)
+  - Date and time (`date[]`, `interval`, `interval[]`, `timestamp[]`, `timestamptz[]`, `timetz`, `timetz[]`)
   - JSONB arrays (`jsonb[]`)
 - **Binary Types**
   - Raw binary data (`bytea`, `bytea[]`)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $query = $em->createQuery('
   - Float arrays (`real[]`, `double precision[]`)
   - Text arrays (`text[]`)
   - Boolean arrays (`bool[]`)
-  - Date arrays (`date[]`, `timestamp[]`, `timestamptz[]`)
+  - Date arrays (`date[]`, `timestamp[]`, `timestamptz[]`, `timetz`, `timetz[]`)
   - JSONB arrays (`jsonb[]`)
 - **Binary Types**
   - Raw binary data (`bytea`, `bytea[]`)

--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -22,6 +22,8 @@
 | interval[] | _interval | `MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray` |
 | timestamp[] | _timestamp | `MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray` |
 | timestamptz[] | _timestamptz | `MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray` |
+| timetz | timetz | `MartinGeorgiev\Doctrine\DBAL\Types\Timetz` |
+| timetz[] | _timetz | `MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray` |
 |---|---|---|
 | jsonb | jsonb | `MartinGeorgiev\Doctrine\DBAL\Types\Jsonb` |
 | jsonb[] | _jsonb | `MartinGeorgiev\Doctrine\DBAL\Types\JsonbArray` |

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -31,7 +31,7 @@ Type::addType('real[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\RealArray");
 Type::addType('text[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TextArray");
 Type::addType('uuid[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\UuidArray");
 
-// Datetime array types
+// Date and time types
 Type::addType('date[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\DateArray");
 Type::addType('interval', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Interval");
 Type::addType('interval[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\IntervalArray");

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -37,6 +37,8 @@ Type::addType('interval', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Interval");
 Type::addType('interval[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\IntervalArray");
 Type::addType('timestamp[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimestampArray");
 Type::addType('timestamptz[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimestampTzArray");
+Type::addType('timetz', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Timetz");
+Type::addType('timetz[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimetzArray");
 
 // JSON types
 Type::addType('jsonb', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Jsonb");
@@ -405,6 +407,9 @@ $platform->registerDoctrineTypeMapping('timestamp[]', 'timestamp[]');
 $platform->registerDoctrineTypeMapping('_timestamp', 'timestamp[]');
 $platform->registerDoctrineTypeMapping('timestamptz[]', 'timestamptz[]');
 $platform->registerDoctrineTypeMapping('_timestamptz', 'timestamptz[]');
+$platform->registerDoctrineTypeMapping('timetz', 'timetz');
+$platform->registerDoctrineTypeMapping('timetz[]', 'timetz[]');
+$platform->registerDoctrineTypeMapping('_timetz', 'timetz[]');
 
 // JSON type mappings
 $platform->registerDoctrineTypeMapping('jsonb', 'jsonb');

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -74,6 +74,9 @@ return [
                 '_timestamp' => 'timestamp[]',
                 'timestamptz[]' => 'timestamptz[]',
                 '_timestamptz' => 'timestamptz[]',
+                'timetz' => 'timetz',
+                'timetz[]' => 'timetz[]',
+                '_timetz' => 'timetz[]',
 
                 // JSON type mappings
                 'jsonb' => 'jsonb',
@@ -204,6 +207,8 @@ return [
         'interval[]' => MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray::class,
         'timestamp[]' => MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray::class,
         'timestamptz[]' => MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray::class,
+        'timetz' => MartinGeorgiev\Doctrine\DBAL\Types\Timetz::class,
+        'timetz[]' => MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray::class,
 
         // JSON types
         'jsonb' => MartinGeorgiev\Doctrine\DBAL\Types\Jsonb::class,

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -201,7 +201,7 @@ return [
         'text[]' => MartinGeorgiev\Doctrine\DBAL\Types\TextArray::class,
         'uuid[]' => MartinGeorgiev\Doctrine\DBAL\Types\UuidArray::class,
 
-        // Datetime array types
+        // Date and time types
         'date[]' => MartinGeorgiev\Doctrine\DBAL\Types\DateArray::class,
         'interval' => MartinGeorgiev\Doctrine\DBAL\Types\Interval::class,
         'interval[]' => MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray::class,

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -31,7 +31,7 @@ doctrine:
             'text[]': MartinGeorgiev\Doctrine\DBAL\Types\TextArray
             'uuid[]': MartinGeorgiev\Doctrine\DBAL\Types\UuidArray
 
-            # Datetime array types
+            # Date and time types
             'date[]': MartinGeorgiev\Doctrine\DBAL\Types\DateArray
             interval: MartinGeorgiev\Doctrine\DBAL\Types\Interval
             'interval[]': MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -37,6 +37,8 @@ doctrine:
             'interval[]': MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray
             'timestamp[]': MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray
             'timestamptz[]': MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray
+            timetz: MartinGeorgiev\Doctrine\DBAL\Types\Timetz
+            'timetz[]': MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray
 
             # JSON types
             jsonb: MartinGeorgiev\Doctrine\DBAL\Types\Jsonb
@@ -174,6 +176,9 @@ doctrine:
                     _timestamp: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMP_ARRAY
                     'timestamptz[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMPTZ_ARRAY
                     _timestamptz: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMPTZ_ARRAY
+                    timetz: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMETZ
+                    'timetz[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMETZ_ARRAY
+                    _timetz: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMETZ_ARRAY
 
                     # JSON type mappings
                     jsonb: !php/const MartinGeorgiev\Doctrine\DBAL\Type::JSONB

--- a/src/MartinGeorgiev/Doctrine/DBAL/Type.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Type.php
@@ -309,6 +309,16 @@ final class Type
     /**
      * @var string
      */
+    public const TIMETZ = 'timetz';
+
+    /**
+     * @var string
+     */
+    public const TIMETZ_ARRAY = 'timetz[]';
+
+    /**
+     * @var string
+     */
     public const TIMESTAMP_ARRAY = 'timestamp[]';
 
     /**

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimetzArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimetzArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTimetzArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid timetz format in array: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimetzArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimetzArrayItemForPHPException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTimetzArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array values must be strings, %s given', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimetzForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimetzForDatabaseException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTimetzForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Database value must be a string, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Database value must be a valid timetz string, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimetzForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimetzForPHPException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTimetzForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Value must be a string, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Timetz.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Timetz.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimetzForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimetzForPHPException;
+
+/**
+ * Implementation of PostgreSQL timetz (time with time zone) data type.
+ *
+ * Stores a time-of-day value with time zone offset. The PHP representation
+ * is a string in the format returned by PostgreSQL (e.g. "12:34:56+02:00").
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-datetime.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class Timetz extends BaseType
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::TIMETZ;
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidTimetzForDatabaseException::forInvalidType($value);
+        }
+
+        if ($value === '') {
+            throw InvalidTimetzForDatabaseException::forInvalidFormat($value);
+        }
+
+        return $value;
+    }
+
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidTimetzForPHPException::forInvalidType($value);
+        }
+
+        return $value;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArray.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimetzArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimetzArrayItemForPHPException;
+
+/**
+ * Implementation of PostgreSQL timetz[] data type.
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-datetime.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class TimetzArray extends BaseStringArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::TIMETZ_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        if ($item === null) {
+            return true;
+        }
+
+        if (!\is_string($item)) {
+            return false;
+        }
+
+        return $item !== '';
+    }
+
+    protected function createInvalidTypeExceptionForPHP(mixed $item): InvalidTimetzArrayItemForPHPException
+    {
+        return InvalidTimetzArrayItemForPHPException::forInvalidType($item);
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidTimetzArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidTimetzArrayItemForDatabaseException::forInvalidFormat($item);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArrayTypeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+class TimetzArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'timetz[]';
+    }
+
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'simple timetz array' => [['10:30:00+00', '14:45:00+02']],
+            'array with negative offset' => [['08:00:00-05', '20:00:00+08']],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArrayTypeTest.php
@@ -16,6 +16,7 @@ class TimetzArrayTypeTest extends ArrayTypeTestCase
         return [
             'simple timetz array' => [['10:30:00+00', '14:45:00+02']],
             'array with negative offset' => [['08:00:00-05', '20:00:00+08']],
+            'array with null item' => [[null, '10:30:00+00']],
         ];
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimetzTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimetzTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 class TimetzTypeTest extends ScalarTypeTestCase
@@ -13,15 +14,23 @@ class TimetzTypeTest extends ScalarTypeTestCase
         return 'timetz';
     }
 
+    #[DataProvider('provideValidTransformations')]
     #[Test]
-    public function can_handle_time_with_timezone(): void
+    public function can_transform_from_php_value(string $testValue): void
     {
-        $this->runDbalBindingRoundTrip($this->getTypeName(), $this->getPostgresTypeName(), '10:30:00+00');
+        $this->runDbalBindingRoundTrip($this->getTypeName(), $this->getPostgresTypeName(), $testValue);
     }
 
-    #[Test]
-    public function can_handle_time_with_positive_offset(): void
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideValidTransformations(): array
     {
-        $this->runDbalBindingRoundTrip($this->getTypeName(), $this->getPostgresTypeName(), '14:45:00+02');
+        return [
+            'UTC time' => ['10:30:00+00'],
+            'positive offset' => ['14:45:00+02'],
+            'negative offset' => ['08:00:00-05'],
+            'with microseconds' => ['12:34:56.123456+02'],
+        ];
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimetzTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimetzTypeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use PHPUnit\Framework\Attributes\Test;
+
+class TimetzTypeTest extends ScalarTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'timetz';
+    }
+
+    #[Test]
+    public function can_handle_time_with_timezone(): void
+    {
+        $this->runDbalBindingRoundTrip($this->getTypeName(), $this->getPostgresTypeName(), '10:30:00+00');
+    }
+
+    #[Test]
+    public function can_handle_time_with_positive_offset(): void
+    {
+        $this->runDbalBindingRoundTrip($this->getTypeName(), $this->getPostgresTypeName(), '14:45:00+02');
+    }
+}

--- a/tests/Integration/MartinGeorgiev/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/TestCase.php
@@ -73,6 +73,8 @@ use MartinGeorgiev\Doctrine\DBAL\Types\SmallIntArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TextArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Timetz;
+use MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange;
 use MartinGeorgiev\Doctrine\DBAL\Types\Tsquery;
 use MartinGeorgiev\Doctrine\DBAL\Types\TsqueryArray;
@@ -322,6 +324,8 @@ abstract class TestCase extends BaseTestCase
             'text[]' => TextArray::class,
             'timestamp[]' => TimestampArray::class,
             'timestamptz[]' => TimestampTzArray::class,
+            'timetz' => Timetz::class,
+            'timetz[]' => TimetzArray::class,
             'tsmultirange' => TsMultirange::class,
             'tsquery' => Tsquery::class,
             'tsquery[]' => TsqueryArray::class,

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArrayTest.php
@@ -159,7 +159,9 @@ class TimetzArrayTest extends TestCase
         return [
             'empty string' => [''],
             'integer' => [123],
+            'float' => [3.14],
             'boolean' => [true],
+            'object' => [new \stdClass()],
         ];
     }
 
@@ -176,12 +178,4 @@ class TimetzArrayTest extends TestCase
         $this->fixture->transformArrayItemForPHP(123);
     }
 
-    #[Test]
-    public function can_convert_array_with_null_to_database(): void
-    {
-        $phpValue = ['12:34:56+02:00', null, '00:00:00+00:00'];
-        $expected = '{"12:34:56+02:00",NULL,"00:00:00+00:00"}';
-
-        $this->assertSame($expected, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
-    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArrayTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimetzArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimetzArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TimetzArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private TimetzArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new TimetzArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('timetz[]', $this->fixture->getName());
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single timetz' => [
+                'phpValue' => ['12:34:56+02:00'],
+                'postgresValue' => '{"12:34:56+02:00"}',
+            ],
+            'multiple timetz values' => [
+                'phpValue' => ['12:34:56+02:00', '00:00:00+00:00'],
+                'postgresValue' => '{"12:34:56+02:00","00:00:00+00:00"}',
+            ],
+            'timetz with microseconds' => [
+                'phpValue' => ['12:34:56.123456-05:00'],
+                'postgresValue' => '{"12:34:56.123456-05:00"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [null, '12:34:56+02:00'],
+                'postgresValue' => '{NULL,"12:34:56+02:00"}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidTimetzArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'empty string item' => [['']],
+            'integer item' => [[123]],
+            'boolean item' => [[true]],
+            'mixed valid and invalid' => [['12:34:56+02:00', '']],
+            'valid mixed with integer' => [['12:34:56+02:00', 123]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidTimetzArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+        ];
+    }
+
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'simple timetz' => ['12:34:56+02:00'],
+            'UTC timetz' => ['00:00:00+00:00'],
+            'timetz with microseconds' => ['12:34:56.123456-05:00'],
+            'null value' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'empty string' => [''],
+            'integer' => [123],
+            'boolean' => [true],
+        ];
+    }
+
+    #[Test]
+    public function can_transform_null_item_for_php(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidTimetzArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(123);
+    }
+
+    #[Test]
+    public function can_convert_array_with_null_to_database(): void
+    {
+        $phpValue = ['12:34:56+02:00', null, '00:00:00+00:00'];
+        $expected = '{"12:34:56+02:00",NULL,"00:00:00+00:00"}';
+
+        $this->assertSame($expected, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimetzArrayTest.php
@@ -177,5 +177,4 @@ class TimetzArrayTest extends TestCase
         $this->expectException(InvalidTimetzArrayItemForPHPException::class);
         $this->fixture->transformArrayItemForPHP(123);
     }
-
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimetzTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimetzTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimetzForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimetzForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Timetz;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TimetzTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private Timetz $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new Timetz();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('timetz', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function converts_null_to_database_value(): void
+    {
+        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+    }
+
+    #[Test]
+    public function converts_null_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+    }
+
+    #[Test]
+    public function converts_empty_string_from_database_to_null(): void
+    {
+        $this->assertNull($this->fixture->convertToPHPValue('', $this->platform));
+    }
+
+    #[DataProvider('provideValidStringValues')]
+    #[Test]
+    public function can_convert_string_to_database_value(string $value): void
+    {
+        $this->assertSame($value, $this->fixture->convertToDatabaseValue($value, $this->platform));
+    }
+
+    #[DataProvider('provideValidStringValues')]
+    #[Test]
+    public function can_convert_string_to_php_value(string $value): void
+    {
+        $this->assertSame($value, $this->fixture->convertToPHPValue($value, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideValidStringValues(): array
+    {
+        return [
+            'simple timetz' => ['12:34:56+02:00'],
+            'UTC' => ['00:00:00+00:00'],
+            'with microseconds' => ['12:34:56.123456-05:00'],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value(mixed $value): void
+    {
+        $this->expectException(InvalidTimetzForDatabaseException::class);
+
+        $this->fixture->convertToDatabaseValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'integer input' => [42],
+            'array input' => [['not', 'a', 'string']],
+            'object input' => [new \stdClass()],
+            'boolean input' => [true],
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_empty_database_value(): void
+    {
+        $this->expectException(InvalidTimetzForDatabaseException::class);
+
+        $this->fixture->convertToDatabaseValue('', $this->platform);
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value(mixed $value): void
+    {
+        $this->expectException(InvalidTimetzForPHPException::class);
+
+        $this->fixture->convertToPHPValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'integer input' => [42],
+            'array input' => [['not', 'a', 'string']],
+            'object input' => [new \stdClass()],
+            'boolean input' => [true],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimetzTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimetzTest.php
@@ -34,48 +34,49 @@ class TimetzTest extends TestCase
         $this->assertSame('timetz', $this->fixture->getName());
     }
 
+    #[DataProvider('provideValidTransformations')]
     #[Test]
-    public function converts_null_to_database_value(): void
+    public function can_transform_from_php_value(?string $phpValue, ?string $databaseValue): void
     {
-        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+        $this->assertSame($databaseValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
     }
 
+    #[DataProvider('provideValidTransformations')]
     #[Test]
-    public function converts_null_to_php_value(): void
+    public function can_transform_to_php_value(?string $phpValue, ?string $databaseValue): void
     {
-        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($databaseValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{phpValue: string|null, databaseValue: string|null}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'databaseValue' => null,
+            ],
+            'simple timetz' => [
+                'phpValue' => '12:34:56+02:00',
+                'databaseValue' => '12:34:56+02:00',
+            ],
+            'UTC' => [
+                'phpValue' => '00:00:00+00:00',
+                'databaseValue' => '00:00:00+00:00',
+            ],
+            'with microseconds' => [
+                'phpValue' => '12:34:56.123456-05:00',
+                'databaseValue' => '12:34:56.123456-05:00',
+            ],
+        ];
     }
 
     #[Test]
     public function converts_empty_string_from_database_to_null(): void
     {
         $this->assertNull($this->fixture->convertToPHPValue('', $this->platform));
-    }
-
-    #[DataProvider('provideValidStringValues')]
-    #[Test]
-    public function can_convert_string_to_database_value(string $value): void
-    {
-        $this->assertSame($value, $this->fixture->convertToDatabaseValue($value, $this->platform));
-    }
-
-    #[DataProvider('provideValidStringValues')]
-    #[Test]
-    public function can_convert_string_to_php_value(string $value): void
-    {
-        $this->assertSame($value, $this->fixture->convertToPHPValue($value, $this->platform));
-    }
-
-    /**
-     * @return array<string, array{string}>
-     */
-    public static function provideValidStringValues(): array
-    {
-        return [
-            'simple timetz' => ['12:34:56+02:00'],
-            'UTC' => ['00:00:00+00:00'],
-            'with microseconds' => ['12:34:56.123456-05:00'],
-        ];
     }
 
     #[DataProvider('provideInvalidDatabaseValueInputs')]
@@ -93,19 +94,13 @@ class TimetzTest extends TestCase
     public static function provideInvalidDatabaseValueInputs(): array
     {
         return [
+            'empty string' => [''],
             'integer input' => [42],
+            'float input' => [3.14],
             'array input' => [['not', 'a', 'string']],
             'object input' => [new \stdClass()],
             'boolean input' => [true],
         ];
-    }
-
-    #[Test]
-    public function throws_exception_for_empty_database_value(): void
-    {
-        $this->expectException(InvalidTimetzForDatabaseException::class);
-
-        $this->fixture->convertToDatabaseValue('', $this->platform);
     }
 
     #[DataProvider('provideInvalidPHPValueInputs')]
@@ -124,6 +119,7 @@ class TimetzTest extends TestCase
     {
         return [
             'integer input' => [42],
+            'float input' => [3.14],
             'array input' => [['not', 'a', 'string']],
             'object input' => [new \stdClass()],
             'boolean input' => [true],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for PostgreSQL `timetz` (time with timezone) type and `timetz[]` array variant with full bidirectional conversion support.

* **Documentation**
  * Updated integration guides for Doctrine, Laravel, and Symfony with `timetz` type configuration examples.
  * Added DBAL array types documentation and development guidelines.
  * Updated available types reference with new `timetz` entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-georgiev/postgresql-for-doctrine/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->