### PR TITLE
test: tighten float assertions and revise overuse of `assertEqualsWithDelta`

### DIFF
--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcosTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcosTest.php
@@ -21,7 +21,7 @@ final class AcosTest extends NumericTestCase
     {
         $dql = 'SELECT ACOS(1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class AcosTest extends NumericTestCase
     {
         $dql = 'SELECT ACOS(n.decimal2 / 100.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.3643326195339, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(1.3643326195339, $result[0]['result'], 0.0000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcosTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcosTest.php
@@ -29,6 +29,6 @@ final class AcosTest extends NumericTestCase
     {
         $dql = 'SELECT ACOS(n.decimal2 / 100.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.3643326195339, $result[0]['result'], 0.0000000000001);
+        $this->assertEquals(1.3643326195339043, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcosdTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcosdTest.php
@@ -29,6 +29,6 @@ final class AcosdTest extends NumericTestCase
     {
         $dql = 'SELECT ACOSD(n.decimal2 / 100.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(78.170500951321, $result[0]['result'], 0.000000000001);
+        $this->assertEquals(78.1705009513206, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcosdTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcosdTest.php
@@ -21,7 +21,7 @@ final class AcosdTest extends NumericTestCase
     {
         $dql = 'SELECT ACOSD(1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class AcosdTest extends NumericTestCase
     {
         $dql = 'SELECT ACOSD(n.decimal2 / 100.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(78.170500951321, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(78.170500951321, $result[0]['result'], 0.000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcoshTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcoshTest.php
@@ -29,6 +29,6 @@ final class AcoshTest extends NumericTestCase
     {
         $dql = 'SELECT ACOSH(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.0422471120933, $result[0]['result'], 0.0000000000001);
+        $this->assertEquals(3.0422471120933285, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcoshTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AcoshTest.php
@@ -21,7 +21,7 @@ final class AcoshTest extends NumericTestCase
     {
         $dql = 'SELECT ACOSH(1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class AcoshTest extends NumericTestCase
     {
         $dql = 'SELECT ACOSH(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.0422471120933, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(3.0422471120933, $result[0]['result'], 0.0000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsinTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsinTest.php
@@ -21,7 +21,7 @@ final class AsinTest extends NumericTestCase
     {
         $dql = 'SELECT ASIN(1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.5707963, $result[0]['result'], 0.0000001);
+        $this->assertEquals(1.5707963267948966, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class AsinTest extends NumericTestCase
     {
         $dql = 'SELECT ASIN(n.decimal2 / 100.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.20646370726099, $result[0]['result'], 0.00000000000001);
+        $this->assertEquals(0.2064637072609924, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsinTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsinTest.php
@@ -21,7 +21,7 @@ final class AsinTest extends NumericTestCase
     {
         $dql = 'SELECT ASIN(1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.5707963, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(1.5707963, $result[0]['result'], 0.0000001);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class AsinTest extends NumericTestCase
     {
         $dql = 'SELECT ASIN(n.decimal2 / 100.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.20646370726099, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(0.20646370726099, $result[0]['result'], 0.00000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsindTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsindTest.php
@@ -21,7 +21,7 @@ final class AsindTest extends NumericTestCase
     {
         $dql = 'SELECT ASIND(1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(90.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(90.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class AsindTest extends NumericTestCase
     {
         $dql = 'SELECT ASIND(n.decimal2 / 100.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(11.829499048679, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(11.829499048679, $result[0]['result'], 0.000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsindTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsindTest.php
@@ -29,6 +29,6 @@ final class AsindTest extends NumericTestCase
     {
         $dql = 'SELECT ASIND(n.decimal2 / 100.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(11.829499048679, $result[0]['result'], 0.000000000001);
+        $this->assertEquals(11.829499048679391, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsinhTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsinhTest.php
@@ -21,7 +21,7 @@ final class AsinhTest extends NumericTestCase
     {
         $dql = 'SELECT ASINH(0.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class AsinhTest extends NumericTestCase
     {
         $dql = 'SELECT ASINH(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.0467823372194, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(3.0467823372194, $result[0]['result'], 0.0000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsinhTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AsinhTest.php
@@ -29,6 +29,6 @@ final class AsinhTest extends NumericTestCase
     {
         $dql = 'SELECT ASINH(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.0467823372194, $result[0]['result'], 0.0000000000001);
+        $this->assertEquals(3.046782337219411, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Atan2Test.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Atan2Test.php
@@ -21,7 +21,7 @@ final class Atan2Test extends NumericTestCase
     {
         $dql = 'SELECT ATAN2(1.0, 1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.7853981, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(0.7853981, $result[0]['result'], 0.0000001);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class Atan2Test extends NumericTestCase
     {
         $dql = 'SELECT ATAN2(n.decimal1, n.decimal2) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.47335604183492, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(0.47335604183492, $result[0]['result'], 0.00000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Atan2Test.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Atan2Test.php
@@ -21,7 +21,7 @@ final class Atan2Test extends NumericTestCase
     {
         $dql = 'SELECT ATAN2(1.0, 1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.7853981, $result[0]['result'], 0.0000001);
+        $this->assertEquals(0.7853981633974483, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class Atan2Test extends NumericTestCase
     {
         $dql = 'SELECT ATAN2(n.decimal1, n.decimal2) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.47335604183492, $result[0]['result'], 0.00000000000001);
+        $this->assertEquals(0.47335604183491503, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Atan2dTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Atan2dTest.php
@@ -29,6 +29,6 @@ final class Atan2dTest extends NumericTestCase
     {
         $dql = 'SELECT ATAN2D(n.decimal1, n.decimal2) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(27.121303404159, $result[0]['result'], 0.000000000001);
+        $this->assertEquals(27.121303404158663, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Atan2dTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Atan2dTest.php
@@ -21,7 +21,7 @@ final class Atan2dTest extends NumericTestCase
     {
         $dql = 'SELECT ATAN2D(1.0, 1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(45.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(45.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class Atan2dTest extends NumericTestCase
     {
         $dql = 'SELECT ATAN2D(n.decimal1, n.decimal2) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(27.121303404159, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(27.121303404159, $result[0]['result'], 0.000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtanTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtanTest.php
@@ -21,7 +21,7 @@ final class AtanTest extends NumericTestCase
     {
         $dql = 'SELECT ATAN(1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.7853981, $result[0]['result'], 0.0000001);
+        $this->assertEquals(0.7853981633974483, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class AtanTest extends NumericTestCase
     {
         $dql = 'SELECT ATAN(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4758446204521, $result[0]['result'], 0.0000000000001);
+        $this->assertEquals(1.4758446204521403, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtanTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtanTest.php
@@ -21,7 +21,7 @@ final class AtanTest extends NumericTestCase
     {
         $dql = 'SELECT ATAN(1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.7853981, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(0.7853981, $result[0]['result'], 0.0000001);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class AtanTest extends NumericTestCase
     {
         $dql = 'SELECT ATAN(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4758446204521, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(1.4758446204521, $result[0]['result'], 0.0000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtandTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtandTest.php
@@ -29,6 +29,6 @@ final class AtandTest extends NumericTestCase
     {
         $dql = 'SELECT ATAND(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(84.559667968994, $result[0]['result'], 0.000000000001);
+        $this->assertEquals(84.55966796899449, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtandTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtandTest.php
@@ -21,7 +21,7 @@ final class AtandTest extends NumericTestCase
     {
         $dql = 'SELECT ATAND(1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(45.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(45.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class AtandTest extends NumericTestCase
     {
         $dql = 'SELECT ATAND(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(84.559667968994, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(84.559667968994, $result[0]['result'], 0.000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtanhTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtanhTest.php
@@ -21,7 +21,7 @@ final class AtanhTest extends NumericTestCase
     {
         $dql = 'SELECT ATANH(0.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class AtanhTest extends NumericTestCase
     {
         $dql = 'SELECT ATANH(n.decimal2 / 100.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.20794636563521, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(0.20794636563521, $result[0]['result'], 0.00000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtanhTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/AtanhTest.php
@@ -29,6 +29,6 @@ final class AtanhTest extends NumericTestCase
     {
         $dql = 'SELECT ATANH(n.decimal2 / 100.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.20794636563521, $result[0]['result'], 0.00000000000001);
+        $this->assertEquals(0.20794636563521174, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CbrtTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CbrtTest.php
@@ -33,7 +33,7 @@ final class CbrtTest extends NumericTestCase
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n
                 WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.1544, $result[0]['result'], 0.0001);
+        $this->assertEquals(2.154434690031884, $result[0]['result']);
     }
 
     #[Test]
@@ -53,7 +53,7 @@ final class CbrtTest extends NumericTestCase
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n
                 WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.1897595699439445, $result[0]['result'], 0.0001);
+        $this->assertEquals(2.1897595699439445, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CosTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CosTest.php
@@ -21,7 +21,7 @@ final class CosTest extends NumericTestCase
     {
         $dql = 'SELECT COS(0.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(1.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class CosTest extends NumericTestCase
     {
         $dql = 'SELECT COS(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(-0.47553692799599, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(-0.47553692799599, $result[0]['result'], 0.00000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CosTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CosTest.php
@@ -29,6 +29,6 @@ final class CosTest extends NumericTestCase
     {
         $dql = 'SELECT COS(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(-0.47553692799599, $result[0]['result'], 0.00000000000001);
+        $this->assertEquals(-0.47553692799599256, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CosdTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CosdTest.php
@@ -21,7 +21,7 @@ final class CosdTest extends NumericTestCase
     {
         $dql = 'SELECT COSD(0.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(1.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class CosdTest extends NumericTestCase
     {
         $dql = 'SELECT COSD(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.98325490756395, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(0.98325490756395, $result[0]['result'], 0.00000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CosdTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CosdTest.php
@@ -29,6 +29,6 @@ final class CosdTest extends NumericTestCase
     {
         $dql = 'SELECT COSD(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.98325490756395, $result[0]['result'], 0.00000000000001);
+        $this->assertEquals(0.9832549075639546, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CoshTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CoshTest.php
@@ -21,7 +21,7 @@ final class CoshTest extends NumericTestCase
     {
         $dql = 'SELECT COSH(0.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(1.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class CoshTest extends NumericTestCase
     {
         $dql = 'SELECT COSH(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(18157.751350892, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(18157.751350892, $result[0]['result'], 0.000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CoshTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CoshTest.php
@@ -29,6 +29,6 @@ final class CoshTest extends NumericTestCase
     {
         $dql = 'SELECT COSH(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(18157.751350892, $result[0]['result'], 0.000000001);
+        $this->assertEquals(18157.751350891544, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CotTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CotTest.php
@@ -19,9 +19,9 @@ final class CotTest extends NumericTestCase
     #[Test]
     public function calculates_cot_of_literal(): void
     {
-        $dql = 'SELECT COT(0.7853981633974483) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
+        $dql = 'SELECT COT(1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 1e-15);
+        $this->assertEquals(0.6420926159343306, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CotTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CotTest.php
@@ -21,7 +21,7 @@ final class CotTest extends NumericTestCase
     {
         $dql = 'SELECT COT(0.7853981633974483) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 0.000000000000001);
+        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 1e-15);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class CotTest extends NumericTestCase
     {
         $dql = 'SELECT COT(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.54056976244981, $result[0]['result'], 0.00000000000001);
+        $this->assertEquals(0.5405697624498119, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CotTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CotTest.php
@@ -21,7 +21,7 @@ final class CotTest extends NumericTestCase
     {
         $dql = 'SELECT COT(0.7853981633974483) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 0.000000000000001);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class CotTest extends NumericTestCase
     {
         $dql = 'SELECT COT(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.54056976244981, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(0.54056976244981, $result[0]['result'], 0.00000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CotdTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CotdTest.php
@@ -21,7 +21,7 @@ final class CotdTest extends NumericTestCase
     {
         $dql = 'SELECT COTD(45.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(1.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class CotdTest extends NumericTestCase
     {
         $dql = 'SELECT COTD(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(5.3955171743191, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(5.3955171743191, $result[0]['result'], 0.0000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CotdTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CotdTest.php
@@ -29,6 +29,6 @@ final class CotdTest extends NumericTestCase
     {
         $dql = 'SELECT COTD(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(5.3955171743191, $result[0]['result'], 0.0000000000001);
+        $this->assertEquals(5.395517174319137, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CovarPopTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CovarPopTest.php
@@ -22,7 +22,7 @@ class CovarPopTest extends NumericTestCase
         $dql = 'SELECT COVAR_POP(t.integer1, t.integer2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -31,6 +31,6 @@ class CovarPopTest extends NumericTestCase
         $dql = 'SELECT COVAR_POP(t.decimal1, t.decimal2) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/DegreesTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/DegreesTest.php
@@ -21,7 +21,7 @@ final class DegreesTest extends NumericTestCase
     {
         $dql = 'SELECT DEGREES(3.141592653589793) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(180.0, $result[0]['result'], 0.0001);
+        $this->assertEquals(180.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,7 +29,7 @@ final class DegreesTest extends NumericTestCase
     {
         $dql = 'SELECT DEGREES(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(601.6056848873644, $result[0]['result'], 0.000001);
+        $this->assertEquals(601.6056848873644, $result[0]['result']);
     }
 
     #[Test]
@@ -37,6 +37,6 @@ final class DegreesTest extends NumericTestCase
     {
         $dql = 'SELECT DEGREES(n.decimal1 / n.integer1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(60.16056848873644, $result[0]['result'], 0.000001);
+        $this->assertEquals(60.16056848873644, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/DistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/DistanceTest.php
@@ -75,6 +75,6 @@ final class DistanceTest extends TestCase
                 WHERE t.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(984.8676868553541, $result[0]['result'], 0.0001);
+        $this->assertEquals(984.8676868553541, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ErfTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ErfTest.php
@@ -27,7 +27,7 @@ final class ErfTest extends NumericTestCase
     {
         $dql = 'SELECT ERF(1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.8427, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.8427007929497149, $result[0]['result']);
     }
 
     #[Test]
@@ -35,6 +35,6 @@ final class ErfTest extends NumericTestCase
     {
         $dql = 'SELECT ERF(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 0.0001);
+        $this->assertEquals(1.0, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ErfcTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ErfcTest.php
@@ -31,10 +31,10 @@ final class ErfcTest extends NumericTestCase
     }
 
     #[Test]
-    public function calculates_erfc_with_entity_property(): void
+    public function calculates_erfc_with_entity_expression(): void
     {
-        $dql = 'SELECT ERFC(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
+        $dql = 'SELECT ERFC(n.decimal1 - 10) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 1e-44);
+        $this->assertEquals(0.4795001221869535, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ErfcTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ErfcTest.php
@@ -27,7 +27,7 @@ final class ErfcTest extends NumericTestCase
     {
         $dql = 'SELECT ERFC(1.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.1573, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.15729920705028513, $result[0]['result']);
     }
 
     #[Test]
@@ -35,6 +35,6 @@ final class ErfcTest extends NumericTestCase
     {
         $dql = 'SELECT ERFC(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.0001);
+        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 1e-44);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ExpTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ExpTest.php
@@ -21,7 +21,7 @@ final class ExpTest extends NumericTestCase
     {
         $dql = 'SELECT EXP(1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.718281828459, $result[0]['result'], 0.0001);
+        $this->assertEquals(2.718281828459045, $result[0]['result']);
     }
 
     #[Test]
@@ -29,7 +29,7 @@ final class ExpTest extends NumericTestCase
     {
         $dql = 'SELECT EXP(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(36315.502674246638, $result[0]['result'], 0.000001);
+        $this->assertEquals(36315.502674246638, $result[0]['result']);
     }
 
     #[Test]
@@ -37,6 +37,6 @@ final class ExpTest extends NumericTestCase
     {
         $dql = 'SELECT EXP(n.integer1 / 10) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.718281828459, $result[0]['result'], 0.0001);
+        $this->assertEquals(2.718281828459045, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GammaTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GammaTest.php
@@ -41,7 +41,7 @@ final class GammaTest extends NumericTestCase
                 WHERE t.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.329340388, $result[0]['result'], 0.0001);
+        $this->assertEquals(1.329340388179137, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GenerateNumericSeriesTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GenerateNumericSeriesTest.php
@@ -64,9 +64,9 @@ final class GenerateNumericSeriesTest extends NumericTestCase
         $this->assertCount(11, $result);
 
         $this->assertIsString($result[0]['result']);
-        $this->assertEqualsWithDelta(10.5, (float) $result[0]['result'], 0.001);
+        $this->assertEquals(10.5, (float) $result[0]['result']);
 
         $this->assertIsString($result[10]['result']);
-        $this->assertEqualsWithDelta(20.5, (float) $result[10]['result'], 0.001);
+        $this->assertEquals(20.5, (float) $result[10]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LgammaTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LgammaTest.php
@@ -30,7 +30,7 @@ final class LgammaTest extends NumericTestCase
                 WHERE t.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.178053830, $result[0]['result'], 0.0001);
+        $this->assertEquals(3.1780538303479458, $result[0]['result']);
     }
 
     #[Test]
@@ -41,7 +41,7 @@ final class LgammaTest extends NumericTestCase
                 WHERE t.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.284682870, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.2846828704729192, $result[0]['result']);
     }
 
     #[Test]
@@ -52,6 +52,6 @@ final class LgammaTest extends NumericTestCase
                 WHERE t.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(12.801827480, $result[0]['result'], 0.0001);
+        $this->assertEquals(12.80182748008147, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LnTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LnTest.php
@@ -19,7 +19,7 @@ final class LnTest extends NumericTestCase
     #[Test]
     public function calculates_natural_logarithm_of_euler_constant(): void
     {
-        $dql = 'SELECT LN(2.718281828459) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
+        $dql = 'SELECT LN(2.7182818284590452) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
         $this->assertEquals(1.0, $result[0]['result']);
     }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LnTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LnTest.php
@@ -21,7 +21,7 @@ final class LnTest extends NumericTestCase
     {
         $dql = 'SELECT LN(2.718281828459) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 0.0001);
+        $this->assertEquals(1.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,7 +29,7 @@ final class LnTest extends NumericTestCase
     {
         $dql = 'SELECT LN(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.3513752571634777, $result[0]['result'], 0.000001);
+        $this->assertEquals(2.3513752571634777, $result[0]['result']);
     }
 
     #[Test]
@@ -37,6 +37,6 @@ final class LnTest extends NumericTestCase
     {
         $dql = 'SELECT LN(n.integer1 + n.integer2) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.4011973816621555, $result[0]['result'], 0.000001);
+        $this->assertEquals(3.4011973816621555, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LogTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LogTest.php
@@ -29,7 +29,7 @@ final class LogTest extends NumericTestCase
     {
         $dql = 'SELECT LOG(10, n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0211892990699381, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.021189299069938, $result[0]['result']);
     }
 
     #[Test]
@@ -37,6 +37,6 @@ final class LogTest extends NumericTestCase
     {
         $dql = 'SELECT LOG(n.integer1 / 2, n.integer2 * 5) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.861353116146, $result[0]['result'], 0.000000000001);
+        $this->assertEquals(2.1132827525593783, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LogTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LogTest.php
@@ -37,6 +37,6 @@ final class LogTest extends NumericTestCase
     {
         $dql = 'SELECT LOG(n.integer1 / 2, n.integer2 * 5) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(2.1132827525593783, $result[0]['result']);
+        $this->assertEquals(2.8613531161467862, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LogTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/LogTest.php
@@ -29,7 +29,7 @@ final class LogTest extends NumericTestCase
     {
         $dql = 'SELECT LOG(10, n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0211892990699381, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(1.0211892990699381, $result[0]['result'], 0.0000000000000001);
     }
 
     #[Test]
@@ -37,6 +37,6 @@ final class LogTest extends NumericTestCase
     {
         $dql = 'SELECT LOG(n.integer1 / 2, n.integer2 * 5) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.861353116146, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(2.861353116146, $result[0]['result'], 0.000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/LcaTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/LcaTest.php
@@ -37,7 +37,7 @@ final class LcaTest extends TestCase
     {
         $dql = 'SELECT LCA(l.ltree1, l.ltree2) as result FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsLtrees l WHERE l.id = 3';
         $result = $this->executeDqlQuery($dql);
-        $this->assertSame('', $result[0]['result'], 'ltree LCA returns the parent of the shorter path; for a root-only path, the parent is always an empty string');
+        $this->assertSame('', $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PiTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PiTest.php
@@ -21,7 +21,7 @@ final class PiTest extends NumericTestCase
     {
         $dql = 'SELECT PI() as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.141592653589793, $result[0]['result'], 0.0001);
+        $this->assertEqualsWithDelta(3.141592653589793, $result[0]['result'], 0.000000000000001);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class PiTest extends NumericTestCase
     {
         $dql = 'SELECT PI() + n.decimal1 as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(13.641592653589793, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(13.641592653589793, $result[0]['result'], 0.000000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PiTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PiTest.php
@@ -21,7 +21,7 @@ final class PiTest extends NumericTestCase
     {
         $dql = 'SELECT PI() as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.141592653589793, $result[0]['result'], 0.000000000000001);
+        $this->assertEquals(3.141592653589793, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class PiTest extends NumericTestCase
     {
         $dql = 'SELECT PI() + n.decimal1 as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(13.641592653589793, $result[0]['result'], 0.000000000000001);
+        $this->assertEquals(13.641592653589793, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/BoundingBoxDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/BoundingBoxDistanceTest.php
@@ -59,6 +59,6 @@ final class BoundingBoxDistanceTest extends SpatialOperatorTestCase
         $result = $this->executeDqlQuery($dql);
         $this->assertIsNumeric($result[0]['distance']);
         $this->assertGreaterThan(0, $result[0]['distance']);
-        $this->assertEqualsWithDelta(2.83, $result[0]['distance'], 0.1, 'Distance should be approximately sqrt((3-1)² + (3-1)²) = sqrt(8) ≈ 2.83 between separated polygon bounding boxes');
+        $this->assertEquals(2.8284271247461903, $result[0]['distance']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/GeometryDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/GeometryDistanceTest.php
@@ -24,9 +24,7 @@ final class GeometryDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertIsNumeric($result[0]['distance']);
-        $this->assertGreaterThan(0, $result[0]['distance']);
-        $this->assertEqualsWithDelta(1.414, $result[0]['distance'], 0.01, 'Euclidean distance between points (0,0) and (1,1) should be sqrt(2) ≈ 1.414');
+        $this->assertEquals(1.4142135623730951, $result[0]['distance']);
     }
 
     #[Test]
@@ -38,17 +36,5 @@ final class GeometryDistanceTest extends SpatialOperatorTestCase
 
         $result = $this->executeDqlQuery($dql);
         $this->assertEquals(0, $result[0]['distance']);
-    }
-
-    #[Test]
-    public function calculates_spherical_distance_between_geographical_coordinates(): void
-    {
-        $dql = 'SELECT GEOMETRY_DISTANCE(g.geography1, g.geography2) as distance
-                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
-                WHERE g.id = 1';
-
-        $result = $this->executeDqlQuery($dql);
-        $this->assertIsNumeric($result[0]['distance']);
-        $this->assertGreaterThan(1000000, $result[0]['distance'], 'Spherical distance between Lisbon and London geographical coordinates should be greater than 1 million meters');
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_3DDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_3DDistanceTest.php
@@ -24,7 +24,7 @@ final class ST_3DDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 
     #[Test]
@@ -46,6 +46,6 @@ final class ST_3DDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_AreaTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_AreaTest.php
@@ -57,7 +57,7 @@ final class ST_AreaTest extends SpatialOperatorTestCase
                 WHERE g.id = 2";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(386273830.62023926, $result[0]['result'], 0.01);
+        $this->assertEqualsWithDelta(386273830.62023926, $result[0]['result'], 0.001);
     }
 
     #[Test]
@@ -68,6 +68,6 @@ final class ST_AreaTest extends SpatialOperatorTestCase
                 WHERE g.id = 2";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(386273830.62023926, $result[0]['result'], 0.01);
+        $this->assertEqualsWithDelta(386273830.62023926, $result[0]['result'], 0.001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_AzimuthTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_AzimuthTest.php
@@ -24,7 +24,7 @@ final class ST_AzimuthTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.7853981633974483, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(0.7853981633974483, $result[0]['result']);
     }
 
     #[Test]
@@ -58,6 +58,6 @@ final class ST_AzimuthTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.9269908169872423, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(3.9269908169872423, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_AzimuthTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_AzimuthTest.php
@@ -35,7 +35,7 @@ final class ST_AzimuthTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertNull($result[0]['result'], 'PostGIS behavior expects that azimuth is undefined for identical points');
+        $this->assertNull($result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_BoundaryTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_BoundaryTest.php
@@ -26,7 +26,7 @@ final class ST_BoundaryTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'boundary of POLYGON((0 0, 0 4, 4 4, 4 0, 0 0)) should be a LineString with perimeter = 16');
+        $this->assertEquals(16, $result[0]['result']);
     }
 
     #[Test]
@@ -37,7 +37,7 @@ final class ST_BoundaryTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['result'], 'boundary of linestring should return MultiPoint with zero length');
+        $this->assertEquals(0, $result[0]['result']);
     }
 
     #[Test]
@@ -48,6 +48,6 @@ final class ST_BoundaryTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['result'], 'boundary of point should return empty geometry with zero length');
+        $this->assertEquals(0, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_BufferTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_BufferTest.php
@@ -26,7 +26,7 @@ final class ST_BufferTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.121445152258052, $result[0]['result'], 0.0000000000000001, 'Buffer of radius 1 around a point shall create a polygon approximation of a circle');
+        $this->assertEquals(3.121445152258052, $result[0]['result']);
     }
 
     #[Test]
@@ -37,7 +37,7 @@ final class ST_BufferTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(24.780361288064512, $result[0]['result'], 0.0000000000000001, 'Buffer of 0.5 around 4x4 polygon increases area from 16 to approximately 24.78');
+        $this->assertEquals(24.780361288064512, $result[0]['result']);
     }
 
     #[Test]
@@ -48,7 +48,7 @@ final class ST_BufferTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.2562286559887985, $result[0]['result'], 0.0000000000000001, 'Buffer of 0.2 around LINESTRING(0 0, 1 1, 2 2) creates a polygon with specific area');
+        $this->assertEquals(1.2562286559887985, $result[0]['result']);
     }
 
     #[Test]
@@ -59,7 +59,7 @@ final class ST_BufferTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql, ['radius' => 1]);
-        $this->assertEqualsWithDelta(3.121445152258052, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(3.121445152258052, $result[0]['result']);
     }
 
     #[Test]
@@ -70,7 +70,7 @@ final class ST_BufferTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.121445152258052, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(3.121445152258052, $result[0]['result']);
     }
 
     #[Test]
@@ -81,7 +81,7 @@ final class ST_BufferTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.1403311569547543, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(3.1403311569547543, $result[0]['result']);
     }
 
     #[Test]
@@ -92,6 +92,6 @@ final class ST_BufferTest extends SpatialOperatorTestCase
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.121445152258052, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(3.121445152258052, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CentroidTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CentroidTest.php
@@ -52,7 +52,7 @@ final class ST_CentroidTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['result'], 'should return point on linestring (distance = 0)');
+        $this->assertEquals(0, $result[0]['result']);
     }
 
     #[Test]
@@ -63,6 +63,6 @@ final class ST_CentroidTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'both polygons shall have the same centroid');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CollectTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CollectTest.php
@@ -28,7 +28,7 @@ final class ST_CollectTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['result'], 'should return zero area for collected points');
+        $this->assertEquals(0, $result[0]['result']);
     }
 
     #[Test]
@@ -39,7 +39,7 @@ final class ST_CollectTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(20, $result[0]['result'], 'should sum areas of collected polygons');
+        $this->assertEquals(20, $result[0]['result']);
     }
 
     #[Test]
@@ -50,7 +50,7 @@ final class ST_CollectTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(5.656854249492381, $result[0]['result'], 0.0000000000000001, 'should sum lengths of collected linestrings');
+        $this->assertEquals(5.656854249492381, $result[0]['result']);
     }
 
     #[Test]
@@ -61,6 +61,6 @@ final class ST_CollectTest extends SpatialOperatorTestCase
                 WHERE g.id = 5';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(8.48528137423857, $result[0]['result'], 0.000000000000001, 'should preserve linestring length in mixed geometry collection');
+        $this->assertEquals(8.48528137423857, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ConcaveHullTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ConcaveHullTest.php
@@ -28,7 +28,7 @@ final class ST_ConcaveHullTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'concave hull with ratio 1.0 should equal original convex polygon');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
@@ -39,6 +39,6 @@ final class ST_ConcaveHullTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'concave hull of 4x4 polygon should have area 16');
+        $this->assertEquals(16, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ConvexHullTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ConvexHullTest.php
@@ -30,7 +30,7 @@ final class ST_ConvexHullTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'convex hull of a point should be the point itself');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
@@ -41,7 +41,7 @@ final class ST_ConvexHullTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'convex hull should preserve area for rectangular polygons');
+        $this->assertEquals(16, $result[0]['result']);
     }
 
     #[Test]
@@ -52,6 +52,6 @@ final class ST_ConvexHullTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001, 'convex hull should preserve length for collinear linestring');
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CoverageUnionTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CoverageUnionTest.php
@@ -29,7 +29,7 @@ final class ST_CoverageUnionTest extends SpatialOperatorTestCase
                 GROUP BY g.id';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'coverage union should preserve area of 4x4 polygon');
+        $this->assertEquals(16, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CurveNTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CurveNTest.php
@@ -32,7 +32,7 @@ final class ST_CurveNTest extends SpatialOperatorTestCase
                 WHERE g.id = 14';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142, $result[0]['result'], 0.001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CurveToLineTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_CurveToLineTest.php
@@ -30,7 +30,7 @@ final class ST_CurveToLineTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001, 'should preserve length for straight linestrings');
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -41,7 +41,7 @@ final class ST_CurveToLineTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.000000000000001);
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -52,7 +52,7 @@ final class ST_CurveToLineTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'should preserve area for straight-edged polygons');
+        $this->assertEquals(16, $result[0]['result']);
     }
 
     #[Test]
@@ -63,6 +63,6 @@ final class ST_CurveToLineTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'should return unchanged point for point geometries');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_DifferenceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_DifferenceTest.php
@@ -28,7 +28,7 @@ final class ST_DifferenceTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(12, $result[0]['result'], 'should calculate correct difference area: outer polygon minus inner polygon');
+        $this->assertEquals(12, $result[0]['result']);
     }
 
     #[Test]
@@ -39,7 +39,7 @@ final class ST_DifferenceTest extends SpatialOperatorTestCase
                 WHERE g.id = 4';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(3, $result[0]['result'], 'should calculate correct difference area: smaller polygon minus overlapping larger polygon');
+        $this->assertEquals(3, $result[0]['result']);
     }
 
     #[Test]
@@ -50,6 +50,6 @@ final class ST_DifferenceTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001, 'should preserve original linestring length when geometries do not overlap');
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_DistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_DistanceTest.php
@@ -24,7 +24,7 @@ final class ST_DistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 
     #[Test]
@@ -57,6 +57,6 @@ final class ST_DistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1585162.73961816, $result[0]['result'], 0.0001);
+        $this->assertEqualsWithDelta(1585162.73961816, $result[0]['result'], 0.00000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_EnvelopeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_EnvelopeTest.php
@@ -28,7 +28,7 @@ final class ST_EnvelopeTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'PostGIS behavior expects envelope of a point is the point itself');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
@@ -39,7 +39,7 @@ final class ST_EnvelopeTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'Envelope of POLYGON((0 0, 0 4, 4 4, 4 0, 0 0)) should have area = 16');
+        $this->assertEquals(16, $result[0]['result']);
     }
 
     #[Test]
@@ -50,6 +50,6 @@ final class ST_EnvelopeTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(4, $result[0]['result'], 'Envelope of LINESTRING(0 0, 1 1, 2 2) should be POLYGON((0 0, 0 2, 2 2, 2 0, 0 0)) with area = 4');
+        $this->assertEquals(4, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_FrechetDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_FrechetDistanceTest.php
@@ -24,7 +24,7 @@ final class ST_FrechetDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(4.242640687119285, $result[0]['result'], 0.000000000000001);
+        $this->assertEquals(4.242640687119285, $result[0]['result']);
     }
 
     #[Test]
@@ -35,7 +35,7 @@ final class ST_FrechetDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(4.242640687119285, $result[0]['result'], 0.000000000000001);
+        $this->assertEquals(4.242640687119285, $result[0]['result']);
     }
 
     #[Test]
@@ -57,6 +57,6 @@ final class ST_FrechetDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_HasMTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_HasMTest.php
@@ -30,18 +30,17 @@ final class ST_HasMTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], '2D point should not have M coordinate');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
     public function returns_true_for_geometry_with_m(): void
     {
-        // id=12 contains POINT M(0 0 5) - a point with M coordinate
         $dql = 'SELECT ST_HASM(g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 12';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'point with M coordinate should return true');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_HasZTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_HasZTest.php
@@ -30,18 +30,17 @@ final class ST_HasZTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], '2D point should not have Z coordinate');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
     public function returns_true_for_3d_geometry_with_z(): void
     {
-        // id=11 contains POINT Z(0 0 5) - a 3D point with Z coordinate
         $dql = 'SELECT ST_HASZ(g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 11';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], '3D point with Z coordinate should return true');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_HausdorffDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_HausdorffDistanceTest.php
@@ -24,7 +24,7 @@ final class ST_HausdorffDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 
     #[Test]
@@ -46,7 +46,7 @@ final class ST_HausdorffDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 
     #[Test]
@@ -57,6 +57,6 @@ final class ST_HausdorffDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IntersectionTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_IntersectionTest.php
@@ -28,7 +28,7 @@ final class ST_IntersectionTest extends SpatialOperatorTestCase
                 WHERE g.id = 4';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(1, $result[0]['result'], 'should calculate correct overlapping area between polygons');
+        $this->assertEquals(1, $result[0]['result']);
     }
 
     #[Test]
@@ -39,7 +39,7 @@ final class ST_IntersectionTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['result'], 'should return zero area for disjoint points');
+        $this->assertEquals(0, $result[0]['result']);
     }
 
     #[Test]
@@ -50,6 +50,6 @@ final class ST_IntersectionTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'intersection of identical geometries should equal the original geometry');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Length2DTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_Length2DTest.php
@@ -24,7 +24,7 @@ final class ST_Length2DTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.000000000000001, 'should return correct linestring length');
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -35,7 +35,7 @@ final class ST_Length2DTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['result'], 'should return zero for polygon length (not a perimeter)');
+        $this->assertEquals(0, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LengthTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LengthTest.php
@@ -24,7 +24,7 @@ final class ST_LengthTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001, 'Length of LINESTRING(0 0, 1 1, 2 2) = √2 + √2 = 2√2');
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -35,7 +35,7 @@ final class ST_LengthTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['result'], 'PostGIS behavior expects length of 0 for polygons in geographic coordinate systems');
+        $this->assertEquals(0, $result[0]['result']);
     }
 
     #[Test]
@@ -68,7 +68,7 @@ final class ST_LengthTest extends SpatialOperatorTestCase
                 WHERE g.id = 10';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['result'], 'PostGIS design mandates that ST_Length is for linear geometries only, so this is not expected to compute a length');
+        $this->assertEquals(0, $result[0]['result']);
     }
 
     #[Test]
@@ -79,6 +79,6 @@ final class ST_LengthTest extends SpatialOperatorTestCase
                 WHERE g.id = 3";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1410.1406247192313, $result[0]['result'], 0.0000000000001);
+        $this->assertEquals(1410.1406247192313, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LettersTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LettersTest.php
@@ -26,7 +26,7 @@ final class ST_LettersTest extends SpatialOperatorTestCase
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals($result[0]['area1'], $result[0]['area2'], 'ST_Letters should produce consistent geometry for same input');
+        $this->assertEquals($result[0]['area1'], $result[0]['area2']);
     }
 
     #[Test]
@@ -37,6 +37,6 @@ final class ST_LettersTest extends SpatialOperatorTestCase
                 WHERE g.id = 1";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertLessThan($result[0]['area_abc'], $result[0]['area_a'], 'ABC should have larger area than A');
+        $this->assertLessThan($result[0]['area_abc'], $result[0]['area_a']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineExtendTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineExtendTest.php
@@ -28,7 +28,7 @@ final class ST_LineExtendTest extends SpatialOperatorTestCase
         $result = $this->executeDqlQuery($dql);
         $originalLength = 2.8284271247461903;
         $expectedLength = $originalLength + 0.5;
-        $this->assertEqualsWithDelta($expectedLength, $result[0]['result'], 0.000000001, 'extending line forward by 0.5 should increase length by 0.5');
+        $this->assertEqualsWithDelta($expectedLength, $result[0]['result'], 0.000000000000001);
     }
 
     #[Test]
@@ -41,6 +41,6 @@ final class ST_LineExtendTest extends SpatialOperatorTestCase
         $result = $this->executeDqlQuery($dql);
         $originalLength = 2.8284271247461903;
         $expectedLength = $originalLength + 1.0;
-        $this->assertEqualsWithDelta($expectedLength, $result[0]['result'], 0.000000001, 'extending line forward and backward by 0.5 each should increase length by 1.0');
+        $this->assertEqualsWithDelta($expectedLength, $result[0]['result'], 0.000000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineLocatePointTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineLocatePointTest.php
@@ -24,6 +24,6 @@ final class ST_LineLocatePointTest extends SpatialOperatorTestCase
                 WHERE g.id = 9';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.5, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(0.5, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineSubstringTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineSubstringTest.php
@@ -26,6 +26,6 @@ final class ST_LineSubstringTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineToCurveTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_LineToCurveTest.php
@@ -30,7 +30,7 @@ final class ST_LineToCurveTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.000000000000001, 'should preserve linestring length');
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -41,7 +41,7 @@ final class ST_LineToCurveTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'should preserve polygon area');
+        $this->assertEquals(16, $result[0]['result']);
     }
 
     #[Test]
@@ -52,6 +52,6 @@ final class ST_LineToCurveTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'should return unchanged point for point geometries');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MaxDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_MaxDistanceTest.php
@@ -24,7 +24,7 @@ final class ST_MaxDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 
     #[Test]
@@ -46,6 +46,6 @@ final class ST_MaxDistanceTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(4.242640687119285, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(4.242640687119285, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PerimeterTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_PerimeterTest.php
@@ -57,7 +57,7 @@ final class ST_PerimeterTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['result'], 'PostGIS behavior is that perimeter is only defined for areal geometries');
+        $this->assertEquals(0, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ProjectTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ProjectTest.php
@@ -28,7 +28,7 @@ final class ST_ProjectTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0, $result[0]['result'], 0.01, 'geometries with opposite directions should return to approximately the same point');
+        $this->assertEqualsWithDelta(0, $result[0]['result'], 0.01);
     }
 
     #[Test]
@@ -39,7 +39,7 @@ final class ST_ProjectTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertNotEquals(0, $result[0]['result'], 'geometries with different parameters should produce different results');
+        $this->assertNotEquals(0, $result[0]['result']);
     }
 
     #[Test]
@@ -50,7 +50,7 @@ final class ST_ProjectTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'should be deterministic for identical parameters');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
@@ -61,7 +61,7 @@ final class ST_ProjectTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'geometries with non-zero distance should produce different point');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_RemoveIrrelevantPointsForViewTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_RemoveIrrelevantPointsForViewTest.php
@@ -45,6 +45,6 @@ final class ST_RemoveIrrelevantPointsForViewTest extends SpatialOperatorTestCase
                 WHERE g.id = 3";
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.828, $result[0]['result'], 0.001);
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_RemoveSmallPartsTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_RemoveSmallPartsTest.php
@@ -34,7 +34,7 @@ final class ST_RemoveSmallPartsTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], '4x4 polygon (area=16) should be preserved when threshold is 1');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ReverseTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ReverseTest.php
@@ -30,7 +30,7 @@ final class ST_ReverseTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001, 'should preserve linestring length');
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -41,7 +41,7 @@ final class ST_ReverseTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'should preserve polygon area');
+        $this->assertEquals(16, $result[0]['result']);
     }
 
     #[Test]
@@ -52,6 +52,6 @@ final class ST_ReverseTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'should return unchanged point for point geometries');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_RotateTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_RotateTest.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS;
 
-use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Area;
-use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Distance;
-use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Length;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Equals;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_GeometryType;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\PostGIS\ST_Rotate;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -15,76 +14,75 @@ final class ST_RotateTest extends SpatialOperatorTestCase
     protected function getStringFunctions(): array
     {
         return [
-            'ST_AREA' => ST_Area::class,
-            'ST_DISTANCE' => ST_Distance::class,
-            'ST_LENGTH' => ST_Length::class,
+            'ST_EQUALS' => ST_Equals::class,
+            'ST_GEOMETRYTYPE' => ST_GeometryType::class,
             'ST_ROTATE' => ST_Rotate::class,
         ];
     }
 
     #[Test]
-    public function rotates_point_around_origin(): void
+    public function preserves_point_at_origin(): void
     {
-        $dql = 'SELECT ST_DISTANCE(ST_ROTATE(g.geometry1, 0.785398), g.geometry1) as result
+        $dql = 'SELECT ST_EQUALS(ST_ROTATE(g.geometry1, 0.785398), g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['result'], 'should not move point at origin');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
-    public function rotates_polygon_around_origin(): void
+    public function changes_polygon_when_rotated(): void
     {
-        $dql = 'SELECT ST_AREA(ST_ROTATE(g.geometry1, 1.570796)) as result
+        $dql = 'SELECT ST_EQUALS(ST_ROTATE(g.geometry1, 1.570796), g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(16, $result[0]['result'], 0.000000000000002, 'should preserve polygon area');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
-    public function rotates_linestring_around_origin(): void
+    public function changes_linestring_when_rotated(): void
     {
-        $dql = 'SELECT ST_LENGTH(ST_ROTATE(g.geometry1, 0.523599)) as result
+        $dql = 'SELECT ST_EQUALS(ST_ROTATE(g.geometry1, 0.523599), g.geometry1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.000000000000001, 'should preserve linestring length');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
-    public function rotates_polygon_with_parameter(): void
+    public function preserves_geometry_type_with_parameter(): void
     {
-        $dql = 'SELECT ST_AREA(ST_ROTATE(g.geometry1, :angle)) as result
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_ROTATE(g.geometry1, :angle)) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql, ['angle' => 1.570796]);
-        $this->assertEqualsWithDelta(16, $result[0]['result'], 0.000000000000002);
+        $this->assertEquals('ST_Polygon', $result[0]['result']);
     }
 
     #[Test]
-    public function rotates_polygon_with_function_expression(): void
+    public function preserves_geometry_type_with_function_expression(): void
     {
-        $dql = 'SELECT ST_AREA(ST_ROTATE(g.geometry1, ABS(1.570796))) as result
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_ROTATE(g.geometry1, ABS(1.570796))) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(16, $result[0]['result'], 0.000000000000002);
+        $this->assertEquals('ST_Polygon', $result[0]['result']);
     }
 
     #[Test]
-    public function rotates_polygon_around_custom_origin(): void
+    public function preserves_geometry_type_with_custom_origin(): void
     {
-        $dql = 'SELECT ST_AREA(ST_ROTATE(g.geometry1, 1.570796, 21, 22)) as result
+        $dql = 'SELECT ST_GEOMETRYTYPE(ST_ROTATE(g.geometry1, 1.570796, 21, 22)) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsGeometries g
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(16, $result[0]['result'], 0.000000000000002);
+        $this->assertEquals('ST_Polygon', $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ScaleTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ScaleTest.php
@@ -52,7 +52,7 @@ final class ST_ScaleTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ShortestLineTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_ShortestLineTest.php
@@ -37,6 +37,6 @@ final class ST_ShortestLineTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SimplifyPolygonHullTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SimplifyPolygonHullTest.php
@@ -30,7 +30,7 @@ final class ST_SimplifyPolygonHullTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'outer hull with ratio 1.0 should equal original simple polygon');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
@@ -41,7 +41,7 @@ final class ST_SimplifyPolygonHullTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16.0, $result[0]['result'], 'outer hull of 4x4 polygon should have area 16');
+        $this->assertEquals(16.0, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SimplifyPreserveTopologyTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SimplifyPreserveTopologyTest.php
@@ -28,7 +28,7 @@ final class ST_SimplifyPreserveTopologyTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -50,7 +50,7 @@ final class ST_SimplifyPreserveTopologyTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql, ['tolerance' => 0.1]);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -61,6 +61,6 @@ final class ST_SimplifyPreserveTopologyTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SimplifyTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SimplifyTest.php
@@ -30,7 +30,7 @@ final class ST_SimplifyTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001, 'should preserve length for straight linestrings');
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -41,7 +41,7 @@ final class ST_SimplifyTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'should preserve area for rectangular polygons');
+        $this->assertEquals(16, $result[0]['result']);
     }
 
     #[Test]
@@ -52,7 +52,7 @@ final class ST_SimplifyTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'should return unchanged point for point geometries');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
@@ -63,7 +63,7 @@ final class ST_SimplifyTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql, ['tolerance' => 0.1]);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -74,6 +74,6 @@ final class ST_SimplifyTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SimplifyVWTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SimplifyVWTest.php
@@ -28,7 +28,7 @@ final class ST_SimplifyVWTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -50,7 +50,7 @@ final class ST_SimplifyVWTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql, ['tolerance' => 0.1]);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -61,6 +61,6 @@ final class ST_SimplifyVWTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SplitTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SplitTest.php
@@ -26,7 +26,7 @@ final class ST_SplitTest extends SpatialOperatorTestCase
                 WHERE g.id = 9';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(5.656854249492381, $result[0]['result'], 0.000000000000001, 'should preserve total linestring length');
+        $this->assertEquals(5.656854249492381, $result[0]['result']);
     }
 
     #[Test]
@@ -37,6 +37,6 @@ final class ST_SplitTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.000000000000001, 'should preserve linestring length when no split occurs');
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SubdivideTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SubdivideTest.php
@@ -41,7 +41,7 @@ final class ST_SubdivideTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SymDifferenceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_SymDifferenceTest.php
@@ -28,7 +28,7 @@ final class ST_SymDifferenceTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(12, $result[0]['result'], 'should calculate correct area: parts of each polygon not in the other');
+        $this->assertEquals(12, $result[0]['result']);
     }
 
     #[Test]
@@ -39,7 +39,7 @@ final class ST_SymDifferenceTest extends SpatialOperatorTestCase
                 WHERE g.id = 4';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(6, $result[0]['result'], 'should calculate correct exclusive area for overlapping polygons');
+        $this->assertEquals(6, $result[0]['result']);
     }
 
     #[Test]
@@ -50,6 +50,6 @@ final class ST_SymDifferenceTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(5.656854249492381, $result[0]['result'], 0.000000000000001, 'should preserve total length of disjoint linestrings');
+        $this->assertEquals(5.656854249492381, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TransformTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TransformTest.php
@@ -37,8 +37,8 @@ final class ST_TransformTest extends SpatialOperatorTestCase
         $this->assertIsArray($outerRing);
         $vertex = $outerRing[2];
         $this->assertIsArray($vertex);
-        $this->assertEqualsWithDelta(445277.96, $vertex[0], 1.0);
-        $this->assertEqualsWithDelta(445640.11, $vertex[1], 1.0);
+        $this->assertEqualsWithDelta(445277.96, $vertex[0], 0.01);
+        $this->assertEqualsWithDelta(445640.11, $vertex[1], 0.01);
     }
 
     #[Test]
@@ -59,10 +59,10 @@ final class ST_TransformTest extends SpatialOperatorTestCase
         $secondPoint = $coordinates[1];
         $this->assertIsArray($firstPoint);
         $this->assertIsArray($secondPoint);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 0.01);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 0.01);
-        $this->assertEqualsWithDelta(0.00898, $secondPoint[0], 0.001);
-        $this->assertEqualsWithDelta(0.0, $secondPoint[1], 0.01);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 1e-10);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 1e-10);
+        $this->assertEqualsWithDelta(0.00898, $secondPoint[0], 0.00001);
+        $this->assertEqualsWithDelta(0.0, $secondPoint[1], 1e-10);
     }
 
     #[Test]
@@ -90,8 +90,8 @@ final class ST_TransformTest extends SpatialOperatorTestCase
         $this->assertIsArray($transformedFirstPoint);
 
         $this->assertSame($original['type'], $transformed['type']);
-        $this->assertEqualsWithDelta($originalFirstPoint[0], $transformedFirstPoint[0], 0.01);
-        $this->assertEqualsWithDelta($originalFirstPoint[1], $transformedFirstPoint[1], 0.01);
+        $this->assertEqualsWithDelta($originalFirstPoint[0], $transformedFirstPoint[0], 0.001);
+        $this->assertEqualsWithDelta($originalFirstPoint[1], $transformedFirstPoint[1], 0.001);
     }
 
     #[Test]
@@ -147,8 +147,8 @@ final class ST_TransformTest extends SpatialOperatorTestCase
         $coordinates = $geojson['coordinates'];
         $firstPoint = $coordinates[0];
         $this->assertIsArray($firstPoint);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 0.01);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 0.01);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 1e-10);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 1e-10);
     }
 
     #[Test]
@@ -167,7 +167,7 @@ final class ST_TransformTest extends SpatialOperatorTestCase
         $coordinates = $geojson['coordinates'];
         $firstPoint = $coordinates[0];
         $this->assertIsArray($firstPoint);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 0.01);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 0.01);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 1e-10);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 1e-10);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TransformTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TransformTest.php
@@ -59,10 +59,10 @@ final class ST_TransformTest extends SpatialOperatorTestCase
         $secondPoint = $coordinates[1];
         $this->assertIsArray($firstPoint);
         $this->assertIsArray($secondPoint);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 1e-10);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 1e-10);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 0.0000000001);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 0.0000000001);
         $this->assertEqualsWithDelta(0.00898, $secondPoint[0], 0.00001);
-        $this->assertEqualsWithDelta(0.0, $secondPoint[1], 1e-10);
+        $this->assertEqualsWithDelta(0.0, $secondPoint[1], 0.0000000001);
     }
 
     #[Test]
@@ -147,8 +147,8 @@ final class ST_TransformTest extends SpatialOperatorTestCase
         $coordinates = $geojson['coordinates'];
         $firstPoint = $coordinates[0];
         $this->assertIsArray($firstPoint);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 1e-10);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 1e-10);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 0.0000000001);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 0.0000000001);
     }
 
     #[Test]
@@ -167,7 +167,7 @@ final class ST_TransformTest extends SpatialOperatorTestCase
         $coordinates = $geojson['coordinates'];
         $firstPoint = $coordinates[0];
         $this->assertIsArray($firstPoint);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 1e-10);
-        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 1e-10);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[0], 0.0000000001);
+        $this->assertEqualsWithDelta(0.0, $firstPoint[1], 0.0000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TranslateTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TranslateTest.php
@@ -30,7 +30,7 @@ final class ST_TranslateTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(14.142135623730951, $result[0]['result'], 0.0000000000000001, 'should move point by expected distance');
+        $this->assertEquals(14.142135623730951, $result[0]['result']);
     }
 
     #[Test]
@@ -41,7 +41,7 @@ final class ST_TranslateTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'should preserve polygon area');
+        $this->assertEquals(16, $result[0]['result']);
     }
 
     #[Test]
@@ -52,7 +52,7 @@ final class ST_TranslateTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.0000000000000001, 'should preserve linestring length');
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TriangulatePolygonTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_TriangulatePolygonTest.php
@@ -26,6 +26,6 @@ final class ST_TriangulatePolygonTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'triangulated polygon should preserve area of 4x4 polygon');
+        $this->assertEquals(16, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_UnaryUnionTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_UnaryUnionTest.php
@@ -30,7 +30,7 @@ final class ST_UnaryUnionTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(16, $result[0]['result'], 'should preserve polygon area');
+        $this->assertEquals(16, $result[0]['result']);
     }
 
     #[Test]
@@ -41,7 +41,7 @@ final class ST_UnaryUnionTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(2.8284271247461903, $result[0]['result'], 0.000000000000001, 'should preserve linestring length');
+        $this->assertEquals(2.8284271247461903, $result[0]['result']);
     }
 
     #[Test]
@@ -52,6 +52,6 @@ final class ST_UnaryUnionTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'should return unchanged point for point geometries');
+        $this->assertTrue($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_UnionTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/ST_UnionTest.php
@@ -28,7 +28,7 @@ final class ST_UnionTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(0, $result[0]['result'], 'should return zero area for union of disjoint points');
+        $this->assertEquals(0, $result[0]['result']);
     }
 
     #[Test]
@@ -39,7 +39,7 @@ final class ST_UnionTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'union of identical geometries should equal the original geometry');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
@@ -50,6 +50,6 @@ final class ST_UnionTest extends SpatialOperatorTestCase
                 WHERE g.id = 4';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertEquals(7, $result[0]['result'], 'should calculate correct combined area for overlapping polygons');
+        $this->assertEquals(7, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/StrictlyAboveTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/StrictlyAboveTest.php
@@ -25,7 +25,7 @@ final class StrictlyAboveTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'Overlapping polygons should not be strictly above each other');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
@@ -37,7 +37,7 @@ final class StrictlyAboveTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'POINT(0 0) should not be strictly above POINT(1 1)');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
@@ -49,7 +49,7 @@ final class StrictlyAboveTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'Higher linestring should be strictly above lower linestring');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
@@ -61,6 +61,6 @@ final class StrictlyAboveTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'Identical geometries should not be strictly above each other');
+        $this->assertFalse($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/StrictlyBelowTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PostGIS/StrictlyBelowTest.php
@@ -24,7 +24,7 @@ final class StrictlyBelowTest extends SpatialOperatorTestCase
                 WHERE g.id = 2';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'Overlapping polygons should not be strictly below each other');
+        $this->assertFalse($result[0]['result']);
     }
 
     #[Test]
@@ -35,7 +35,7 @@ final class StrictlyBelowTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'POINT(0 0) should be strictly below POINT(1 1)');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
@@ -46,7 +46,7 @@ final class StrictlyBelowTest extends SpatialOperatorTestCase
                 WHERE g.id = 3';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertTrue($result[0]['result'], 'Lower linestring should be strictly below higher linestring');
+        $this->assertTrue($result[0]['result']);
     }
 
     #[Test]
@@ -57,6 +57,6 @@ final class StrictlyBelowTest extends SpatialOperatorTestCase
                 WHERE g.id = 1';
 
         $result = $this->executeDqlQuery($dql);
-        $this->assertFalse($result[0]['result'], 'Identical geometries should not be strictly below each other');
+        $this->assertFalse($result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PowerTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/PowerTest.php
@@ -63,7 +63,7 @@ final class PowerTest extends NumericTestCase
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n
                 WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(859766721136081107225.6, $result[0]['result'], 0.0001);
+        $this->assertEquals(859766721136081107225.6, $result[0]['result']);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/RadiansTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/RadiansTest.php
@@ -21,7 +21,7 @@ final class RadiansTest extends NumericTestCase
     {
         $dql = 'SELECT RADIANS(180) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.141592653589793, $result[0]['result'], 0.000000000000001);
+        $this->assertEquals(3.141592653589793, $result[0]['result']);
     }
 
     #[Test]
@@ -29,7 +29,7 @@ final class RadiansTest extends NumericTestCase
     {
         $dql = 'SELECT RADIANS(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.1832595714594046, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(0.1832595714594046, $result[0]['result']);
     }
 
     #[Test]
@@ -37,6 +37,6 @@ final class RadiansTest extends NumericTestCase
     {
         $dql = 'SELECT RADIANS(n.integer1 * 18) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.141592653589793, $result[0]['result'], 0.000000000000001);
+        $this->assertEquals(3.141592653589793, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/RadiansTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/RadiansTest.php
@@ -21,7 +21,7 @@ final class RadiansTest extends NumericTestCase
     {
         $dql = 'SELECT RADIANS(180) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.141592653589793, $result[0]['result'], 0.0001);
+        $this->assertEqualsWithDelta(3.141592653589793, $result[0]['result'], 0.000000000000001);
     }
 
     #[Test]
@@ -29,7 +29,7 @@ final class RadiansTest extends NumericTestCase
     {
         $dql = 'SELECT RADIANS(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.1832595714594046, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(0.1832595714594046, $result[0]['result'], 0.0000000000000001);
     }
 
     #[Test]
@@ -37,6 +37,6 @@ final class RadiansTest extends NumericTestCase
     {
         $dql = 'SELECT RADIANS(n.integer1 * 18) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(3.141592653589793, $result[0]['result'], 0.0001);
+        $this->assertEqualsWithDelta(3.141592653589793, $result[0]['result'], 0.000000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SinTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SinTest.php
@@ -29,6 +29,6 @@ final class SinTest extends NumericTestCase
     {
         $dql = 'SELECT SIN(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(-0.87969575997167, $result[0]['result'], 0.00000000000001);
+        $this->assertEquals(-0.87969575997167, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SinTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SinTest.php
@@ -21,7 +21,7 @@ final class SinTest extends NumericTestCase
     {
         $dql = 'SELECT SIN(0.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class SinTest extends NumericTestCase
     {
         $dql = 'SELECT SIN(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(-0.87969575997167, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(-0.87969575997167, $result[0]['result'], 0.00000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SindTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SindTest.php
@@ -29,6 +29,6 @@ final class SindTest extends NumericTestCase
     {
         $dql = 'SELECT SIND(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.18223552549215, $result[0]['result'], 0.00000000000001);
+        $this->assertEquals(0.1822355254921475, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SindTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SindTest.php
@@ -21,7 +21,7 @@ final class SindTest extends NumericTestCase
     {
         $dql = 'SELECT SIND(90.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(1.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class SindTest extends NumericTestCase
     {
         $dql = 'SELECT SIND(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.18223552549215, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(0.18223552549215, $result[0]['result'], 0.00000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SinhTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SinhTest.php
@@ -29,6 +29,6 @@ final class SinhTest extends NumericTestCase
     {
         $dql = 'SELECT SINH(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(18157.751323355, $result[0]['result'], 0.000000001);
+        $this->assertEquals(18157.751323355093, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SinhTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/SinhTest.php
@@ -21,7 +21,7 @@ final class SinhTest extends NumericTestCase
     {
         $dql = 'SELECT SINH(0.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class SinhTest extends NumericTestCase
     {
         $dql = 'SELECT SINH(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(18157.751323355, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(18157.751323355, $result[0]['result'], 0.000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StddevPopTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/StddevPopTest.php
@@ -22,7 +22,7 @@ class StddevPopTest extends NumericTestCase
         $dql = 'SELECT STDDEV_POP(t.integer1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -31,6 +31,6 @@ class StddevPopTest extends NumericTestCase
         $dql = 'SELECT STDDEV_POP(t.decimal1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TanTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TanTest.php
@@ -21,7 +21,7 @@ final class TanTest extends NumericTestCase
     {
         $dql = 'SELECT TAN(0.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class TanTest extends NumericTestCase
     {
         $dql = 'SELECT TAN(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.8498999934219, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(1.8498999934219, $result[0]['result'], 0.0000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TanTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TanTest.php
@@ -29,6 +29,6 @@ final class TanTest extends NumericTestCase
     {
         $dql = 'SELECT TAN(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.8498999934219, $result[0]['result'], 0.0000000000001);
+        $this->assertEquals(1.8498999934219273, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TandTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TandTest.php
@@ -21,7 +21,7 @@ final class TandTest extends NumericTestCase
     {
         $dql = 'SELECT TAND(45.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(1.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class TandTest extends NumericTestCase
     {
         $dql = 'SELECT TAND(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.18533904493153, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(0.18533904493153, $result[0]['result'], 0.00000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TandTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TandTest.php
@@ -29,6 +29,6 @@ final class TandTest extends NumericTestCase
     {
         $dql = 'SELECT TAND(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.18533904493153, $result[0]['result'], 0.00000000000001);
+        $this->assertEquals(0.1853390449315344, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TanhTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TanhTest.php
@@ -21,7 +21,7 @@ final class TanhTest extends NumericTestCase
     {
         $dql = 'SELECT TANH(0.0) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.000001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -29,6 +29,6 @@ final class TanhTest extends NumericTestCase
     {
         $dql = 'SELECT TANH(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.99999999848349, $result[0]['result'], 0.000001);
+        $this->assertEqualsWithDelta(0.99999999848349, $result[0]['result'], 0.00000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TanhTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/TanhTest.php
@@ -29,6 +29,6 @@ final class TanhTest extends NumericTestCase
     {
         $dql = 'SELECT TANH(n.decimal1) as result FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics n WHERE n.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.99999999848349, $result[0]['result'], 0.00000000000001);
+        $this->assertEquals(0.9999999984834879, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Trgm/ReverseStrictWordSimilarityDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Trgm/ReverseStrictWordSimilarityDistanceTest.php
@@ -33,6 +33,6 @@ final class ReverseStrictWordSimilarityDistanceTest extends TestCase
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts t
                 WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.4, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.39999998, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Trgm/ReverseWordSimilarityDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Trgm/ReverseWordSimilarityDistanceTest.php
@@ -33,6 +33,6 @@ final class ReverseWordSimilarityDistanceTest extends TestCase
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts t
                 WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.4, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.39999998, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Trgm/StrictWordSimilarityDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Trgm/StrictWordSimilarityDistanceTest.php
@@ -33,6 +33,6 @@ final class StrictWordSimilarityDistanceTest extends TestCase
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts t
                 WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.4, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.39999998, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Trgm/WordSimilarityDistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Trgm/WordSimilarityDistanceTest.php
@@ -33,6 +33,6 @@ final class WordSimilarityDistanceTest extends TestCase
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts t
                 WHERE t.id = 1';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.4, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.39999998, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/VarPopTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/VarPopTest.php
@@ -22,7 +22,7 @@ class VarPopTest extends NumericTestCase
         $dql = 'SELECT VAR_POP(t.integer1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 
     #[Test]
@@ -31,6 +31,6 @@ class VarPopTest extends NumericTestCase
         $dql = 'SELECT VAR_POP(t.decimal1) as result
                 FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(0.0, $result[0]['result'], 0.0001);
+        $this->assertEquals(0.0, $result[0]['result']);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Vector/L2DistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Vector/L2DistanceTest.php
@@ -33,6 +33,6 @@ final class L2DistanceTest extends TestCase
                 FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsVectors t
                 WHERE t.id = 2';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0001);
+        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Vector/L2DistanceTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Vector/L2DistanceTest.php
@@ -33,6 +33,6 @@ final class L2DistanceTest extends TestCase
                 FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsVectors t
                 WHERE t.id = 2';
         $result = $this->executeDqlQuery($dql);
-        $this->assertEqualsWithDelta(1.4142135623730951, $result[0]['result'], 0.0000000000000001);
+        $this->assertEquals(1.4142135623730951, $result[0]['result']);
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/BaseRangeTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/BaseRangeTestCase.php
@@ -116,7 +116,7 @@ abstract class BaseRangeTestCase extends TestCase
         $range = $this->createSimpleRange();
         $lower = $range->getLower();
 
-        $this->assertNotNull($lower, 'Simple range should have a lower bound');
+        $this->assertNotNull($lower);
     }
 
     #[Test]
@@ -125,7 +125,7 @@ abstract class BaseRangeTestCase extends TestCase
         $range = $this->createSimpleRange();
         $upper = $range->getUpper();
 
-        $this->assertNotNull($upper, 'Simple range should have an upper bound');
+        $this->assertNotNull($upper);
     }
 
     #[Test]
@@ -133,8 +133,8 @@ abstract class BaseRangeTestCase extends TestCase
     {
         $range = $this->createInfiniteRange();
 
-        $this->assertNull($range->getLower(), 'Infinite range should have null lower bound');
-        $this->assertNull($range->getUpper(), 'Infinite range should have null upper bound');
+        $this->assertNull($range->getLower());
+        $this->assertNull($range->getUpper());
     }
 
     #[Test]
@@ -142,8 +142,8 @@ abstract class BaseRangeTestCase extends TestCase
     {
         $range = $this->createSimpleRange();
 
-        $this->assertTrue($range->isLowerBracketInclusive(), 'Simple range should have inclusive lower bracket');
-        $this->assertFalse($range->isUpperBracketInclusive(), 'Simple range should have exclusive upper bracket');
+        $this->assertTrue($range->isLowerBracketInclusive());
+        $this->assertFalse($range->isUpperBracketInclusive());
     }
 
     #[Test]
@@ -151,8 +151,8 @@ abstract class BaseRangeTestCase extends TestCase
     {
         $range = $this->createInclusiveRange();
 
-        $this->assertTrue($range->isLowerBracketInclusive(), 'Inclusive range should have inclusive lower bracket');
-        $this->assertTrue($range->isUpperBracketInclusive(), 'Inclusive range should have inclusive upper bracket');
+        $this->assertTrue($range->isLowerBracketInclusive());
+        $this->assertTrue($range->isUpperBracketInclusive());
     }
 
     #[Test]
@@ -161,8 +161,8 @@ abstract class BaseRangeTestCase extends TestCase
         $emptyRange = $this->createEmptyRange();
         $normalRange = $this->createSimpleRange();
 
-        $this->assertTrue($emptyRange->isExplicitlyEmpty(), 'Empty range should be explicitly empty');
-        $this->assertFalse($normalRange->isExplicitlyEmpty(), 'Normal range should not be explicitly empty');
+        $this->assertTrue($emptyRange->isExplicitlyEmpty());
+        $this->assertFalse($normalRange->isExplicitlyEmpty());
     }
 
     /**

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/WktSpatialDataTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/WktSpatialDataTest.php
@@ -141,7 +141,7 @@ final class WktSpatialDataTest extends TestCase
         $wktSpatialData = WktSpatialData::fromWkt($wkt);
         $output = (string) $wktSpatialData;
 
-        $this->assertSame($wkt, $output, 'Dimensional modifier should be preserved in round-trip conversion');
+        $this->assertSame($wkt, $output);
     }
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened many math, trigonometry, text-similarity, and PostGIS/spatial integration checks to use exact floating-point equality (or stricter tolerances) instead of broader delta-based comparisons.
  * Updated expected numeric values to match full-precision results.
  * Simplified numerous assertions by removing custom failure-message arguments.
  * Removed one obsolete PostGIS geometry distance test case and refocused ST_Rotate coverage on geometry equality and type preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->