### PR TITLE
feat: widen support of PostGIS functions

### DIFF
--- a/docs/AVAILABLE-FUNCTIONS-AND-OPERATORS.md
+++ b/docs/AVAILABLE-FUNCTIONS-AND-OPERATORS.md
@@ -194,10 +194,14 @@ Distance functions for fixed-dimension float vectors stored with the `vector` ty
 - **JSONB Path Functions**: Advanced JSONB querying with path expressions
 
 ### **Spatial Functions (PostGIS)**
+- **Accessor Functions**: Retrieve geometry properties
+- **Constructor Functions**: Create geometries from coordinates and parameters
 - **Relationship Functions**: Test spatial relationships between geometries
 - **Measurement Functions**: Calculate distances, areas, lengths, and angles
 - **Overlay Functions**: Perform geometric operations (intersection, union, difference)
 - **Processing Functions**: Transform, simplify, and modify geometries
+- **Editor Functions**: Modify geometry properties (SRID, coordinates, snapping, segmentizing)
+- **Linear Referencing Functions**: Locate points and substrings along linear geometries
 
 ### **Text & Pattern Functions**
 - **Regexp Functions**: Pattern matching and replacement

--- a/docs/SPATIAL-FUNCTIONS-AND-OPERATORS.md
+++ b/docs/SPATIAL-FUNCTIONS-AND-OPERATORS.md
@@ -84,10 +84,20 @@ These functions return properties and information about geometries.
 
 | PostgreSQL functions | Register for DQL as | Description | Implemented by |
 |---|---|---|---|
+| ST_CoordDim | ST_COORDDIM | Returns the coordinate dimension of a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_CoordDim` |
 | ST_CurveN | ST_CURVEN | Returns the Nth curve of a CompoundCurve | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_CurveN` |
+| ST_GeometryType | ST_GEOMETRYTYPE | Returns the SQL-MM type string of a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType` |
 | ST_HasM | ST_HASM | Returns true if the geometry has an M (measure) coordinate | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_HasM` |
 | ST_HasZ | ST_HASZ | Returns true if the geometry has a Z coordinate | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_HasZ` |
+| ST_IsEmpty | ST_ISEMPTY | Returns true if the geometry is an empty geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_IsEmpty` |
+| ST_IsValid | ST_ISVALID | Returns true if the geometry is well-formed and valid | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_IsValid` |
+| ST_NPoints | ST_NPOINTS | Returns the number of points (vertices) in a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_NPoints` |
 | ST_NumCurves | ST_NUMCURVES | Returns the number of curves in a CompoundCurve | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_NumCurves` |
+| ST_NumGeometries | ST_NUMGEOMETRIES | Returns the number of elements in a geometry collection | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_NumGeometries` |
+| ST_SRID | ST_SRID | Returns the spatial reference identifier of a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SRID` |
+| ST_X | ST_X | Returns the X coordinate of a Point | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_X` |
+| ST_Y | ST_Y | Returns the Y coordinate of a Point | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Y` |
+| ST_Z | ST_Z | Returns the Z coordinate of a Point | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Z` |
 
 ## PostGIS Measurement Functions
 
@@ -104,7 +114,9 @@ These functions calculate various measurements of geometries including lengths, 
 | ST_Distance | ST_DISTANCE | Returns the 2D distance between two geometries | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Distance` |
 | ST_3DDistance | ST_3DDISTANCE | Returns the 3D distance between two geometries | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_3DDistance` |
 | ST_Centroid | ST_CENTROID | Returns the geometric center of a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Centroid` |
+| ST_ClosestPoint | ST_CLOSESTPOINT | Returns the 2D point on geometry A that is closest to geometry B | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_ClosestPoint` |
 | ST_MaxDistance | ST_MAXDISTANCE | Returns the maximum distance between two geometries | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MaxDistance` |
+| ST_ShortestLine | ST_SHORTESTLINE | Returns the 2D shortest line between two geometries | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_ShortestLine` |
 | ST_HausdorffDistance | ST_HAUSDORFFDISTANCE | Returns the Hausdorff distance between two geometries | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_HausdorffDistance` |
 | ST_FrechetDistance | ST_FRECHETDISTANCE | Returns the Fréchet distance between two geometries | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_FrechetDistance` |
 | ST_Azimuth | ST_AZIMUTH | Returns the azimuth between two points in radians | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Azimuth` |
@@ -136,6 +148,18 @@ These functions work with polygonal coverages (sets of non-overlapping polygons 
 |---|---|---|---|
 | ST_CoverageUnion | ST_COVERAGEUNION | Computes the union of a set of polygons forming a coverage by removing shared edges | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_CoverageUnion` |
 
+## PostGIS Geometry Constructor Functions
+
+These functions create new geometry objects from coordinates, other geometries, or well-known representations.
+
+| PostgreSQL functions | Register for DQL as | Description | Implemented by |
+|---|---|---|---|
+| ST_MakeEnvelope | ST_MAKEENVELOPE | Creates a rectangular Polygon from minimum and maximum coordinates | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MakeEnvelope` |
+| ST_MakeLine | ST_MAKELINE | Creates a LineString from Point, MultiPoint, or LineString geometries | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MakeLine` |
+| ST_MakePoint | ST_MAKEPOINT | Creates a 2D, 3DZ, or 4D Point from coordinates | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MakePoint` |
+| ST_Point | ST_POINT | Creates a Point with an optional SRID | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Point` |
+| ST_TileEnvelope | ST_TILEENVELOPE | Creates a rectangular Polygon for a Web Mercator tile by zoom/x/y | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_TileEnvelope` |
+
 ## PostGIS GeoJSON functions
 
 | PostgreSQL functions | Register for DQL as | Description | Implemented by |
@@ -155,24 +179,43 @@ These functions modify and transform geometries including buffering, simplificat
 | ST_ConvexHull | ST_CONVEXHULL | Returns the convex hull of a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_ConvexHull` |
 | ST_CurveToLine | ST_CURVETOLINE | Converts curved geometries to linear geometries | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_CurveToLine` |
 | ST_Envelope | ST_ENVELOPE | Returns the bounding box as a polygon | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Envelope` |
+| ST_FlipCoordinates | ST_FLIPCOORDINATES | Returns a geometry with X and Y coordinates flipped | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_FlipCoordinates` |
 | ST_Force2D | ST_FORCE2D | Forces geometry to 2D by removing Z/M coordinates | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Force2D` |
 | ST_Force3D | ST_FORCE3D | Forces geometry to 3D by adding Z coordinate if needed | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Force3D` |
 | ST_Force4D | ST_FORCE4D | Forces geometry to 4D by adding Z and M coordinates if needed | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Force4D` |
 | ST_Letters | ST_LETTERS | Creates geometries that look like letters | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Letters` |
 | ST_LineExtend | ST_LINEEXTEND | Returns a line extended forwards and backwards by specified distances | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_LineExtend` |
 | ST_LineToCurve | ST_LINETOCURVE | Converts linear geometries to curved geometries where possible | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_LineToCurve` |
+| ST_MinimumBoundingCircle | ST_MINIMUMBOUNDINGCIRCLE | Returns the smallest circle polygon that contains a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MinimumBoundingCircle` |
+| ST_OffsetCurve | ST_OFFSETCURVE | Returns an offset line at a given distance and side from an input line | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_OffsetCurve` |
+| ST_PointOnSurface | ST_POINTONSURFACE | Returns a point guaranteed to lie on the surface of a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_PointOnSurface` |
+| ST_GeneratePoints | ST_GENERATEPOINTS | Generates a multipoint of random points inside a polygon | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeneratePoints` |
 | ST_RemoveIrrelevantPointsForView | ST_REMOVEIRRELEVANTPOINTSFORVIEW | Removes points that are irrelevant for rendering a geometry at a given view | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_RemoveIrrelevantPointsForView` |
 | ST_RemoveSmallParts | ST_REMOVESMALLPARTS | Removes small polygon rings and linestrings from a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_RemoveSmallParts` |
 | ST_Reverse | ST_REVERSE | Reverses the order of points in a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Reverse` |
 | ST_Rotate | ST_ROTATE | Rotates a geometry by given angle | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Rotate` |
 | ST_Scale | ST_SCALE | Scales a geometry by given factors | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Scale` |
+| ST_Segmentize | ST_SEGMENTIZE | Returns a modified geometry having no segment longer than the given max length | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Segmentize` |
+| ST_SetSRID | ST_SETSRID | Sets the SRID on a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SetSRID` |
 | ST_Simplify | ST_SIMPLIFY | Simplifies geometry using Douglas-Peucker algorithm | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Simplify` |
 | ST_SimplifyPolygonHull | ST_SIMPLIFYPOLYGONHULL | Computes a simplified topology-preserving outer or inner hull of a polygon | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SimplifyPolygonHull` |
 | ST_SimplifyPreserveTopology | ST_SIMPLIFYPRESERVETOPOLOGY | Simplifies geometry while preserving topology | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SimplifyPreserveTopology` |
 | ST_SimplifyVW | ST_SIMPLIFYVW | Simplifies geometry using Visvalingam-Whyatt algorithm | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SimplifyVW` |
+| ST_Snap | ST_SNAP | Snaps the vertices and segments of a geometry to another geometry's vertices | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Snap` |
 | ST_Transform | ST_TRANSFORM | Transforms geometry to different coordinate system | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Transform` |
 | ST_Translate | ST_TRANSLATE | Translates a geometry by given offsets | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Translate` |
 | ST_TriangulatePolygon | ST_TRIANGULATEPOLYGON | Computes the constrained Delaunay triangulation of a polygon | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_TriangulatePolygon` |
+| ST_VoronoiPolygons | ST_VORONOIPOLYGONS | Returns the 2D Voronoi diagram polygons from the vertices of a geometry | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_VoronoiPolygons` |
+
+## PostGIS Linear Referencing Functions
+
+These functions work with measures along linear geometries for operations like locating points along routes.
+
+| PostgreSQL functions | Register for DQL as | Description | Implemented by |
+|---|---|---|---|
+| ST_LineInterpolatePoint | ST_LINEINTERPOLATEPOINT | Returns a point interpolated along a line at a fractional position | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_LineInterpolatePoint` |
+| ST_LineLocatePoint | ST_LINELOCATEPOINT | Returns the fractional location of the closest point on a line to a given point | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_LineLocatePoint` |
+| ST_LineSubstring | ST_LINESUBSTRING | Returns the portion of a line between two fractional locations | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_LineSubstring` |
 
 ## Usage Examples
 

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/NDimensionalBoundingBoxDistance.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/NDimensionalBoundingBoxDistance.php
@@ -12,6 +12,11 @@ use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
  * Returns the n-D distance between A and B bounding boxes.
  * This operator works with multi-dimensional geometries.
  *
+ * Note: The <<#>> operator was removed from PostGIS in version 2.2.0 when true KNN distance
+ * support was added to the <<->> operator, making bounding box distance variants obsolete.
+ * This class is kept for legacy compatibility only and will not work with PostGIS 2.2+.
+ * The recommendation is to use NDimensionalCentroidDistance (using <<->>) instead.
+ *
  * @see https://postgis.net/docs/reference.html#Operators_Distance
  * @since 3.5
  *

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ClosestPoint.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ClosestPoint.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunctionWithOptionalBooleanLastArgument;
+
+/**
+ * Implementation of PostGIS ST_ClosestPoint().
+ *
+ * Returns the 2D point on geometry A that is closest to geometry B.
+ *
+ * @see https://postgis.net/docs/ST_ClosestPoint.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_CLOSESTPOINT(g.geometry1, g.geometry2) FROM Entity g"
+ * @example Using it in DQL with use_spheroid: "SELECT ST_CLOSESTPOINT(g.geography1, g.geography2, 'true') FROM Entity g"
+ */
+class ST_ClosestPoint extends BaseVariadicFunctionWithOptionalBooleanLastArgument
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return ['StringPrimary'];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_ClosestPoint';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 2;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 3;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CoordDim.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CoordDim.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_CoordDim().
+ *
+ * Returns the coordinate dimension of a geometry.
+ *
+ * @see https://postgis.net/docs/ST_CoordDim.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_COORDDIM(g.geometry) FROM Entity g"
+ */
+class ST_CoordDim extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_CoordDim(%s)');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_FlipCoordinates.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_FlipCoordinates.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_FlipCoordinates().
+ *
+ * Returns a version of the geometry with X and Y axis flipped.
+ *
+ * @see https://postgis.net/docs/ST_FlipCoordinates.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_FLIPCOORDINATES(g.geometry) FROM Entity g"
+ */
+class ST_FlipCoordinates extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_FlipCoordinates(%s)');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeneratePoints.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeneratePoints.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * Implementation of PostGIS ST_GeneratePoints().
+ *
+ * Generates a multipoint of random points inside a polygon geometry.
+ *
+ * @see https://postgis.net/docs/ST_GeneratePoints.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_GENERATEPOINTS(g.geometry, 10) FROM Entity g"
+ * @example Using it in DQL with seed: "SELECT ST_GENERATEPOINTS(g.geometry, 10, 42) FROM Entity g"
+ */
+class ST_GeneratePoints extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return [
+            'StringPrimary,ArithmeticPrimary,ArithmeticPrimary',
+            'StringPrimary,ArithmeticPrimary',
+        ];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_GeneratePoints';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 2;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 3;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeometryType.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeometryType.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_GeometryType().
+ *
+ * Returns the SQL-MM type string of a geometry.
+ *
+ * @see https://postgis.net/docs/ST_GeometryType.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_GEOMETRYTYPE(g.geometry) FROM Entity g"
+ */
+class ST_GeometryType extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_GeometryType(%s)');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsEmpty.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsEmpty.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_IsEmpty().
+ *
+ * Returns true if the geometry is an empty geometry.
+ *
+ * @see https://postgis.net/docs/ST_IsEmpty.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE ST_ISEMPTY(g.geometry) = TRUE"
+ */
+class ST_IsEmpty extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_IsEmpty(%s)');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsValid.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsValid.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * Implementation of PostGIS ST_IsValid().
+ *
+ * Returns true if the geometry is well-formed and valid per the OGC rules.
+ *
+ * @see https://postgis.net/docs/ST_IsValid.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE ST_ISVALID(g.geometry) = TRUE"
+ * @example Using it in DQL with flags: "WHERE ST_ISVALID(g.geometry, 1) = TRUE"
+ */
+class ST_IsValid extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return [
+            'StringPrimary,ArithmeticPrimary',
+            'StringPrimary',
+        ];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_IsValid';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 1;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 2;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineInterpolatePoint.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineInterpolatePoint.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunctionWithOptionalBooleanLastArgument;
+
+/**
+ * Implementation of PostGIS ST_LineInterpolatePoint().
+ *
+ * Returns a point interpolated along a line at a fractional position.
+ * For geography types, an optional boolean parameter controls whether to use spheroid calculations.
+ *
+ * @see https://postgis.net/docs/ST_LineInterpolatePoint.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_LINEINTERPOLATEPOINT(g.geometry, 0.5) FROM Entity g"
+ * @example Using it in DQL (geography): "SELECT ST_LINEINTERPOLATEPOINT(g.geography, 0.5, 'true') FROM Entity g"
+ */
+class ST_LineInterpolatePoint extends BaseVariadicFunctionWithOptionalBooleanLastArgument
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return [
+            'StringPrimary,ArithmeticPrimary,StringPrimary',
+            'StringPrimary,ArithmeticPrimary',
+        ];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_LineInterpolatePoint';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 2;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 3;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineLocatePoint.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineLocatePoint.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunctionWithOptionalBooleanLastArgument;
+
+/**
+ * Implementation of PostGIS ST_LineLocatePoint().
+ *
+ * Returns the fractional location of the closest point on a line to a given point.
+ *
+ * @see https://postgis.net/docs/ST_LineLocatePoint.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_LINELOCATEPOINT(g.geometry1, g.geometry2) FROM Entity g"
+ * @example Using it in DQL with use_spheroid: "SELECT ST_LINELOCATEPOINT(g.geography1, g.geography2, 'true') FROM Entity g"
+ */
+class ST_LineLocatePoint extends BaseVariadicFunctionWithOptionalBooleanLastArgument
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return ['StringPrimary'];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_LineLocatePoint';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 2;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 3;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineSubstring.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineSubstring.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_LineSubstring().
+ *
+ * Returns the portion of a line between two fractional locations.
+ *
+ * @see https://postgis.net/docs/ST_LineSubstring.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_LINESUBSTRING(g.geometry, 0.2, 0.8) FROM Entity g"
+ */
+class ST_LineSubstring extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_LineSubstring(%s, %s, %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('ArithmeticPrimary');
+        $this->addNodeMapping('ArithmeticPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeEnvelope.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeEnvelope.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * Implementation of PostGIS ST_MakeEnvelope().
+ *
+ * Creates a rectangular polygon from minimum and maximum coordinates, with an optional SRID.
+ *
+ * @see https://postgis.net/docs/ST_MakeEnvelope.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_MAKEENVELOPE(0, 0, 1, 1) FROM Entity g"
+ * @example Using it in DQL with srid: "SELECT ST_MAKEENVELOPE(0, 0, 1, 1, 4326) FROM Entity g"
+ */
+class ST_MakeEnvelope extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return ['ArithmeticPrimary'];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_MakeEnvelope';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 4;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 5;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeLine.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeLine.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * Implementation of PostGIS ST_MakeLine().
+ *
+ * Creates a LineString from Point, MultiPoint, or LineString geometries.
+ *
+ * @see https://postgis.net/docs/ST_MakeLine.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_MAKELINE(g.geometry1, g.geometry2) FROM Entity g"
+ */
+class ST_MakeLine extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return ['StringPrimary'];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_MakeLine';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 1;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 2;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakePoint.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakePoint.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * Implementation of PostGIS ST_MakePoint().
+ *
+ * Creates a 2D, 3DZ, or 4D point geometry from coordinate values.
+ *
+ * @see https://postgis.net/docs/ST_MakePoint.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_MAKEPOINT(1.0, 2.0) FROM Entity g"
+ * @example Using it in DQL: "SELECT ST_MAKEPOINT(1.0, 2.0, 3.0) FROM Entity g"
+ * @example Using it in DQL: "SELECT ST_MAKEPOINT(1.0, 2.0, 3.0, 4.0) FROM Entity g"
+ */
+class ST_MakePoint extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return ['ArithmeticPrimary'];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_MakePoint';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 2;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 4;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MinimumBoundingCircle.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MinimumBoundingCircle.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * Implementation of PostGIS ST_MinimumBoundingCircle().
+ *
+ * Returns the smallest circle polygon that contains a geometry.
+ *
+ * @see https://postgis.net/docs/ST_MinimumBoundingCircle.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_MINIMUMBOUNDINGCIRCLE(g.geometry) FROM Entity g"
+ * @example Using it in DQL with num_segs_per_qt_circ: "SELECT ST_MINIMUMBOUNDINGCIRCLE(g.geometry, 48) FROM Entity g"
+ */
+class ST_MinimumBoundingCircle extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return [
+            'StringPrimary,ArithmeticPrimary',
+            'StringPrimary',
+        ];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_MinimumBoundingCircle';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 1;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 2;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NPoints.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NPoints.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_NPoints().
+ *
+ * Returns the number of points (vertices) in a geometry.
+ *
+ * @see https://postgis.net/docs/ST_NPoints.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_NPOINTS(g.geometry) FROM Entity g"
+ */
+class ST_NPoints extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_NPoints(%s)');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NumGeometries.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NumGeometries.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_NumGeometries().
+ *
+ * Returns the number of elements in a geometry collection.
+ *
+ * @see https://postgis.net/docs/ST_NumGeometries.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_NUMGEOMETRIES(g.geometry) FROM Entity g"
+ */
+class ST_NumGeometries extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_NumGeometries(%s)');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_OffsetCurve.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_OffsetCurve.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * Implementation of PostGIS ST_OffsetCurve().
+ *
+ * Returns an offset line at a given distance and side from an input line.
+ *
+ * @see https://postgis.net/docs/ST_OffsetCurve.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_OFFSETCURVE(g.geometry, 1.0) FROM Entity g"
+ * @example Using it in DQL with style: "SELECT ST_OFFSETCURVE(g.geometry, 1.0, 'quad_segs=4 join=round') FROM Entity g"
+ */
+class ST_OffsetCurve extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return [
+            'StringPrimary,ArithmeticPrimary,StringPrimary',
+            'StringPrimary,ArithmeticPrimary',
+        ];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_OffsetCurve';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 2;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 3;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Point.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Point.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * Implementation of PostGIS ST_Point().
+ *
+ * Creates a point with X, Y and an optional SRID.
+ *
+ * @see https://postgis.net/docs/ST_Point.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_POINT(1.0, 2.0) FROM Entity g"
+ * @example Using it in DQL: "SELECT ST_POINT(1.0, 2.0, 4326) FROM Entity g"
+ */
+class ST_Point extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return ['ArithmeticPrimary'];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_Point';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 2;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 3;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Point.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Point.php
@@ -17,7 +17,7 @@ use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  *
  * @example Using it in DQL: "SELECT ST_POINT(1.0, 2.0) FROM Entity g"
- * @example Using it in DQL: "SELECT ST_POINT(1.0, 2.0, 4326) FROM Entity g"
+ * @example Using it in DQL with SRID: "SELECT ST_POINT(1.0, 2.0, 4326) FROM Entity g"
  */
 class ST_Point extends BaseVariadicFunction
 {

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PointOnSurface.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PointOnSurface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_PointOnSurface().
+ *
+ * Returns a point guaranteed to lie on the surface of a geometry.
+ *
+ * @see https://postgis.net/docs/ST_PointOnSurface.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_POINTONSURFACE(g.geometry) FROM Entity g"
+ */
+class ST_PointOnSurface extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_PointOnSurface(%s)');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SRID.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SRID.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_SRID().
+ *
+ * Returns the spatial reference system identifier for a geometry.
+ *
+ * @see https://postgis.net/docs/ST_SRID.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_SRID(g.geometry) FROM Entity g"
+ */
+class ST_SRID extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_SRID(%s)');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Segmentize.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Segmentize.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_Segmentize().
+ *
+ * Returns a modified geometry having no segment longer than the given max segment length.
+ *
+ * @see https://postgis.net/docs/ST_Segmentize.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_SEGMENTIZE(g.geometry, 0.5) FROM Entity g"
+ */
+class ST_Segmentize extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_Segmentize(%s, %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('ArithmeticPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SetSRID.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SetSRID.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_SetSRID().
+ *
+ * Sets the SRID on a geometry to a particular integer value without transforming coordinates.
+ *
+ * @see https://postgis.net/docs/ST_SetSRID.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_SETSRID(g.geometry, 4326) FROM Entity g"
+ */
+class ST_SetSRID extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_SetSRID(%s, %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('ArithmeticPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ShortestLine.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ShortestLine.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_ShortestLine().
+ *
+ * Returns the 2D shortest line between two geometries.
+ *
+ * @see https://postgis.net/docs/ST_ShortestLine.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_SHORTESTLINE(g.geometry1, g.geometry2) FROM Entity g"
+ */
+class ST_ShortestLine extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_ShortestLine(%s, %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Snap.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Snap.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_Snap().
+ *
+ * Snaps the vertices and segments of a geometry to another geometry's vertices within a tolerance.
+ *
+ * @see https://postgis.net/docs/ST_Snap.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_SNAP(g.geometry1, g.geometry2, 0.01) FROM Entity g"
+ */
+class ST_Snap extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_Snap(%s, %s, %s)');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('ArithmeticPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TileEnvelope.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TileEnvelope.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
 
-use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
 
 /**
  * Implementation of PostGIS ST_TileEnvelope().
@@ -17,14 +17,32 @@ use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  *
  * @example Using it in DQL: "SELECT ST_TILEENVELOPE(10, 512, 384) FROM Entity g"
+ * @example Using it in DQL with bounds: "SELECT ST_TILEENVELOPE(10, 512, 384, ST_MAKEENVELOPE(0, 0, 180, 90, 4326)) FROM Entity g"
+ * @example Using it in DQL with margin: "SELECT ST_TILEENVELOPE(10, 512, 384, ST_MAKEENVELOPE(0, 0, 180, 90, 4326), 0.1) FROM Entity g"
  */
-class ST_TileEnvelope extends BaseFunction
+class ST_TileEnvelope extends BaseVariadicFunction
 {
-    protected function customizeFunction(): void
+    protected function getNodeMappingPattern(): array
     {
-        $this->setFunctionPrototype('ST_TileEnvelope(%s, %s, %s)');
-        $this->addNodeMapping('ArithmeticPrimary');
-        $this->addNodeMapping('ArithmeticPrimary');
-        $this->addNodeMapping('ArithmeticPrimary');
+        return [
+            'ArithmeticPrimary,ArithmeticPrimary,ArithmeticPrimary,StringPrimary,ArithmeticPrimary',
+            'ArithmeticPrimary,ArithmeticPrimary,ArithmeticPrimary,StringPrimary',
+            'ArithmeticPrimary,ArithmeticPrimary,ArithmeticPrimary',
+        ];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_TileEnvelope';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 3;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 5;
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TileEnvelope.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TileEnvelope.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_TileEnvelope().
+ *
+ * Returns the bounding box polygon for a Web Mercator tile specified by zoom/x/y.
+ *
+ * @see https://postgis.net/docs/ST_TileEnvelope.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_TILEENVELOPE(10, 512, 384) FROM Entity g"
+ */
+class ST_TileEnvelope extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_TileEnvelope(%s, %s, %s)');
+        $this->addNodeMapping('ArithmeticPrimary');
+        $this->addNodeMapping('ArithmeticPrimary');
+        $this->addNodeMapping('ArithmeticPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_VoronoiPolygons.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_VoronoiPolygons.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * Implementation of PostGIS ST_VoronoiPolygons().
+ *
+ * Returns the 2D Voronoi diagram polygons computed from the vertices of a geometry.
+ *
+ * @see https://postgis.net/docs/ST_VoronoiPolygons.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_VORONOIPOLYGONS(g.geometry) FROM Entity g"
+ * @example Using it in DQL with tolerance: "SELECT ST_VORONOIPOLYGONS(g.geometry, 8.0) FROM Entity g"
+ * @example Using it in DQL with tolerance and extend_to: "SELECT ST_VORONOIPOLYGONS(g.geometry1, 8.0, g.geometry2) FROM Entity g"
+ */
+class ST_VoronoiPolygons extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return [
+            'StringPrimary,ArithmeticPrimary,StringPrimary',
+            'StringPrimary,ArithmeticPrimary',
+            'StringPrimary',
+        ];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'ST_VoronoiPolygons';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 1;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 3;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_X.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_X.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_X().
+ *
+ * Returns the X coordinate of a point geometry.
+ *
+ * @see https://postgis.net/docs/ST_X.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_X(g.geometry) FROM Entity g"
+ */
+class ST_X extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_X(%s)');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Y.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Y.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_Y().
+ *
+ * Returns the Y coordinate of a point geometry.
+ *
+ * @see https://postgis.net/docs/ST_Y.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_Y(g.geometry) FROM Entity g"
+ */
+class ST_Y extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_Y(%s)');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Z.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Z.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostGIS ST_Z().
+ *
+ * Returns the Z coordinate of a 3D point geometry.
+ *
+ * @see https://postgis.net/docs/ST_Z.html
+ * @since 4.7
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT ST_Z(g.geometry) FROM Entity g"
+ */
+class ST_Z extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('ST_Z(%s)');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_3DLengthTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_3DLengthTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_3DLength;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Length;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_3DLengthTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_3DLENGTH' => ST_3DLength::class,
+            'ST_LENGTH' => ST_Length::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_length_for_linestring(): void
+    {
+        $dql = 'SELECT ST_3DLENGTH(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 10';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(2000, $result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_3d_length_greater_than_or_equal_to_2d_length(): void
+    {
+        $dql = 'SELECT ST_3DLENGTH(g.geometry1) as length_3d, ST_LENGTH(g.geometry1) as length_2d
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 3';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertGreaterThanOrEqual($result[0]['length_2d'], $result[0]['length_3d']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ClosestPointTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ClosestPointTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_ClosestPoint;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Equals;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_ClosestPointTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_CLOSESTPOINT' => ST_ClosestPoint::class,
+            'ST_EQUALS' => ST_Equals::class,
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_point_geometry(): void
+    {
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_CLOSESTPOINT(g.geometry1, g.geometry2)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_Point', $result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_same_point_for_identical_geometries(): void
+    {
+        $dql = 'SELECT ST_EQUALS(ST_CLOSESTPOINT(g.geometry1, g.geometry1), g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CollectionHomogenizeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CollectionHomogenizeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Collect;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_CollectionHomogenize;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_CollectionHomogenizeTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_COLLECTIONHOMOGENIZE' => ST_CollectionHomogenize::class,
+            'ST_COLLECT' => ST_Collect::class,
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
+        ];
+    }
+
+    #[Test]
+    public function homogenizes_collection_of_same_type_points(): void
+    {
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_COLLECTIONHOMOGENIZE(ST_COLLECT(g.geometry1, g.geometry2))) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_MultiPoint', $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CoordDimTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CoordDimTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_CoordDim;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_CoordDimTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_COORDDIM' => ST_CoordDim::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_two_for_2d_point(): void
+    {
+        $dql = 'SELECT ST_COORDDIM(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(2, $result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_three_for_3d_point(): void
+    {
+        $dql = 'SELECT ST_COORDDIM(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 11';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(3, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_DistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_DistanceTest.php
@@ -24,7 +24,7 @@ final class ST_DistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001, 'Distance between POINT(0 0) and POINT(1 1) = √2');
+        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_FlipCoordinatesTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_FlipCoordinatesTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_FlipCoordinates;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_X;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Y;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_FlipCoordinatesTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_FLIPCOORDINATES' => ST_FlipCoordinates::class,
+            'ST_X' => ST_X::class,
+            'ST_Y' => ST_Y::class,
+        ];
+    }
+
+    #[Test]
+    public function flips_coordinates(): void
+    {
+        $dql = 'SELECT ST_X(g.geometry1) as original_x, ST_Y(g.geometry1) as original_y,
+                       ST_X(ST_FLIPCOORDINATES(g.geometry1)) as flipped_x, ST_Y(ST_FLIPCOORDINATES(g.geometry1)) as flipped_y
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals($result[0]['original_y'], $result[0]['flipped_x']);
+        $this->assertEquals($result[0]['original_x'], $result[0]['flipped_y']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Force3DTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Force3DTest.php
@@ -5,34 +5,23 @@ declare(strict_types=1);
 namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
 
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_CoordDim;
-use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Force2D;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Force3D;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Z;
 use PHPUnit\Framework\Attributes\Test;
 
-final class ST_Force2DTest extends SpatialOperatorTestCase
+final class ST_Force3DTest extends SpatialOperatorTestCase
 {
     protected function getStringFunctions(): array
     {
         return [
             'ST_COORDDIM' => ST_CoordDim::class,
-            'ST_FORCE2D' => ST_Force2D::class,
+            'ST_FORCE3D' => ST_Force3D::class,
+            'ST_Z' => ST_Z::class,
         ];
     }
 
     #[Test]
-    public function preserves_2d_point(): void
-    {
-        $dql = 'SELECT ST_COORDDIM(g.geometry1) as original,
-                       ST_COORDDIM(ST_FORCE2D(g.geometry1)) as transformed
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
-                WHERE g.id = 1';
-
-        $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(2, $result[0]['original']);
-        $this->assertEquals(2, $result[0]['transformed']);
-    }
-
-    #[Test]
-    public function promotes_3d_point_to_4d(): void
+    public function preserves_3d_point(): void
     {
         $dql = 'SELECT ST_COORDDIM(g.geometry1) as original,
                        ST_COORDDIM(ST_FORCE2D(g.geometry1)) as transformed
@@ -41,6 +30,19 @@ final class ST_Force2DTest extends SpatialOperatorTestCase
 
         $result = $this->executeDqlQuery($dql);
         $this->assertEquals(3, $result[0]['original']);
-        $this->assertEquals(2, $result[0]['transformed']);
+        $this->assertEquals(3, $result[0]['transformed']);
+    }
+
+    #[Test]
+    public function promotes_2d_point_to_3d(): void
+    {
+        $dql = 'SELECT ST_COORDDIM(g.geometry1) as original,
+                       ST_COORDDIM(ST_FORCE2D(g.geometry1)) as transformed
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(2, $result[0]['original']);
+        $this->assertEquals(3, $result[0]['transformed']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Force3DTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Force3DTest.php
@@ -24,7 +24,7 @@ final class ST_Force3DTest extends SpatialOperatorTestCase
     public function preserves_3d_point(): void
     {
         $dql = 'SELECT ST_COORDDIM(g.geometry1) as original,
-                       ST_COORDDIM(ST_FORCE2D(g.geometry1)) as transformed
+                       ST_COORDDIM(ST_FORCE3D(g.geometry1)) as transformed
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 11';
 
@@ -37,7 +37,7 @@ final class ST_Force3DTest extends SpatialOperatorTestCase
     public function promotes_2d_point_to_3d(): void
     {
         $dql = 'SELECT ST_COORDDIM(g.geometry1) as original,
-                       ST_COORDDIM(ST_FORCE2D(g.geometry1)) as transformed
+                       ST_COORDDIM(ST_FORCE3D(g.geometry1)) as transformed
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Force4DTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Force4DTest.php
@@ -5,42 +5,42 @@ declare(strict_types=1);
 namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
 
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_CoordDim;
-use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Force2D;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Force4D;
 use PHPUnit\Framework\Attributes\Test;
 
-final class ST_Force2DTest extends SpatialOperatorTestCase
+final class ST_Force4DTest extends SpatialOperatorTestCase
 {
     protected function getStringFunctions(): array
     {
         return [
             'ST_COORDDIM' => ST_CoordDim::class,
-            'ST_FORCE2D' => ST_Force2D::class,
+            'ST_FORCE4D' => ST_Force4D::class,
         ];
     }
 
     #[Test]
-    public function preserves_2d_point(): void
+    public function promotes_2d_point_to_4d(): void
     {
         $dql = 'SELECT ST_COORDDIM(g.geometry1) as original,
-                       ST_COORDDIM(ST_FORCE2D(g.geometry1)) as transformed
+                       ST_COORDDIM(ST_FORCE4D(g.geometry1)) as transformed
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
         $this->assertEquals(2, $result[0]['original']);
-        $this->assertEquals(2, $result[0]['transformed']);
+        $this->assertEquals(4, $result[0]['transformed']);
     }
 
     #[Test]
     public function promotes_3d_point_to_4d(): void
     {
         $dql = 'SELECT ST_COORDDIM(g.geometry1) as original,
-                       ST_COORDDIM(ST_FORCE2D(g.geometry1)) as transformed
+                       ST_COORDDIM(ST_FORCE4D(g.geometry1)) as transformed
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 11';
 
         $result = $this->executeDqlQuery($dql);
         $this->assertEquals(3, $result[0]['original']);
-        $this->assertEquals(2, $result[0]['transformed']);
+        $this->assertEquals(4, $result[0]['transformed']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_FrechetDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_FrechetDistanceTest.php
@@ -50,13 +50,13 @@ final class ST_FrechetDistanceTest extends SpatialOperatorTestCase
     }
 
     #[Test]
-    public function returns_frechet_distance_between_polygons(): void
+    public function returns_frechet_distance_between_overlapping_polygons(): void
     {
         $dql = 'SELECT ST_FRECHETDISTANCE(g.geometry1, g.geometry2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.000000000000001, 'should return correct distance between overlapping polygons');
+        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeneratePointsTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeneratePointsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeneratePoints;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_NPoints;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_GeneratePointsTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_GENERATEPOINTS' => ST_GeneratePoints::class,
+            'ST_NPOINTS' => ST_NPoints::class,
+        ];
+    }
+
+    #[Test]
+    public function generates_points_inside_polygon(): void
+    {
+        $dql = 'SELECT ST_NPOINTS(ST_GENERATEPOINTS(g.geometry1, 5)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(5, $result[0]['result']);
+    }
+
+    #[Test]
+    public function generates_points_with_seed(): void
+    {
+        $dql = 'SELECT ST_NPOINTS(ST_GENERATEPOINTS(g.geometry1, 3, 42)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(3, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeometryTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeometryTypeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_GeometryTypeTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_point_type(): void
+    {
+        $dql = 'SELECT ST_GEOMETRYTYPE(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_Point', $result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_polygon_type(): void
+    {
+        $dql = 'SELECT ST_GEOMETRYTYPE(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_Polygon', $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsEmptyTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsEmptyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_IsEmpty;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_IsEmptyTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_ISEMPTY' => ST_IsEmpty::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_false_for_non_empty_point(): void
+    {
+        $dql = 'SELECT ST_ISEMPTY(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertFalse($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsValidTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsValidTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_IsValid;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_IsValidTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_ISVALID' => ST_IsValid::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_true_for_valid_point(): void
+    {
+        $dql = 'SELECT ST_ISVALID(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_true_for_valid_point_with_flags(): void
+    {
+        $dql = 'SELECT ST_ISVALID(g.geometry1, 0) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineInterpolatePointTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineInterpolatePointTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_LineInterpolatePoint;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_X;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_LineInterpolatePointTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
+            'ST_LINEINTERPOLATEPOINT' => ST_LineInterpolatePoint::class,
+            'ST_X' => ST_X::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_point_geometry(): void
+    {
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_LINEINTERPOLATEPOINT(g.geometry1, 0.5)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 3';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_Point', $result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_midpoint_of_linestring(): void
+    {
+        $dql = 'SELECT ST_X(ST_LINEINTERPOLATEPOINT(g.geometry1, 0.5)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 3';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(1.0, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineLocatePointTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineLocatePointTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_LineLocatePoint;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_LineLocatePointTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_LINELOCATEPOINT' => ST_LineLocatePoint::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_half_for_midpoint(): void
+    {
+        $dql = 'SELECT ST_LINELOCATEPOINT(g.geometry1, g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 9';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEqualsWithDelta(0.5, $result[0]['result'], 0.0000000000000001);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineSubstringTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineSubstringTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Length;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_LineSubstring;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_LineSubstringTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_LENGTH' => ST_Length::class,
+            'ST_LINESUBSTRING' => ST_LineSubstring::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_half_length_for_half_substring(): void
+    {
+        $dql = 'SELECT ST_LENGTH(ST_LINESUBSTRING(g.geometry1, 0.0, 0.5)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 3';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeEnvelopeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeEnvelopeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MakeEnvelope;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SRID;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_MakeEnvelopeTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
+            'ST_MAKEENVELOPE' => ST_MakeEnvelope::class,
+            'ST_SRID' => ST_SRID::class,
+        ];
+    }
+
+    #[Test]
+    public function creates_polygon_envelope(): void
+    {
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_MAKEENVELOPE(0, 0, 1, 1)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_Polygon', $result[0]['result']);
+    }
+
+    #[Test]
+    public function creates_envelope_with_srid(): void
+    {
+        $dql = 'SELECT ST_SRID(ST_MAKEENVELOPE(0, 0, 1, 1, 4326)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(4326, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeLineTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeLineTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MakeLine;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_MakeLineTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
+            'ST_MAKELINE' => ST_MakeLine::class,
+        ];
+    }
+
+    #[Test]
+    public function creates_linestring_from_two_points(): void
+    {
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_MAKELINE(g.geometry1, g.geometry2)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_LineString', $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakePointTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakePointTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MakePoint;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_X;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Z;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_MakePointTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_MAKEPOINT' => ST_MakePoint::class,
+            'ST_X' => ST_X::class,
+            'ST_Z' => ST_Z::class,
+        ];
+    }
+
+    #[Test]
+    public function creates_2d_point(): void
+    {
+        $dql = 'SELECT ST_X(ST_MAKEPOINT(10, 20)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(10, $result[0]['result']);
+    }
+
+    #[Test]
+    public function creates_3d_point(): void
+    {
+        $dql = 'SELECT ST_Z(ST_MAKEPOINT(11, 22, 33)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(33, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MaxDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MaxDistanceTest.php
@@ -24,7 +24,7 @@ final class ST_MaxDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001, 'Maximum distance between POINT(0 0) and POINT(1 1) = √2');
+        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
     }
 
     #[Test]
@@ -46,6 +46,6 @@ final class ST_MaxDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(4.242640687119285, $result[0]['result'], 0.0000000000000001, 'Maximum distance between polygon corners (0,0) to (3,3) = √18');
+        $this->assertEqualsWithDelta(4.242640687119285, $result[0]['result'], 0.0000000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MinimumBoundingCircleTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MinimumBoundingCircleTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Area;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MinimumBoundingCircle;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_MinimumBoundingCircleTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_AREA' => ST_Area::class,
+            'ST_MINIMUMBOUNDINGCIRCLE' => ST_MinimumBoundingCircle::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_bounding_circle_with_area_greater_than_polygon(): void
+    {
+        $dql = 'SELECT ST_AREA(ST_MINIMUMBOUNDINGCIRCLE(g.geometry1)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertGreaterThan(16, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NPointsTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NPointsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_NPoints;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_NPointsTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_NPOINTS' => ST_NPoints::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_point_count_for_polygon(): void
+    {
+        $dql = 'SELECT ST_NPOINTS(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(5, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NumGeometriesTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NumGeometriesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_NumGeometries;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_NumGeometriesTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_NUMGEOMETRIES' => ST_NumGeometries::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_one_for_single_geometry(): void
+    {
+        $dql = 'SELECT ST_NUMGEOMETRIES(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(1, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_OffsetCurveTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_OffsetCurveTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_OffsetCurve;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_OffsetCurveTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
+            'ST_OFFSETCURVE' => ST_OffsetCurve::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_offset_linestring(): void
+    {
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_OFFSETCURVE(g.geometry1, 1)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 3';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_LineString', $result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_offset_linestring_with_style_parameters(): void
+    {
+        $dql = "SELECT ST_GEOMETRYTYPE(ST_OFFSETCURVE(g.geometry1, 1, 'quad_segs=4 join=round')) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 3";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_LineString', $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PointOnSurfaceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PointOnSurfaceTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Contains;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_PointOnSurface;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_PointOnSurfaceTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_CONTAINS' => ST_Contains::class,
+            'ST_POINTONSURFACE' => ST_PointOnSurface::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_point_inside_polygon(): void
+    {
+        $dql = 'SELECT ST_CONTAINS(g.geometry1, ST_POINTONSURFACE(g.geometry1)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PointTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PointTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Point;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SRID;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_X;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_PointTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_POINT' => ST_Point::class,
+            'ST_SRID' => ST_SRID::class,
+            'ST_X' => ST_X::class,
+        ];
+    }
+
+    #[Test]
+    public function creates_point_with_correct_x(): void
+    {
+        $dql = 'SELECT ST_X(ST_POINT(42, 7)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(42, $result[0]['result']);
+    }
+
+    #[Test]
+    public function creates_point_with_srid(): void
+    {
+        $dql = 'SELECT ST_SRID(ST_POINT(1, 2, 4326)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(4326, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SRIDTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SRIDTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SRID;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_SRIDTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_SRID' => ST_SRID::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_srid_of_geometry(): void
+    {
+        $dql = 'SELECT ST_SRID(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(4326, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ScaleTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ScaleTest.php
@@ -30,7 +30,7 @@ final class ST_ScaleTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'should return unchanged point at origin (0 * factor = 0)');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
@@ -41,7 +41,7 @@ final class ST_ScaleTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(36, $result[0]['result'], 'should scale polygon area by factor squared (16 * 1.5 * 1.5 = 36)');
+        $this->assertEquals(36, $result[0]['result']);
     }
 
     #[Test]
@@ -52,7 +52,7 @@ final class ST_ScaleTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.000000000000001, 'should scale linestring length by factor (2.828... * 0.5 = 1.414...)');
+        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.000000000000001);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SegmentizeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SegmentizeTest.php
@@ -22,7 +22,7 @@ final class ST_SegmentizeTest extends SpatialOperatorTestCase
     public function increases_point_count_on_linestring(): void
     {
         $dql = 'SELECT ST_NPOINTS(g.geometry1) as original,
-        $              ST_NPOINTS(ST_SEGMENTIZE(g.geometry1, 0.5)) as segmentized
+                       ST_NPOINTS(ST_SEGMENTIZE(g.geometry1, 0.5)) as segmentized
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 3';
 

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SegmentizeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SegmentizeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_NPoints;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Segmentize;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_SegmentizeTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_NPOINTS' => ST_NPoints::class,
+            'ST_SEGMENTIZE' => ST_Segmentize::class,
+        ];
+    }
+
+    #[Test]
+    public function increases_point_count_on_linestring(): void
+    {
+        $dql = 'SELECT ST_NPOINTS(g.geometry1) as original,
+        $              ST_NPOINTS(ST_SEGMENTIZE(g.geometry1, 0.5)) as segmentized
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 3';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertTrue($result[0]['segmentized'] > $result[0]['original']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SetSRIDTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SetSRIDTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SetSRID;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SRID;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_SetSRIDTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_SETSRID' => ST_SetSRID::class,
+            'ST_SRID' => ST_SRID::class,
+        ];
+    }
+
+    #[Test]
+    public function sets_srid_on_geometry(): void
+    {
+        $dql = 'SELECT ST_SRID(ST_SETSRID(g.geometry1, 3857)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 4';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(3857, $result[0]['result']);
+    }
+
+    #[Test]
+    public function changes_srid_on_geometry_with_existing_srid(): void
+    {
+        $dql = 'SELECT ST_SRID(ST_SETSRID(g.geometry1, 3857)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(3857, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ShortestLineTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ShortestLineTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Length;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_ShortestLine;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_ShortestLineTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_LENGTH' => ST_Length::class,
+            'ST_SHORTESTLINE' => ST_ShortestLine::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_zero_length_for_identical_geometries(): void
+    {
+        $dql = 'SELECT ST_LENGTH(ST_SHORTESTLINE(g.geometry1, g.geometry1)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(0, $result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_shortest_line_between_separate_points(): void
+    {
+        $dql = 'SELECT ST_LENGTH(ST_SHORTESTLINE(g.geometry1, g.geometry2)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SnapTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SnapTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Snap;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_SnapTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
+            'ST_SNAP' => ST_Snap::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_snapped_geometry(): void
+    {
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_SNAP(g.geometry1, g.geometry2, 2.0)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 2';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_Polygon', $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TileEnvelopeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TileEnvelopeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SRID;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_TileEnvelope;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_TileEnvelopeTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
+            'ST_SRID' => ST_SRID::class,
+            'ST_TILEENVELOPE' => ST_TileEnvelope::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_polygon_geometry(): void
+    {
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_TILEENVELOPE(10, 512, 384)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_Polygon', $result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_envelope_in_web_mercator_srid(): void
+    {
+        $dql = 'SELECT ST_SRID(ST_TILEENVELOPE(10, 512, 384)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(3857, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_VoronoiPolygonsTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_VoronoiPolygonsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_NumGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_VoronoiPolygons;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_VoronoiPolygonsTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
+            'ST_NUMGEOMETRIES' => ST_NumGeometries::class,
+            'ST_VORONOIPOLYGONS' => ST_VoronoiPolygons::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_geometry_collection(): void
+    {
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_VORONOIPOLYGONS(g.geometry1)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 3';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals('ST_GeometryCollection', $result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_voronoi_polygons_for_linestring_vertices(): void
+    {
+        $dql = 'SELECT ST_NUMGEOMETRIES(ST_VORONOIPOLYGONS(g.geometry1)) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 3';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(3, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_XTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_XTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_X;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_XTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_X' => ST_X::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_x_coordinate_of_a_point(): void
+    {
+        $dql = 'SELECT ST_X(g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(1, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_YTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_YTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Y;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_YTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_Y' => ST_Y::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_y_coordinate_of_a_point(): void
+    {
+        $dql = 'SELECT ST_Y(g.geometry2) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(1, $result[0]['result']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ZTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ZTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Z;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ST_ZTest extends SpatialOperatorTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_Z' => ST_Z::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_z_coordinate_of_3d_point(): void
+    {
+        $dql = 'SELECT ST_Z(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 11';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertEquals(5, $result[0]['result']);
+    }
+
+    #[Test]
+    public function returns_null_for_2d_point(): void
+    {
+        $dql = 'SELECT ST_Z(g.geometry1) as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
+                WHERE g.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertNull($result[0]['result']);
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_AsGeoJSONTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_AsGeoJSONTest.php
@@ -20,22 +20,22 @@ final class ST_AsGeoJSONTest extends TestCase
     protected function getExpectedSqlStatements(): array
     {
         return [
-            'with one argument' => 'SELECT ST_AsGeoJSON(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
-            'with two arguments' => 'SELECT ST_AsGeoJSON(c0_.geometry1, 6) AS sclr_0 FROM ContainsGeometries c0_',
-            'with three arguments' => 'SELECT ST_AsGeoJSON(c0_.geometry1, 6, 2) AS sclr_0 FROM ContainsGeometries c0_',
-            'with named parameter' => 'SELECT ST_AsGeoJSON(c0_.geometry1, ?) AS sclr_0 FROM ContainsGeometries c0_',
-            'with function expression' => 'SELECT ST_AsGeoJSON(c0_.geometry1, MIN(1)) AS sclr_0 FROM ContainsGeometries c0_',
+            'converts geometry' => 'SELECT ST_AsGeoJSON(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+            'converts geometry with max decimal digits' => 'SELECT ST_AsGeoJSON(c0_.geometry1, 6) AS sclr_0 FROM ContainsGeometries c0_',
+            'converts geometry with options' => 'SELECT ST_AsGeoJSON(c0_.geometry1, 6, 2) AS sclr_0 FROM ContainsGeometries c0_',
+            'converts geometry with named parameter' => 'SELECT ST_AsGeoJSON(c0_.geometry1, ?) AS sclr_0 FROM ContainsGeometries c0_',
+            'converts geometry with function expression' => 'SELECT ST_AsGeoJSON(c0_.geometry1, MIN(1)) AS sclr_0 FROM ContainsGeometries c0_',
         ];
     }
 
     protected function getDqlStatements(): array
     {
         return [
-            'with one argument' => \sprintf('SELECT ST_ASGEOJSON(g.geometry1) FROM %s g', ContainsGeometries::class),
-            'with two arguments' => \sprintf('SELECT ST_ASGEOJSON(g.geometry1, 6) FROM %s g', ContainsGeometries::class),
-            'with three arguments' => \sprintf('SELECT ST_ASGEOJSON(g.geometry1, 6, 2) FROM %s g', ContainsGeometries::class),
-            'with named parameter' => \sprintf('SELECT ST_ASGEOJSON(g.geometry1, :dql_parameter) FROM %s g', ContainsGeometries::class),
-            'with function expression' => \sprintf('SELECT ST_ASGEOJSON(g.geometry1, MIN(1)) FROM %s g', ContainsGeometries::class),
+            'converts geometry' => \sprintf('SELECT ST_ASGEOJSON(g.geometry1) FROM %s g', ContainsGeometries::class),
+            'converts geometry with max decimal digits' => \sprintf('SELECT ST_ASGEOJSON(g.geometry1, 6) FROM %s g', ContainsGeometries::class),
+            'converts geometry with options' => \sprintf('SELECT ST_ASGEOJSON(g.geometry1, 6, 2) FROM %s g', ContainsGeometries::class),
+            'converts geometry with named parameter' => \sprintf('SELECT ST_ASGEOJSON(g.geometry1, :dql_parameter) FROM %s g', ContainsGeometries::class),
+            'converts geometry with function expression' => \sprintf('SELECT ST_ASGEOJSON(g.geometry1, MIN(1)) FROM %s g', ContainsGeometries::class),
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ClosestPointTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ClosestPointTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidBooleanException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_ClosestPoint;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_ClosestPointTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_CLOSESTPOINT' => ST_ClosestPoint::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'finds closest point between geometries' => 'SELECT ST_ClosestPoint(c0_.geometry1, c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+            'finds closest point with use_spheroid' => "SELECT ST_ClosestPoint(c0_.geometry1, c0_.geometry2, 'true') AS sclr_0 FROM ContainsGeometries c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'finds closest point between geometries' => \sprintf('SELECT ST_CLOSESTPOINT(g.geometry1, g.geometry2) FROM %s g', ContainsGeometries::class),
+            'finds closest point with use_spheroid' => \sprintf("SELECT ST_CLOSESTPOINT(g.geometry1, g.geometry2, 'true') FROM %s g", ContainsGeometries::class),
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_invalid_boolean(): void
+    {
+        $this->expectException(InvalidBooleanException::class);
+        $this->expectExceptionMessage('Invalid boolean value "invalid" provided for ST_ClosestPoint. Must be "true" or "false".');
+
+        $dql = \sprintf("SELECT ST_CLOSESTPOINT(g.geometry1, g.geometry2, 'invalid') FROM %s g", ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+
+    #[Test]
+    public function throws_exception_for_non_constant_boolean_parameter(): void
+    {
+        $this->expectException(InvalidBooleanException::class);
+        $this->expectExceptionMessage('The boolean parameter for ST_ClosestPoint must be a string literal');
+
+        $dql = \sprintf('SELECT ST_CLOSESTPOINT(g.geometry1, g.geometry2, g.geometry1) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_ClosestPoint() requires between 2 and 3 arguments');
+
+        $dql = \sprintf("SELECT ST_CLOSESTPOINT(g.geometry1, g.geometry2, 'true', 99) FROM %s g", ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ConcaveHullTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ConcaveHullTest.php
@@ -22,16 +22,16 @@ final class ST_ConcaveHullTest extends TestCase
     protected function getExpectedSqlStatements(): array
     {
         return [
-            'with two arguments' => 'SELECT ST_ConcaveHull(c0_.geometry1, 0.99) AS sclr_0 FROM ContainsGeometries c0_',
-            'with three arguments (allow_holes)' => "SELECT ST_ConcaveHull(c0_.geometry1, 0.99, 'true') AS sclr_0 FROM ContainsGeometries c0_",
+            'computes concave hull' => 'SELECT ST_ConcaveHull(c0_.geometry1, 0.99) AS sclr_0 FROM ContainsGeometries c0_',
+            'computes concave hull allowing holes' => "SELECT ST_ConcaveHull(c0_.geometry1, 0.99, 'true') AS sclr_0 FROM ContainsGeometries c0_",
         ];
     }
 
     protected function getDqlStatements(): array
     {
         return [
-            'with two arguments' => \sprintf('SELECT ST_CONCAVEHULL(g.geometry1, 0.99) FROM %s g', ContainsGeometries::class),
-            'with three arguments (allow_holes)' => \sprintf("SELECT ST_CONCAVEHULL(g.geometry1, 0.99, 'true') FROM %s g", ContainsGeometries::class),
+            'computes concave hull' => \sprintf('SELECT ST_CONCAVEHULL(g.geometry1, 0.99) FROM %s g', ContainsGeometries::class),
+            'computes concave hull allowing holes' => \sprintf("SELECT ST_CONCAVEHULL(g.geometry1, 0.99, 'true') FROM %s g", ContainsGeometries::class),
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CoordDimTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CoordDimTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_CoordDim;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_CoordDimTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_COORDDIM' => ST_CoordDim::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_CoordDim(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_COORDDIM(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_FlipCoordinatesTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_FlipCoordinatesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_FlipCoordinates;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_FlipCoordinatesTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_FLIPCOORDINATES' => ST_FlipCoordinates::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_FlipCoordinates(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_FLIPCOORDINATES(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeneratePointsTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeneratePointsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeneratePoints;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_GeneratePointsTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_GENERATEPOINTS' => ST_GeneratePoints::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'generates random points' => 'SELECT ST_GeneratePoints(c0_.geometry1, 10) AS sclr_0 FROM ContainsGeometries c0_',
+            'generates random points with seed' => 'SELECT ST_GeneratePoints(c0_.geometry1, 10, 42) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'generates random points' => 'SELECT ST_GENERATEPOINTS(g.geometry1, 10) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+            'generates random points with seed' => 'SELECT ST_GENERATEPOINTS(g.geometry1, 10, 42) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_GeneratePoints() requires between 2 and 3 arguments');
+
+        $dql = \sprintf('SELECT ST_GENERATEPOINTS(g.geometry1, 10, 42, 99) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeometryTypeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_GeometryTypeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_GeometryTypeTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_GeometryType(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_GEOMETRYTYPE(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsEmptyTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsEmptyTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_IsEmpty;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_IsEmptyTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_ISEMPTY' => ST_IsEmpty::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_IsEmpty(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_ISEMPTY(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsValidTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IsValidTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_IsValid;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_IsValidTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_ISVALID' => ST_IsValid::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'validates geometry' => 'SELECT ST_IsValid(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+            'validates geometry with flags' => 'SELECT ST_IsValid(c0_.geometry1, 1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'validates geometry' => \sprintf('SELECT ST_ISVALID(g.geometry1) FROM %s g', ContainsGeometries::class),
+            'validates geometry with flags' => \sprintf('SELECT ST_ISVALID(g.geometry1, 1) FROM %s g', ContainsGeometries::class),
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_IsValid() requires between 1 and 2 arguments');
+
+        $dql = \sprintf('SELECT ST_ISVALID(g.geometry1, 1, 99) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LettersTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LettersTest.php
@@ -20,16 +20,16 @@ final class ST_LettersTest extends TestCase
     protected function getExpectedSqlStatements(): array
     {
         return [
-            'with one argument' => "SELECT ST_Letters('ABC') AS sclr_0 FROM ContainsGeometries c0_",
-            'with two arguments (custom font)' => "SELECT ST_Letters('ABC', '{\"A\": \"...\"}') AS sclr_0 FROM ContainsGeometries c0_",
+            'renders text as geometry' => "SELECT ST_Letters('ABC') AS sclr_0 FROM ContainsGeometries c0_",
+            'renders text with custom font' => "SELECT ST_Letters('ABC', '{\"A\": \"...\"}') AS sclr_0 FROM ContainsGeometries c0_",
         ];
     }
 
     protected function getDqlStatements(): array
     {
         return [
-            'with one argument' => \sprintf("SELECT ST_LETTERS('ABC') FROM %s g", ContainsGeometries::class),
-            'with two arguments (custom font)' => \sprintf("SELECT ST_LETTERS('ABC', '{\"A\": \"...\"}') FROM %s g", ContainsGeometries::class),
+            'renders text as geometry' => \sprintf("SELECT ST_LETTERS('ABC') FROM %s g", ContainsGeometries::class),
+            'renders text with custom font' => \sprintf("SELECT ST_LETTERS('ABC', '{\"A\": \"...\"}') FROM %s g", ContainsGeometries::class),
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineInterpolatePointTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineInterpolatePointTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidBooleanException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_LineInterpolatePoint;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_LineInterpolatePointTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_LINEINTERPOLATEPOINT' => ST_LineInterpolatePoint::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'interpolates point along line' => 'SELECT ST_LineInterpolatePoint(c0_.geometry1, 0.5) AS sclr_0 FROM ContainsGeometries c0_',
+            'interpolates point with use_spheroid' => "SELECT ST_LineInterpolatePoint(c0_.geometry1, 0.5, 'true') AS sclr_0 FROM ContainsGeometries c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'interpolates point along line' => \sprintf('SELECT ST_LINEINTERPOLATEPOINT(g.geometry1, 0.5) FROM %s g', ContainsGeometries::class),
+            'interpolates point with use_spheroid' => \sprintf("SELECT ST_LINEINTERPOLATEPOINT(g.geometry1, 0.5, 'true') FROM %s g", ContainsGeometries::class),
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_invalid_boolean(): void
+    {
+        $this->expectException(InvalidBooleanException::class);
+        $this->expectExceptionMessage('Invalid boolean value "invalid" provided for ST_LineInterpolatePoint. Must be "true" or "false".');
+
+        $dql = \sprintf("SELECT ST_LINEINTERPOLATEPOINT(g.geometry1, 0.5, 'invalid') FROM %s g", ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+
+    #[Test]
+    public function throws_exception_for_non_constant_boolean_parameter(): void
+    {
+        $this->expectException(InvalidBooleanException::class);
+        $this->expectExceptionMessage('The boolean parameter for ST_LineInterpolatePoint must be a string literal');
+
+        $dql = \sprintf('SELECT ST_LINEINTERPOLATEPOINT(g.geometry1, 0.5, g.geometry1) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_LineInterpolatePoint() requires between 2 and 3 arguments');
+
+        $dql = \sprintf("SELECT ST_LINEINTERPOLATEPOINT(g.geometry1, 0.5, 'true', 99) FROM %s g", ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineLocatePointTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineLocatePointTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidBooleanException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_LineLocatePoint;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_LineLocatePointTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_LINELOCATEPOINT' => ST_LineLocatePoint::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'locates point on line' => 'SELECT ST_LineLocatePoint(c0_.geometry1, c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+            'locates point on line with use_spheroid' => "SELECT ST_LineLocatePoint(c0_.geometry1, c0_.geometry2, 'true') AS sclr_0 FROM ContainsGeometries c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'locates point on line' => \sprintf('SELECT ST_LINELOCATEPOINT(g.geometry1, g.geometry2) FROM %s g', ContainsGeometries::class),
+            'locates point on line with use_spheroid' => \sprintf("SELECT ST_LINELOCATEPOINT(g.geometry1, g.geometry2, 'true') FROM %s g", ContainsGeometries::class),
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_invalid_boolean(): void
+    {
+        $this->expectException(InvalidBooleanException::class);
+        $this->expectExceptionMessage('Invalid boolean value "invalid" provided for ST_LineLocatePoint. Must be "true" or "false".');
+
+        $dql = \sprintf("SELECT ST_LINELOCATEPOINT(g.geometry1, g.geometry2, 'invalid') FROM %s g", ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+
+    #[Test]
+    public function throws_exception_for_non_constant_boolean_parameter(): void
+    {
+        $this->expectException(InvalidBooleanException::class);
+        $this->expectExceptionMessage('The boolean parameter for ST_LineLocatePoint must be a string literal');
+
+        $dql = \sprintf('SELECT ST_LINELOCATEPOINT(g.geometry1, g.geometry2, g.geometry1) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_LineLocatePoint() requires between 2 and 3 arguments');
+
+        $dql = \sprintf("SELECT ST_LINELOCATEPOINT(g.geometry1, g.geometry2, 'true', 99) FROM %s g", ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineSubstringTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineSubstringTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_LineSubstring;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_LineSubstringTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_LINESUBSTRING' => ST_LineSubstring::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_LineSubstring(c0_.geometry1, 0.2, 0.8) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_LINESUBSTRING(g.geometry1, 0.2, 0.8) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeEnvelopeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeEnvelopeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MakeEnvelope;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_MakeEnvelopeTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_MAKEENVELOPE' => ST_MakeEnvelope::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'creates envelope from bounds' => 'SELECT ST_MakeEnvelope(0, 0, 1, 1) AS sclr_0 FROM ContainsGeometries c0_',
+            'creates envelope with SRID' => 'SELECT ST_MakeEnvelope(0, 0, 1, 1, 4326) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'creates envelope from bounds' => 'SELECT ST_MAKEENVELOPE(0, 0, 1, 1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+            'creates envelope with SRID' => 'SELECT ST_MAKEENVELOPE(0, 0, 1, 1, 4326) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_MakeEnvelope() requires between 4 and 5 arguments');
+
+        $dql = \sprintf('SELECT ST_MAKEENVELOPE(0, 0, 1, 1, 4326, 99) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeLineTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakeLineTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MakeLine;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_MakeLineTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_MAKELINE' => ST_MakeLine::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'creates line as aggregate' => 'SELECT ST_MakeLine(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+            'creates line from two geometries' => 'SELECT ST_MakeLine(c0_.geometry1, c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'creates line as aggregate' => \sprintf('SELECT ST_MAKELINE(g.geometry1) FROM %s g', ContainsGeometries::class),
+            'creates line from two geometries' => \sprintf('SELECT ST_MAKELINE(g.geometry1, g.geometry2) FROM %s g', ContainsGeometries::class),
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_MakeLine() requires between 1 and 2 arguments');
+
+        $dql = \sprintf('SELECT ST_MAKELINE(g.geometry1, g.geometry2, g.geometry1) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakePointTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MakePointTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MakePoint;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_MakePointTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_MAKEPOINT' => ST_MakePoint::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'creates 2D point' => 'SELECT ST_MakePoint(1, 2) AS sclr_0 FROM ContainsGeometries c0_',
+            'creates 3DZ point' => 'SELECT ST_MakePoint(1, 2, 3) AS sclr_0 FROM ContainsGeometries c0_',
+            'creates 4D point' => 'SELECT ST_MakePoint(1, 2, 3, 4) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'creates 2D point' => 'SELECT ST_MAKEPOINT(1, 2) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+            'creates 3DZ point' => 'SELECT ST_MAKEPOINT(1, 2, 3) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+            'creates 4D point' => 'SELECT ST_MAKEPOINT(1, 2, 3, 4) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_MakePoint() requires between 2 and 4 arguments');
+
+        $dql = \sprintf('SELECT ST_MAKEPOINT(1, 2, 3, 4, 5) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MinimumBoundingCircleTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MinimumBoundingCircleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_MinimumBoundingCircle;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_MinimumBoundingCircleTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_MINIMUMBOUNDINGCIRCLE' => ST_MinimumBoundingCircle::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'computes bounding circle' => 'SELECT ST_MinimumBoundingCircle(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+            'computes bounding circle with segments per quarter' => 'SELECT ST_MinimumBoundingCircle(c0_.geometry1, 48) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'computes bounding circle' => 'SELECT ST_MINIMUMBOUNDINGCIRCLE(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+            'computes bounding circle with segments per quarter' => 'SELECT ST_MINIMUMBOUNDINGCIRCLE(g.geometry1, 48) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_MinimumBoundingCircle() requires between 1 and 2 arguments');
+
+        $dql = \sprintf('SELECT ST_MINIMUMBOUNDINGCIRCLE(g.geometry1, 48, 99) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NPointsTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NPointsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_NPoints;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_NPointsTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_NPOINTS' => ST_NPoints::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_NPoints(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_NPOINTS(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NumGeometriesTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_NumGeometriesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_NumGeometries;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_NumGeometriesTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_NUMGEOMETRIES' => ST_NumGeometries::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_NumGeometries(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_NUMGEOMETRIES(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_OffsetCurveTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_OffsetCurveTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_OffsetCurve;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_OffsetCurveTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_OFFSETCURVE' => ST_OffsetCurve::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'offsets curve by distance' => 'SELECT ST_OffsetCurve(c0_.geometry1, 1) AS sclr_0 FROM ContainsGeometries c0_',
+            'offsets curve with style parameters' => "SELECT ST_OffsetCurve(c0_.geometry1, 1, 'quad_segs=4 join=round') AS sclr_0 FROM ContainsGeometries c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'offsets curve by distance' => \sprintf('SELECT ST_OFFSETCURVE(g.geometry1, 1) FROM %s g', ContainsGeometries::class),
+            'offsets curve with style parameters' => \sprintf("SELECT ST_OFFSETCURVE(g.geometry1, 1, 'quad_segs=4 join=round') FROM %s g", ContainsGeometries::class),
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_OffsetCurve() requires between 2 and 3 arguments');
+
+        $dql = \sprintf("SELECT ST_OFFSETCURVE(g.geometry1, 1, 'quad_segs=4', 99) FROM %s g", ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PointOnSurfaceTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PointOnSurfaceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_PointOnSurface;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_PointOnSurfaceTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_POINTONSURFACE' => ST_PointOnSurface::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_PointOnSurface(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_POINTONSURFACE(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PointTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PointTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Point;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_PointTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_POINT' => ST_Point::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'creates point from coordinates' => 'SELECT ST_Point(1, 2) AS sclr_0 FROM ContainsGeometries c0_',
+            'creates point with SRID' => 'SELECT ST_Point(1, 2, 4326) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'creates point from coordinates' => 'SELECT ST_POINT(1, 2) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+            'creates point with SRID' => 'SELECT ST_POINT(1, 2, 4326) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_Point() requires between 2 and 3 arguments');
+
+        $dql = \sprintf('SELECT ST_POINT(1, 2, 4326, 99) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_RemoveIrrelevantPointsForViewTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_RemoveIrrelevantPointsForViewTest.php
@@ -22,16 +22,16 @@ final class ST_RemoveIrrelevantPointsForViewTest extends TestCase
     protected function getExpectedSqlStatements(): array
     {
         return [
-            'with two arguments' => "SELECT ST_RemoveIrrelevantPointsForView(c0_.geometry1, 'BOX(-10 -10, 10 10)') AS sclr_0 FROM ContainsGeometries c0_",
-            'with three arguments (cartesian_hint)' => "SELECT ST_RemoveIrrelevantPointsForView(c0_.geometry1, 'BOX(-10 -10, 10 10)', 'true') AS sclr_0 FROM ContainsGeometries c0_",
+            'removes irrelevant points for view' => "SELECT ST_RemoveIrrelevantPointsForView(c0_.geometry1, 'BOX(-10 -10, 10 10)') AS sclr_0 FROM ContainsGeometries c0_",
+            'removes irrelevant points with cartesian hint' => "SELECT ST_RemoveIrrelevantPointsForView(c0_.geometry1, 'BOX(-10 -10, 10 10)', 'true') AS sclr_0 FROM ContainsGeometries c0_",
         ];
     }
 
     protected function getDqlStatements(): array
     {
         return [
-            'with two arguments' => \sprintf("SELECT ST_REMOVEIRRELEVANTPOINTSFORVIEW(g.geometry1, 'BOX(-10 -10, 10 10)') FROM %s g", ContainsGeometries::class),
-            'with three arguments (cartesian_hint)' => \sprintf("SELECT ST_REMOVEIRRELEVANTPOINTSFORVIEW(g.geometry1, 'BOX(-10 -10, 10 10)', 'true') FROM %s g", ContainsGeometries::class),
+            'removes irrelevant points for view' => \sprintf("SELECT ST_REMOVEIRRELEVANTPOINTSFORVIEW(g.geometry1, 'BOX(-10 -10, 10 10)') FROM %s g", ContainsGeometries::class),
+            'removes irrelevant points with cartesian hint' => \sprintf("SELECT ST_REMOVEIRRELEVANTPOINTSFORVIEW(g.geometry1, 'BOX(-10 -10, 10 10)', 'true') FROM %s g", ContainsGeometries::class),
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SRIDTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SRIDTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SRID;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_SRIDTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_SRID' => ST_SRID::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_SRID(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_SRID(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SegmentizeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SegmentizeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Segmentize;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_SegmentizeTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_SEGMENTIZE' => ST_Segmentize::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_Segmentize(c0_.geometry1, 0.5) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_SEGMENTIZE(g.geometry1, 0.5) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SetSRIDTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SetSRIDTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_SetSRID;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_SetSRIDTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_SETSRID' => ST_SetSRID::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_SetSRID(c0_.geometry1, 4326) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_SETSRID(g.geometry1, 4326) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ShortestLineTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ShortestLineTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_ShortestLine;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_ShortestLineTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_SHORTESTLINE' => ST_ShortestLine::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_ShortestLine(c0_.geometry1, c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_SHORTESTLINE(g.geometry1, g.geometry2) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SimplifyPolygonHullTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SimplifyPolygonHullTest.php
@@ -22,16 +22,16 @@ final class ST_SimplifyPolygonHullTest extends TestCase
     protected function getExpectedSqlStatements(): array
     {
         return [
-            'with two arguments (outer hull)' => 'SELECT ST_SimplifyPolygonHull(c0_.geometry1, 0.9) AS sclr_0 FROM ContainsGeometries c0_',
-            'with three arguments (inner hull)' => "SELECT ST_SimplifyPolygonHull(c0_.geometry1, 0.9, 'false') AS sclr_0 FROM ContainsGeometries c0_",
+            'simplifies to outer hull' => 'SELECT ST_SimplifyPolygonHull(c0_.geometry1, 0.9) AS sclr_0 FROM ContainsGeometries c0_',
+            'simplifies to inner hull' => "SELECT ST_SimplifyPolygonHull(c0_.geometry1, 0.9, 'false') AS sclr_0 FROM ContainsGeometries c0_",
         ];
     }
 
     protected function getDqlStatements(): array
     {
         return [
-            'with two arguments (outer hull)' => \sprintf('SELECT ST_SIMPLIFYPOLYGONHULL(g.geometry1, 0.9) FROM %s g', ContainsGeometries::class),
-            'with three arguments (inner hull)' => \sprintf("SELECT ST_SIMPLIFYPOLYGONHULL(g.geometry1, 0.9, 'false') FROM %s g", ContainsGeometries::class),
+            'simplifies to outer hull' => \sprintf('SELECT ST_SIMPLIFYPOLYGONHULL(g.geometry1, 0.9) FROM %s g', ContainsGeometries::class),
+            'simplifies to inner hull' => \sprintf("SELECT ST_SIMPLIFYPOLYGONHULL(g.geometry1, 0.9, 'false') FROM %s g", ContainsGeometries::class),
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SnapTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SnapTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Snap;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_SnapTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_SNAP' => ST_Snap::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_Snap(c0_.geometry1, c0_.geometry2, 0.01) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_SNAP(g.geometry1, g.geometry2, 0.01) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TileEnvelopeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TileEnvelopeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_TileEnvelope;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_TileEnvelopeTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_TILEENVELOPE' => ST_TileEnvelope::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_TileEnvelope(10, 512, 384) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_TILEENVELOPE(10, 512, 384) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TileEnvelopeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TileEnvelopeTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
 
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_TileEnvelope;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
 
 final class ST_TileEnvelopeTest extends TestCase
@@ -19,14 +22,28 @@ final class ST_TileEnvelopeTest extends TestCase
     protected function getExpectedSqlStatements(): array
     {
         return [
-            'SELECT ST_TileEnvelope(10, 512, 384) AS sclr_0 FROM ContainsGeometries c0_',
+            'creates tile envelope from zoom/x/y' => 'SELECT ST_TileEnvelope(10, 512, 384) AS sclr_0 FROM ContainsGeometries c0_',
+            'creates tile envelope with bounds' => 'SELECT ST_TileEnvelope(10, 512, 384, c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+            'creates tile envelope with bounds and margin' => 'SELECT ST_TileEnvelope(10, 512, 384, c0_.geometry1, 0.1) AS sclr_0 FROM ContainsGeometries c0_',
         ];
     }
 
     protected function getDqlStatements(): array
     {
         return [
-            'SELECT ST_TILEENVELOPE(10, 512, 384) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+            'creates tile envelope from zoom/x/y' => 'SELECT ST_TILEENVELOPE(10, 512, 384) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+            'creates tile envelope with bounds' => 'SELECT ST_TILEENVELOPE(10, 512, 384, g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+            'creates tile envelope with bounds and margin' => 'SELECT ST_TILEENVELOPE(10, 512, 384, g.geometry1, 0.1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
         ];
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_TileEnvelope() requires between 3 and 5 arguments');
+
+        $dql = \sprintf('SELECT ST_TILEENVELOPE(10, 512, 384, g.geometry1, 0.1, 99) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_VoronoiPolygonsTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_VoronoiPolygonsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_VoronoiPolygons;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_VoronoiPolygonsTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_VORONOIPOLYGONS' => ST_VoronoiPolygons::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'creates polygons from geometry' => 'SELECT ST_VoronoiPolygons(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+            'creates polygons with tolerance' => 'SELECT ST_VoronoiPolygons(c0_.geometry1, 0.0) AS sclr_0 FROM ContainsGeometries c0_',
+            'creates polygons with tolerance and extend_to' => 'SELECT ST_VoronoiPolygons(c0_.geometry1, 0.0, c0_.geometry2) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'creates polygons from geometry' => \sprintf('SELECT ST_VORONOIPOLYGONS(g.geometry1) FROM %s g', ContainsGeometries::class),
+            'creates polygons with tolerance' => \sprintf('SELECT ST_VORONOIPOLYGONS(g.geometry1, 0.0) FROM %s g', ContainsGeometries::class),
+            'creates polygons with tolerance and extend_to' => \sprintf('SELECT ST_VORONOIPOLYGONS(g.geometry1, 0.0, g.geometry2) FROM %s g', ContainsGeometries::class),
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_arguments(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('ST_VoronoiPolygons() requires between 1 and 3 arguments');
+
+        $dql = \sprintf('SELECT ST_VORONOIPOLYGONS(g.geometry1, 0.0, g.geometry2, 99) FROM %s g', ContainsGeometries::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_XTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_XTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_X;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_XTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_X' => ST_X::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_X(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_X(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_YTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_YTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Y;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_YTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_Y' => ST_Y::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_Y(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_Y(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ZTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ZTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Z;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class ST_ZTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'ST_Z' => ST_Z::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'SELECT ST_Z(c0_.geometry1) AS sclr_0 FROM ContainsGeometries c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'SELECT ST_Z(g.geometry1) FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g',
+        ];
+    }
+}


### PR DESCRIPTION
**New functions:**

- _Constructors_: ST_GeneratePoints, ST_MakeEnvelope, ST_MakeLine, ST_MakePoint, ST_Point, ST_TileEnvelope

- _Accessors_: ST_CoordDim, ST_GeometryType, ST_IsEmpty, ST_IsValid, ST_NPoints, ST_NumGeometries, ST_SRID, ST_X, ST_Y, ST_Z

- _Processing_: ST_ClosestPoint, ST_FlipCoordinates, ST_LineInterpolatePoint, ST_LineLocatePoint, ST_LineSubstring, ST_MinimumBoundingCircle, ST_OffsetCurve, ST_PointOnSurface, ST_Segmentize, ST_SetSRID, ST_ShortestLine, ST_Snap, ST_VoronoiPolygons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Doctrine DQL support for many additional PostGIS spatial functions, including closest point, coordinate dimension, coordinate flipping, point/line constructors, SRID helpers, and several measurement/processing/linear-referencing utilities.
* **Documentation**
  * Expanded and reordered the PostGIS spatial functions/operator reference, including broader accessor/constructor/processing tables and added linear-referencing entries.
* **Tests**
  * Added integration and unit coverage for the new functions, including SQL/DQL generation, argument-arity validation, and optional boolean argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->