### PR TITLE
chore: drop deprecated Rector ruleset `EARLY_RETURN`

### DIFF
--- a/ci/rector/config.php
+++ b/ci/rector/config.php
@@ -32,7 +32,6 @@ return RectorConfig::configure()
     ->withSets([
         SetList::CODE_QUALITY,
         SetList::DEAD_CODE,
-        SetList::EARLY_RETURN,
         SetList::NAMING,
         SetList::TYPE_DECLARATION,
         SetList::PRIVATIZATION,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality configuration to stop applying early-return refactoring rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->