### PR TITLE
feat: add support for the optional shift interval argument of `UUIDV7`

### DIFF
--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Uuidv7.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Uuidv7.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\TokenType;
+use MartinGeorgiev\Utils\DoctrineLexer;
+use MartinGeorgiev\Utils\DoctrineOrm;
+
 /**
  * Implementation of PostgreSQL UUIDV7().
  *
- * Generates a time-based UUID v7.
+ * Generates a time-based UUID v7. The optional shift argument (PostgreSQL interval)
+ * shifts the computed timestamp by the given interval.
  *
  * @see https://www.postgresql.org/docs/18/functions-uuid.html
  * @since 3.6
@@ -15,11 +22,31 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  *
  * @example Using it in DQL: "SELECT UUIDV7() FROM Entity e"
+ * @example Using it in DQL with shift: "SELECT UUIDV7('1 hour') FROM Entity e"
  */
 class Uuidv7 extends BaseFunction
 {
     protected function customizeFunction(): void
     {
-        $this->setFunctionPrototype('uuidv7()');
+        $this->setFunctionPrototype('uuidv7(%s)');
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $shouldUseLexer = DoctrineOrm::isPre219();
+
+        $this->customizeFunction();
+
+        $parser->match($shouldUseLexer ? Lexer::T_IDENTIFIER : TokenType::T_IDENTIFIER);
+        $parser->match($shouldUseLexer ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
+
+        $closeParenthesisType = $shouldUseLexer ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS;
+        if (DoctrineLexer::getLookaheadType($parser->getLexer()) === $closeParenthesisType) {
+            $this->setFunctionPrototype('uuidv7()');
+        } else {
+            $this->nodes[] = $parser->StringPrimary();
+        }
+
+        $parser->match($closeParenthesisType);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Uuidv7Test.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Uuidv7Test.php
@@ -37,6 +37,20 @@ final class Uuidv7Test extends NumericTestCase
     }
 
     #[Test]
+    public function generates_uuid_v7_with_shift_interval(): void
+    {
+        $dql = "SELECT UUIDV7('1 hour') as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t
+                WHERE t.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $uuid = $result[0]['result'];
+
+        $this->assertIsString($uuid);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i', $uuid);
+    }
+
+    #[Test]
     public function generates_unique_uuids(): void
     {
         $dql = 'SELECT UUIDV7() as uuid1, UUIDV7() as uuid2 

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Uuidv7Test.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Uuidv7Test.php
@@ -20,6 +20,7 @@ final class Uuidv7Test extends TestCase
     {
         return [
             'generates uuid v7' => 'SELECT uuidv7() AS sclr_0 FROM ContainsTexts c0_',
+            'generates uuid v7 with shift interval' => "SELECT uuidv7('1 hour') AS sclr_0 FROM ContainsTexts c0_",
         ];
     }
 
@@ -27,6 +28,7 @@ final class Uuidv7Test extends TestCase
     {
         return [
             'generates uuid v7' => \sprintf('SELECT UUIDV7() FROM %s e', ContainsTexts::class),
+            'generates uuid v7 with shift interval' => \sprintf("SELECT UUIDV7('1 hour') FROM %s e", ContainsTexts::class),
         ];
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional time interval when generating UUIDv7 values, such as `UUIDV7('1 hour')`.

* **Tests**
  * Added coverage confirming shifted UUIDv7 generation works and produces valid UUIDv7-formatted results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->