### PR TITLE
feat: add support for `citext` DBAL type and its array variation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ $query = $em->createQuery('
 - **Text Search Types**
   - Full-text search document (`tsvector`, `tsvector[]`)
   - Full-text search query (`tsquery`, `tsquery[]`)
+- **Case-Insensitive Text Types** (requires [citext](https://www.postgresql.org/docs/current/citext.html) extension)
+  - Case-insensitive text (`citext`, `citext[]`)
 - **Key-Value Types** (requires [hstore](https://www.postgresql.org/docs/18/hstore.html) extension)
   - Key-value store (`hstore`, `hstore[]`)
 - **Monetary Types**

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $query = $em->createQuery('
 - **Text Search Types**
   - Full-text search document (`tsvector`, `tsvector[]`)
   - Full-text search query (`tsquery`, `tsquery[]`)
-- **Case-Insensitive Text Types** (requires [citext](https://www.postgresql.org/docs/current/citext.html) extension)
+- **Case-Insensitive Text Types** (requires [citext](https://www.postgresql.org/docs/18/citext.html) extension)
   - Case-insensitive text (`citext`, `citext[]`)
 - **Key-Value Types** (requires [hstore](https://www.postgresql.org/docs/18/hstore.html) extension)
   - Key-value store (`hstore`, `hstore[]`)

--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -27,6 +27,8 @@
 | jsonb[] | _jsonb | `MartinGeorgiev\Doctrine\DBAL\Types\JsonbArray` |
 | text[] | _text | `MartinGeorgiev\Doctrine\DBAL\Types\TextArray` |
 | uuid[] | _uuid | `MartinGeorgiev\Doctrine\DBAL\Types\UuidArray` (see [note](#uuid-array-type)) |
+| citext | citext | `MartinGeorgiev\Doctrine\DBAL\Types\Citext` (see [note](#citext-type)) |
+| citext[] | _citext | `MartinGeorgiev\Doctrine\DBAL\Types\CitextArray` |
 |---|---|---|
 | cidr | cidr | `MartinGeorgiev\Doctrine\DBAL\Types\Cidr` |
 | cidr[] | _cidr | `MartinGeorgiev\Doctrine\DBAL\Types\CidrArray` |
@@ -214,3 +216,17 @@ CREATE EXTENSION IF NOT EXISTS hstore;
 ```
 
 It maps to `array<string, string|null>` in PHP. Keys and values are always strings; a `NULL` value in hstore is represented as `null` in PHP.
+
+---
+
+## Citext Type
+
+The `citext` type requires the PostgreSQL [`citext`](https://www.postgresql.org/docs/current/citext.html) extension. Enable it with:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS citext;
+```
+
+It is a case-insensitive text type: comparisons are case-insensitive in PostgreSQL while the original casing of values is preserved. It maps to `string` in PHP and behaves identically to `text` for storage and retrieval — the difference is purely in how PostgreSQL evaluates equality and ordering.
+
+Use `citext` when you want case-insensitive lookups (e.g. usernames, email addresses) without lowercasing values on write.

--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -235,7 +235,7 @@ It maps to `array<string, string|null>` in PHP. Keys and values are always strin
 
 ## Citext Type
 
-The `citext` type requires the PostgreSQL [`citext`](https://www.postgresql.org/docs/current/citext.html) extension. Enable it with:
+The `citext` type requires the PostgreSQL [`citext`](https://www.postgresql.org/docs/18/citext.html) extension. Enable it with:
 
 ```sql
 CREATE EXTENSION IF NOT EXISTS citext;

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -31,6 +31,10 @@ Type::addType('real[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\RealArray");
 Type::addType('text[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TextArray");
 Type::addType('uuid[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\UuidArray");
 
+// Case-insensitive text types
+Type::addType('citext', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Citext");
+Type::addType('citext[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\CitextArray");
+
 // Datetime array types
 Type::addType('date[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\DateArray");
 Type::addType('interval', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Interval");
@@ -394,6 +398,11 @@ $platform->registerDoctrineTypeMapping('text[]', 'text[]');
 $platform->registerDoctrineTypeMapping('_text', 'text[]');
 $platform->registerDoctrineTypeMapping('uuid[]', 'uuid[]');
 $platform->registerDoctrineTypeMapping('_uuid', 'uuid[]');
+
+// Case-insensitive text type mappings
+$platform->registerDoctrineTypeMapping('citext', 'citext');
+$platform->registerDoctrineTypeMapping('citext[]', 'citext[]');
+$platform->registerDoctrineTypeMapping('_citext', 'citext[]');
 
 // Datetime array type mappings
 $platform->registerDoctrineTypeMapping('date[]', 'date[]');

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -64,6 +64,11 @@ return [
                 'uuid[]' => 'uuid[]',
                 '_uuid' => 'uuid[]',
 
+                // Case-insensitive text type mappings
+                'citext' => 'citext',
+                'citext[]' => 'citext[]',
+                '_citext' => 'citext[]',
+
                 // Datetime array type mappings
                 'date[]' => 'date[]',
                 '_date' => 'date[]',
@@ -197,6 +202,10 @@ return [
         'real[]' => MartinGeorgiev\Doctrine\DBAL\Types\RealArray::class,
         'text[]' => MartinGeorgiev\Doctrine\DBAL\Types\TextArray::class,
         'uuid[]' => MartinGeorgiev\Doctrine\DBAL\Types\UuidArray::class,
+
+        // Case-insensitive text types
+        'citext' => MartinGeorgiev\Doctrine\DBAL\Types\Citext::class,
+        'citext[]' => MartinGeorgiev\Doctrine\DBAL\Types\CitextArray::class,
 
         // Datetime array types
         'date[]' => MartinGeorgiev\Doctrine\DBAL\Types\DateArray::class,

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -90,6 +90,10 @@ doctrine:
             tsmultirange: MartinGeorgiev\Doctrine\DBAL\Types\TsMultirange
             tstzmultirange: MartinGeorgiev\Doctrine\DBAL\Types\TstzMultirange
 
+            # Case-insensitive text types
+            citext: MartinGeorgiev\Doctrine\DBAL\Types\Citext
+            'citext[]': MartinGeorgiev\Doctrine\DBAL\Types\CitextArray
+
             # Text search types
             tsquery: MartinGeorgiev\Doctrine\DBAL\Types\Tsquery
             'tsquery[]': MartinGeorgiev\Doctrine\DBAL\Types\TsqueryArray
@@ -163,6 +167,11 @@ doctrine:
                     _text: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TEXT_ARRAY
                     'uuid[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::UUID_ARRAY
                     _uuid: !php/const MartinGeorgiev\Doctrine\DBAL\Type::UUID_ARRAY
+
+                    # Case-insensitive text type mappings
+                    citext: !php/const MartinGeorgiev\Doctrine\DBAL\Type::CITEXT
+                    'citext[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::CITEXT_ARRAY
+                    _citext: !php/const MartinGeorgiev\Doctrine\DBAL\Type::CITEXT_ARRAY
 
                     # Datetime array type mappings
                     'date[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::DATE_ARRAY

--- a/src/MartinGeorgiev/Doctrine/DBAL/Type.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Type.php
@@ -59,6 +59,16 @@ final class Type
     /**
      * @var string
      */
+    public const CITEXT = 'citext';
+
+    /**
+     * @var string
+     */
+    public const CITEXT_ARRAY = 'citext[]';
+
+    /**
+     * @var string
+     */
     public const CIDR = 'cidr';
 
     /**

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Citext.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Citext.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCitextForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCitextForPHPException;
+
+/**
+ * Implementation of PostgreSQL citext extension type.
+ *
+ * Case-insensitive text type — comparisons are case-insensitive in PostgreSQL
+ * while preserving the original casing. Requires the citext extension.
+ *
+ * @see https://www.postgresql.org/docs/18/citext.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class Citext extends BaseType
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::CITEXT;
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidCitextForDatabaseException::forInvalidType($value);
+        }
+
+        return $value;
+    }
+
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidCitextForPHPException::forInvalidType($value);
+        }
+
+        return $value;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Citext.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Citext.php
@@ -42,7 +42,7 @@ final class Citext extends BaseType
 
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
     {
-        if ($value === null || $value === '') {
+        if ($value === null) {
             return null;
         }
 

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/CitextArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/CitextArray.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCitextArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCitextArrayItemForPHPException;
+
+/**
+ * Implementation of PostgreSQL citext[] data type.
+ *
+ * @see https://www.postgresql.org/docs/18/citext.html
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class CitextArray extends BaseStringArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::CITEXT_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        return $item === null || \is_string($item);
+    }
+
+    protected function createInvalidTypeExceptionForPHP(mixed $item): InvalidCitextArrayItemForPHPException
+    {
+        return InvalidCitextArrayItemForPHPException::forInvalidType($item);
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidCitextArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidCitextArrayItemForDatabaseException::forInvalidType($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCitextArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCitextArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCitextArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array values must be strings, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCitextArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCitextArrayItemForPHPException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCitextArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array values must be strings, %s given', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCitextForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCitextForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCitextForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Database value must be a string, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCitextForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCitextForPHPException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.6
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCitextForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Value must be a string, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/HstoreArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/HstoreArray.php
@@ -15,7 +15,7 @@ use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
  *
  * Maps PostgreSQL hstore[] to PHP array<int, array<string, string|null>|null>.
  *
- * @see https://www.postgresql.org/docs/current/hstore.html
+ * @see https://www.postgresql.org/docs/18/hstore.html
  * @since 4.6
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTypeTest.php
@@ -23,15 +23,14 @@ class CitextArrayTypeTest extends ArrayTypeTestCase
         return 'citext[]';
     }
 
-    /**
-     * @return array<string, array{array<int, string>}>
-     */
     public static function provideValidTransformations(): array
     {
         return [
             'simple string array' => [['foo', 'bar', 'baz']],
             'mixed case array' => [['Hello', 'WORLD', 'CamelCase']],
             'array with special chars' => [['café', 'naïve']],
+            'array with null item' => [[null, 'hello']],
+            'array with empty string' => [['', 'hello']],
         ];
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTypeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+class CitextArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            $this->connection->executeStatement('CREATE EXTENSION IF NOT EXISTS citext');
+        } catch (\Throwable) {
+            $this->markTestSkipped('citext extension is not available');
+        }
+    }
+
+    protected function getTypeName(): string
+    {
+        return 'citext[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, string>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'simple string array' => [['foo', 'bar', 'baz']],
+            'mixed case array' => [['Hello', 'WORLD', 'CamelCase']],
+            'array with special chars' => [['café', 'naïve']],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTypeTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Test;
-
 class CitextArrayTypeTest extends ArrayTypeTestCase
 {
     protected function setUp(): void
@@ -15,6 +12,7 @@ class CitextArrayTypeTest extends ArrayTypeTestCase
 
         try {
             $this->connection->executeStatement('CREATE EXTENSION IF NOT EXISTS citext');
+            $this->connection->executeStatement(\sprintf('ALTER EXTENSION citext SET SCHEMA %s', self::DATABASE_SCHEMA));
         } catch (\Throwable) {
             $this->markTestSkipped('citext extension is not available');
         }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 class CitextTypeTest extends ScalarTypeTestCase
@@ -25,21 +26,22 @@ class CitextTypeTest extends ScalarTypeTestCase
         return 'citext';
     }
 
+    #[DataProvider('provideValidTransformations')]
     #[Test]
-    public function can_handle_simple_citext_value(): void
+    public function can_transform_from_php_value(string $testValue): void
     {
-        $typeName = $this->getTypeName();
-        $columnType = $this->getPostgresTypeName();
-
-        $this->runDbalBindingRoundTrip($typeName, $columnType, 'Hello World');
+        $this->runDbalBindingRoundTrip($this->getTypeName(), $this->getPostgresTypeName(), $testValue);
     }
 
-    #[Test]
-    public function can_handle_citext_with_mixed_case(): void
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideValidTransformations(): array
     {
-        $typeName = $this->getTypeName();
-        $columnType = $this->getPostgresTypeName();
-
-        $this->runDbalBindingRoundTrip($typeName, $columnType, 'CaseInsensitive TEXT');
+        return [
+            'simple text' => ['Hello World'],
+            'mixed case' => ['CaseInsensitive TEXT'],
+            'empty string' => [''],
+        ];
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextTypeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use PHPUnit\Framework\Attributes\Test;
+
+class CitextTypeTest extends ScalarTypeTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            $this->connection->executeStatement('CREATE EXTENSION IF NOT EXISTS citext');
+        } catch (\Throwable) {
+            $this->markTestSkipped('citext extension is not available');
+        }
+    }
+
+    protected function getTypeName(): string
+    {
+        return 'citext';
+    }
+
+    #[Test]
+    public function can_handle_simple_citext_value(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, 'Hello World');
+    }
+
+    #[Test]
+    public function can_handle_citext_with_mixed_case(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, 'CaseInsensitive TEXT');
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextTypeTest.php
@@ -14,6 +14,7 @@ class CitextTypeTest extends ScalarTypeTestCase
 
         try {
             $this->connection->executeStatement('CREATE EXTENSION IF NOT EXISTS citext');
+            $this->connection->executeStatement(\sprintf('ALTER EXTENSION citext SET SCHEMA %s', self::DATABASE_SCHEMA));
         } catch (\Throwable) {
             $this->markTestSkipped('citext extension is not available');
         }

--- a/tests/Integration/MartinGeorgiev/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/TestCase.php
@@ -27,6 +27,8 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Cidr;
 use MartinGeorgiev\Doctrine\DBAL\Types\CidrArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Circle;
 use MartinGeorgiev\Doctrine\DBAL\Types\CircleArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Citext;
+use MartinGeorgiev\Doctrine\DBAL\Types\CitextArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateMultirange;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateMultirangeArray;
@@ -290,6 +292,8 @@ abstract class TestCase extends BaseTestCase
             'circle' => Circle::class,
             'circle[]' => CircleArray::class,
             'cidr[]' => CidrArray::class,
+            'citext' => Citext::class,
+            'citext[]' => CitextArray::class,
             'date[]' => DateArray::class,
             'daterange' => DateRange::class,
             'daterange[]' => DateRangeArray::class,

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\CitextArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCitextArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCitextArrayItemForPHPException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CitextArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private CitextArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new CitextArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('citext[]', $this->fixture->getName());
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_from_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function can_transform_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single string' => [
+                'phpValue' => ['hello'],
+                'postgresValue' => '{"hello"}',
+            ],
+            'multiple strings' => [
+                'phpValue' => ['Hello', 'World'],
+                'postgresValue' => '{"Hello","World"}',
+            ],
+            'mixed case strings' => [
+                'phpValue' => ['User@Example.COM', 'hello world'],
+                'postgresValue' => '{"User@Example.COM","hello world"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [null, 'hello'],
+                'postgresValue' => '{NULL,"hello"}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidCitextArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'integer item' => [[123]],
+            'boolean item' => [[true]],
+            'object item' => [[new \stdClass()]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidCitextArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+        ];
+    }
+
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'simple string' => ['hello'],
+            'mixed case string' => ['Hello World'],
+            'empty string' => [''],
+            'null value' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function can_validate_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'integer' => [123],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function can_transform_null_item_for_php(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidCitextArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(123);
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTest.php
@@ -156,6 +156,7 @@ class CitextArrayTest extends TestCase
     {
         return [
             'integer' => [123],
+            'float' => [3.14],
             'boolean' => [true],
             'object' => [new \stdClass()],
         ];

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextTest.php
@@ -70,13 +70,11 @@ class CitextTest extends TestCase
                 'phpValue' => 'User@Example.COM',
                 'databaseValue' => 'User@Example.COM',
             ],
+            'empty string' => [
+                'phpValue' => '',
+                'databaseValue' => '',
+            ],
         ];
-    }
-
-    #[Test]
-    public function converts_empty_string_from_database_to_null(): void
-    {
-        $this->assertNull($this->fixture->convertToPHPValue('', $this->platform));
     }
 
     #[DataProvider('provideInvalidDatabaseValueInputs')]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextTest.php
@@ -34,16 +34,43 @@ class CitextTest extends TestCase
         $this->assertSame('citext', $this->fixture->getName());
     }
 
+    #[DataProvider('provideValidTransformations')]
     #[Test]
-    public function converts_null_to_database_value(): void
+    public function can_transform_from_php_value(?string $phpValue, ?string $databaseValue): void
     {
-        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+        $this->assertSame($databaseValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
     }
 
+    #[DataProvider('provideValidTransformations')]
     #[Test]
-    public function converts_null_to_php_value(): void
+    public function can_transform_to_php_value(?string $phpValue, ?string $databaseValue): void
     {
-        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($databaseValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{phpValue: string|null, databaseValue: string|null}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'databaseValue' => null,
+            ],
+            'simple text' => [
+                'phpValue' => 'hello',
+                'databaseValue' => 'hello',
+            ],
+            'mixed case' => [
+                'phpValue' => 'Hello World',
+                'databaseValue' => 'Hello World',
+            ],
+            'email' => [
+                'phpValue' => 'User@Example.COM',
+                'databaseValue' => 'User@Example.COM',
+            ],
+        ];
     }
 
     #[Test]
@@ -52,35 +79,9 @@ class CitextTest extends TestCase
         $this->assertNull($this->fixture->convertToPHPValue('', $this->platform));
     }
 
-    #[DataProvider('provideValidStringValues')]
-    #[Test]
-    public function can_convert_string_to_database_value(string $value): void
-    {
-        $this->assertSame($value, $this->fixture->convertToDatabaseValue($value, $this->platform));
-    }
-
-    #[DataProvider('provideValidStringValues')]
-    #[Test]
-    public function can_convert_string_to_php_value(string $value): void
-    {
-        $this->assertSame($value, $this->fixture->convertToPHPValue($value, $this->platform));
-    }
-
-    /**
-     * @return array<string, array{string}>
-     */
-    public static function provideValidStringValues(): array
-    {
-        return [
-            'simple text' => ['hello'],
-            'mixed case' => ['Hello World'],
-            'email' => ['User@Example.COM'],
-        ];
-    }
-
     #[DataProvider('provideInvalidDatabaseValueInputs')]
     #[Test]
-    public function throws_exception_for_invalid_database_value(mixed $value): void
+    public function throws_exception_for_invalid_database_value_inputs(mixed $value): void
     {
         $this->expectException(InvalidCitextForDatabaseException::class);
 
@@ -94,14 +95,16 @@ class CitextTest extends TestCase
     {
         return [
             'integer input' => [42],
+            'float input' => [3.14],
             'array input' => [['not', 'a', 'string']],
+            'boolean input' => [true],
             'object input' => [new \stdClass()],
         ];
     }
 
     #[DataProvider('provideInvalidPHPValueInputs')]
     #[Test]
-    public function throws_exception_for_invalid_php_value(mixed $value): void
+    public function throws_exception_for_invalid_php_value_inputs(mixed $value): void
     {
         $this->expectException(InvalidCitextForPHPException::class);
 
@@ -115,7 +118,9 @@ class CitextTest extends TestCase
     {
         return [
             'integer input' => [42],
+            'float input' => [3.14],
             'array input' => [['not', 'a', 'string']],
+            'boolean input' => [true],
             'object input' => [new \stdClass()],
         ];
     }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Citext;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCitextForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCitextForPHPException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CitextTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    private MockObject $platform;
+
+    private Citext $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = new Citext();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('citext', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function converts_null_to_database_value(): void
+    {
+        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+    }
+
+    #[Test]
+    public function converts_null_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+    }
+
+    #[Test]
+    public function converts_empty_string_from_database_to_null(): void
+    {
+        $this->assertNull($this->fixture->convertToPHPValue('', $this->platform));
+    }
+
+    #[DataProvider('provideValidStringValues')]
+    #[Test]
+    public function can_convert_string_to_database_value(string $value): void
+    {
+        $this->assertSame($value, $this->fixture->convertToDatabaseValue($value, $this->platform));
+    }
+
+    #[DataProvider('provideValidStringValues')]
+    #[Test]
+    public function can_convert_string_to_php_value(string $value): void
+    {
+        $this->assertSame($value, $this->fixture->convertToPHPValue($value, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideValidStringValues(): array
+    {
+        return [
+            'simple text' => ['hello'],
+            'mixed case' => ['Hello World'],
+            'email' => ['User@Example.COM'],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value(mixed $value): void
+    {
+        $this->expectException(InvalidCitextForDatabaseException::class);
+
+        $this->fixture->convertToDatabaseValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'integer input' => [42],
+            'array input' => [['not', 'a', 'string']],
+            'object input' => [new \stdClass()],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value(mixed $value): void
+    {
+        $this->expectException(InvalidCitextForPHPException::class);
+
+        $this->fixture->convertToPHPValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'integer input' => [42],
+            'array input' => [['not', 'a', 'string']],
+            'object input' => [new \stdClass()],
+        ];
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for PostgreSQL case-insensitive text (`citext`) and `citext[]` array types.

* **Documentation**
  * README and AVAILABLE-TYPES updated with citext guidance and examples.
  * Integration guides for Doctrine, Laravel, and Symfony updated with configuration and mapping notes.
  * Minor documentation link update for hstore reference.

* **Tests**
  * Added unit and integration tests covering citext and citext[] behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-georgiev/postgresql-for-doctrine/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->