### PR TITLE
chore: export-ignore `.envrc`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /.augment           export-ignore
 /.claude            export-ignore
 /.cursor            export-ignore
+/.envrc             export-ignore
 /.windsurf          export-ignore
 /.github            export-ignore
 /ci                 export-ignore


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Prevented the `.envrc` configuration file from being included in exported source archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->