### PR TITLE
feat: add support for `numeric[]`, `varchar[]`, `time[]` and `json[]` data types

### DIFF
--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -16,18 +16,22 @@
 | bigint[] | _int8 | `MartinGeorgiev\Doctrine\DBAL\Types\BigIntArray` |
 | real[] | _float4 | `MartinGeorgiev\Doctrine\DBAL\Types\RealArray` |
 | double precision[] | _float8 | `MartinGeorgiev\Doctrine\DBAL\Types\DoublePrecisionArray` |
+| numeric[] | _numeric | `MartinGeorgiev\Doctrine\DBAL\Types\NumericArray` (see [note](#numeric-array-type)) |
 |---|---|---|
 | date[] | _date | `MartinGeorgiev\Doctrine\DBAL\Types\DateArray` |
 | interval | interval | `MartinGeorgiev\Doctrine\DBAL\Types\Interval` |
 | interval[] | _interval | `MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray` |
+| time[] | _time | `MartinGeorgiev\Doctrine\DBAL\Types\TimeArray` |
 | timestamp[] | _timestamp | `MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray` |
 | timestamptz[] | _timestamptz | `MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray` |
 | timetz | timetz | `MartinGeorgiev\Doctrine\DBAL\Types\Timetz` |
 | timetz[] | _timetz | `MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray` |
 |---|---|---|
+| json[] | _json | `MartinGeorgiev\Doctrine\DBAL\Types\JsonArray` |
 | jsonb | jsonb | `MartinGeorgiev\Doctrine\DBAL\Types\Jsonb` |
 | jsonb[] | _jsonb | `MartinGeorgiev\Doctrine\DBAL\Types\JsonbArray` |
 | text[] | _text | `MartinGeorgiev\Doctrine\DBAL\Types\TextArray` |
+| varchar[] | _varchar | `MartinGeorgiev\Doctrine\DBAL\Types\VarcharArray` |
 | uuid[] | _uuid | `MartinGeorgiev\Doctrine\DBAL\Types\UuidArray` (see [note](#uuid-array-type)) |
 | citext | citext | `MartinGeorgiev\Doctrine\DBAL\Types\Citext` (see [note](#citext-type)) |
 | citext[] | _citext | `MartinGeorgiev\Doctrine\DBAL\Types\CitextArray` |
@@ -168,6 +172,15 @@ class Permissions
 ```
 
 **Important:** `BIT` without a length defaults to `BIT(1)` in PostgreSQL, which stores exactly one bit. Use `BIT VARYING` for variable-length bit strings, or specify an explicit length with `BIT(n)`.
+
+---
+
+## Numeric Array Type
+
+The `numeric[]` type maps array items to PHP strings (e.g. `'502.00'`) rather than floats. PostgreSQL's [`numeric`](https://www.postgresql.org/docs/18/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL) is an arbitrary-precision type, and converting its values to PHP floats would silently lose precision and trailing zeros — the same reason Doctrine's own `decimal` type uses strings.
+
+- Array items written to the database must be numeric strings (or `null`); PHP integers and floats are rejected
+- `decimal[]` is a PostgreSQL alias of `numeric[]` — columns declared as `DECIMAL[]` are reported by PostgreSQL as `numeric[]`, so this type covers both
 
 ---
 

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -27,9 +27,11 @@ Type::addType('smallint[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\SmallIntArra
 Type::addType('integer[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\IntegerArray");
 Type::addType('bigint[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\BigIntArray");
 Type::addType('double precision[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\DoublePrecisionArray");
+Type::addType('numeric[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\NumericArray");
 Type::addType('real[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\RealArray");
 Type::addType('text[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TextArray");
 Type::addType('uuid[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\UuidArray");
+Type::addType('varchar[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\VarcharArray");
 
 // Case-insensitive text types
 Type::addType('citext', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Citext");
@@ -39,12 +41,14 @@ Type::addType('citext[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\CitextArray");
 Type::addType('date[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\DateArray");
 Type::addType('interval', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Interval");
 Type::addType('interval[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\IntervalArray");
+Type::addType('time[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimeArray");
 Type::addType('timestamp[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimestampArray");
 Type::addType('timestamptz[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimestampTzArray");
 Type::addType('timetz', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Timetz");
 Type::addType('timetz[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimetzArray");
 
 // JSON types
+Type::addType('json[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\JsonArray");
 Type::addType('jsonb', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Jsonb");
 Type::addType('jsonb[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\JsonbArray");
 
@@ -482,12 +486,16 @@ $platform->registerDoctrineTypeMapping('bigint[]', 'bigint[]');
 $platform->registerDoctrineTypeMapping('_int8', 'bigint[]');
 $platform->registerDoctrineTypeMapping('double precision[]', 'double precision[]');
 $platform->registerDoctrineTypeMapping('_float8', 'double precision[]');
+$platform->registerDoctrineTypeMapping('numeric[]', 'numeric[]');
+$platform->registerDoctrineTypeMapping('_numeric', 'numeric[]');
 $platform->registerDoctrineTypeMapping('real[]', 'real[]');
 $platform->registerDoctrineTypeMapping('_float4', 'real[]');
 $platform->registerDoctrineTypeMapping('text[]', 'text[]');
 $platform->registerDoctrineTypeMapping('_text', 'text[]');
 $platform->registerDoctrineTypeMapping('uuid[]', 'uuid[]');
 $platform->registerDoctrineTypeMapping('_uuid', 'uuid[]');
+$platform->registerDoctrineTypeMapping('varchar[]', 'varchar[]');
+$platform->registerDoctrineTypeMapping('_varchar', 'varchar[]');
 
 // Case-insensitive text type mappings
 $platform->registerDoctrineTypeMapping('citext', 'citext');
@@ -500,6 +508,8 @@ $platform->registerDoctrineTypeMapping('_date', 'date[]');
 $platform->registerDoctrineTypeMapping('interval', 'interval');
 $platform->registerDoctrineTypeMapping('interval[]', 'interval[]');
 $platform->registerDoctrineTypeMapping('_interval', 'interval[]');
+$platform->registerDoctrineTypeMapping('time[]', 'time[]');
+$platform->registerDoctrineTypeMapping('_time', 'time[]');
 $platform->registerDoctrineTypeMapping('timestamp[]', 'timestamp[]');
 $platform->registerDoctrineTypeMapping('_timestamp', 'timestamp[]');
 $platform->registerDoctrineTypeMapping('timestamptz[]', 'timestamptz[]');
@@ -509,6 +519,8 @@ $platform->registerDoctrineTypeMapping('timetz[]', 'timetz[]');
 $platform->registerDoctrineTypeMapping('_timetz', 'timetz[]');
 
 // JSON type mappings
+$platform->registerDoctrineTypeMapping('json[]', 'json[]');
+$platform->registerDoctrineTypeMapping('_json', 'json[]');
 $platform->registerDoctrineTypeMapping('jsonb', 'jsonb');
 $platform->registerDoctrineTypeMapping('jsonb[]', 'jsonb[]');
 $platform->registerDoctrineTypeMapping('_jsonb', 'jsonb[]');

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -57,12 +57,16 @@ return [
                 '_int8' => 'bigint[]',
                 'double precision[]' => 'double precision[]',
                 '_float8' => 'double precision[]',
+                'numeric[]' => 'numeric[]',
+                '_numeric' => 'numeric[]',
                 'real[]' => 'real[]',
                 '_float4' => 'real[]',
                 '_text' => 'text[]',
                 'text[]' => 'text[]',
                 'uuid[]' => 'uuid[]',
                 '_uuid' => 'uuid[]',
+                'varchar[]' => 'varchar[]',
+                '_varchar' => 'varchar[]',
 
                 // Case-insensitive text type mappings
                 'citext' => 'citext',
@@ -75,6 +79,8 @@ return [
                 'interval' => 'interval',
                 'interval[]' => 'interval[]',
                 '_interval' => 'interval[]',
+                'time[]' => 'time[]',
+                '_time' => 'time[]',
                 'timestamp[]' => 'timestamp[]',
                 '_timestamp' => 'timestamp[]',
                 'timestamptz[]' => 'timestamptz[]',
@@ -84,6 +90,8 @@ return [
                 '_timetz' => 'timetz[]',
 
                 // JSON type mappings
+                'json[]' => 'json[]',
+                '_json' => 'json[]',
                 'jsonb' => 'jsonb',
                 '_jsonb' => 'jsonb[]',
                 'jsonb[]' => 'jsonb[]',
@@ -226,9 +234,11 @@ return [
         'integer[]' => MartinGeorgiev\Doctrine\DBAL\Types\IntegerArray::class,
         'smallint[]' => MartinGeorgiev\Doctrine\DBAL\Types\SmallIntArray::class,
         'double precision[]' => MartinGeorgiev\Doctrine\DBAL\Types\DoublePrecisionArray::class,
+        'numeric[]' => MartinGeorgiev\Doctrine\DBAL\Types\NumericArray::class,
         'real[]' => MartinGeorgiev\Doctrine\DBAL\Types\RealArray::class,
         'text[]' => MartinGeorgiev\Doctrine\DBAL\Types\TextArray::class,
         'uuid[]' => MartinGeorgiev\Doctrine\DBAL\Types\UuidArray::class,
+        'varchar[]' => MartinGeorgiev\Doctrine\DBAL\Types\VarcharArray::class,
 
         // Case-insensitive text types
         'citext' => MartinGeorgiev\Doctrine\DBAL\Types\Citext::class,
@@ -238,12 +248,14 @@ return [
         'date[]' => MartinGeorgiev\Doctrine\DBAL\Types\DateArray::class,
         'interval' => MartinGeorgiev\Doctrine\DBAL\Types\Interval::class,
         'interval[]' => MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray::class,
+        'time[]' => MartinGeorgiev\Doctrine\DBAL\Types\TimeArray::class,
         'timestamp[]' => MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray::class,
         'timestamptz[]' => MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray::class,
         'timetz' => MartinGeorgiev\Doctrine\DBAL\Types\Timetz::class,
         'timetz[]' => MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray::class,
 
         // JSON types
+        'json[]' => MartinGeorgiev\Doctrine\DBAL\Types\JsonArray::class,
         'jsonb' => MartinGeorgiev\Doctrine\DBAL\Types\Jsonb::class,
         'jsonb[]' => MartinGeorgiev\Doctrine\DBAL\Types\JsonbArray::class,
 

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -27,20 +27,24 @@ doctrine:
             'integer[]': MartinGeorgiev\Doctrine\DBAL\Types\IntegerArray
             'bigint[]': MartinGeorgiev\Doctrine\DBAL\Types\BigIntArray
             'double precision[]': MartinGeorgiev\Doctrine\DBAL\Types\DoublePrecisionArray
+            'numeric[]': MartinGeorgiev\Doctrine\DBAL\Types\NumericArray
             'real[]': MartinGeorgiev\Doctrine\DBAL\Types\RealArray
             'text[]': MartinGeorgiev\Doctrine\DBAL\Types\TextArray
             'uuid[]': MartinGeorgiev\Doctrine\DBAL\Types\UuidArray
+            'varchar[]': MartinGeorgiev\Doctrine\DBAL\Types\VarcharArray
 
             # Date and time types
             'date[]': MartinGeorgiev\Doctrine\DBAL\Types\DateArray
             interval: MartinGeorgiev\Doctrine\DBAL\Types\Interval
             'interval[]': MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray
+            'time[]': MartinGeorgiev\Doctrine\DBAL\Types\TimeArray
             'timestamp[]': MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray
             'timestamptz[]': MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray
             timetz: MartinGeorgiev\Doctrine\DBAL\Types\Timetz
             'timetz[]': MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray
 
             # JSON types
+            'json[]': MartinGeorgiev\Doctrine\DBAL\Types\JsonArray
             jsonb: MartinGeorgiev\Doctrine\DBAL\Types\Jsonb
             'jsonb[]': MartinGeorgiev\Doctrine\DBAL\Types\JsonbArray
 
@@ -175,12 +179,16 @@ doctrine:
                     _int8: !php/const MartinGeorgiev\Doctrine\DBAL\Type::BIGINT_ARRAY
                     'double precision[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::DOUBLE_PRECISION_ARRAY
                     _float8: !php/const MartinGeorgiev\Doctrine\DBAL\Type::DOUBLE_PRECISION_ARRAY
+                    'numeric[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::NUMERIC_ARRAY
+                    _numeric: !php/const MartinGeorgiev\Doctrine\DBAL\Type::NUMERIC_ARRAY
                     'real[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::REAL_ARRAY
                     _float4: !php/const MartinGeorgiev\Doctrine\DBAL\Type::REAL_ARRAY
                     'text[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TEXT_ARRAY
                     _text: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TEXT_ARRAY
                     'uuid[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::UUID_ARRAY
                     _uuid: !php/const MartinGeorgiev\Doctrine\DBAL\Type::UUID_ARRAY
+                    'varchar[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::VARCHAR_ARRAY
+                    _varchar: !php/const MartinGeorgiev\Doctrine\DBAL\Type::VARCHAR_ARRAY
 
                     # Case-insensitive text type mappings
                     citext: !php/const MartinGeorgiev\Doctrine\DBAL\Type::CITEXT
@@ -193,6 +201,8 @@ doctrine:
                     interval: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INTERVAL
                     'interval[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::INTERVAL_ARRAY
                     _interval: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INTERVAL_ARRAY
+                    'time[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIME_ARRAY
+                    _time: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIME_ARRAY
                     'timestamp[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMP_ARRAY
                     _timestamp: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMP_ARRAY
                     'timestamptz[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMPTZ_ARRAY
@@ -202,6 +212,8 @@ doctrine:
                     _timetz: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMETZ_ARRAY
 
                     # JSON type mappings
+                    'json[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::JSON_ARRAY
+                    _json: !php/const MartinGeorgiev\Doctrine\DBAL\Type::JSON_ARRAY
                     jsonb: !php/const MartinGeorgiev\Doctrine\DBAL\Type::JSONB
                     'jsonb[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::JSONB_ARRAY
                     _jsonb: !php/const MartinGeorgiev\Doctrine\DBAL\Type::JSONB_ARRAY

--- a/src/MartinGeorgiev/Doctrine/DBAL/Type.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Type.php
@@ -219,6 +219,11 @@ final class Type
     /**
      * @var string
      */
+    public const JSON_ARRAY = 'json[]';
+
+    /**
+     * @var string
+     */
     public const JSONB = 'jsonb';
 
     /**
@@ -289,6 +294,11 @@ final class Type
     /**
      * @var string
      */
+    public const NUMERIC_ARRAY = 'numeric[]';
+
+    /**
+     * @var string
+     */
     public const NUMMULTIRANGE = 'nummultirange';
 
     /**
@@ -355,6 +365,11 @@ final class Type
      * @var string
      */
     public const TEXT_ARRAY = 'text[]';
+
+    /**
+     * @var string
+     */
+    public const TIME_ARRAY = 'time[]';
 
     /**
      * @var string
@@ -440,6 +455,11 @@ final class Type
      * @var string
      */
     public const UUID_ARRAY = 'uuid[]';
+
+    /**
+     * @var string
+     */
+    public const VARCHAR_ARRAY = 'varchar[]';
 
     /**
      * @var string

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidNumericArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidNumericArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidNumericArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid numeric format in array: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidNumericArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidNumericArrayItemForPHPException.php
@@ -7,11 +7,11 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
 use Doctrine\DBAL\Types\ConversionException;
 
 /**
- * @since 3.0
+ * @since 4.8
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  */
-class InvalidJsonArrayItemForPHPException extends ConversionException
+class InvalidNumericArrayItemForPHPException extends ConversionException
 {
     private static function create(string $message, mixed $value): self
     {
@@ -20,12 +20,7 @@ class InvalidJsonArrayItemForPHPException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Array values must be valid JSON objects, %s given', $value);
-    }
-
-    public static function forInvalidFormat(mixed $value): self
-    {
-        return self::create('Invalid JSON format in array: %s', $value);
+        return self::create('Array values must be strings, %s given', $value);
     }
 
     public static function forInvalidArrayType(mixed $value): self

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimeArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimeArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTimeArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid time format in array: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimeArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimeArrayItemForPHPException.php
@@ -7,11 +7,11 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
 use Doctrine\DBAL\Types\ConversionException;
 
 /**
- * @since 3.0
+ * @since 4.8
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>
  */
-class InvalidJsonArrayItemForPHPException extends ConversionException
+class InvalidTimeArrayItemForPHPException extends ConversionException
 {
     private static function create(string $message, mixed $value): self
     {
@@ -20,12 +20,7 @@ class InvalidJsonArrayItemForPHPException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Array values must be valid JSON objects, %s given', $value);
-    }
-
-    public static function forInvalidFormat(mixed $value): self
-    {
-        return self::create('Invalid JSON format in array: %s', $value);
+        return self::create('Array values must be strings, %s given', $value);
     }
 
     public static function forInvalidArrayType(mixed $value): self

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonArray.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidJsonArrayItemForPHPException;
+
+/**
+ * Implementation of PostgreSQL JSON[] data type.
+ *
+ * Unlike JSONB[], PostgreSQL stores JSON values as exact textual copies,
+ * preserving key order and whitespace. The PHP-side conversion is identical
+ * to JSONB[].
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-json.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class JsonArray extends JsonbArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::JSON_ARRAY;
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidJsonArrayItemForPHPException::forInvalidArrayType($value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonArray.php
@@ -10,9 +10,8 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidJsonArrayItemForPHPExce
 /**
  * Implementation of PostgreSQL JSON[] data type.
  *
- * Unlike JSONB[], PostgreSQL stores JSON values as exact textual copies,
- * preserving key order and whitespace. The PHP-side conversion is identical
- * to JSONB[].
+ * Unlike JSONB[], PostgreSQL stores JSON values as exact textual copies, preserving key order and whitespace.
+ * The PHP-side conversion is identical to JSONB[].
  *
  * @see https://www.postgresql.org/docs/18/datatype-json.html
  * @since 4.8

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
@@ -12,11 +12,10 @@ use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
 /**
  * Implementation of PostgreSQL NUMERIC[] data type.
  *
- * Array items are handled as numeric strings so the exact precision and scale
- * of the values survive the round-trip (e.g. trailing zeros like "502.00").
- * PHP integers and floats are rejected as array items - floats cannot represent
- * arbitrary-precision decimals without data loss. PostgreSQL treats DECIMAL[]
- * as an alias of NUMERIC[], so this type covers both.
+ * Array items are handled as numeric strings so the exact precision and scale of the values survive the round-trip
+ * (e.g. trailing zeros like "502.00"). PHP integers and floats are rejected as array items - floats cannot represent
+ * arbitrary-precision decimals without data loss.
+ * PostgreSQL treats DECIMAL[] as an alias of NUMERIC[], so this type covers both.
  *
  * @see https://www.postgresql.org/docs/18/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL
  * @since 4.8

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidNumericArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidNumericArrayItemForPHPException;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
+
+/**
+ * Implementation of PostgreSQL NUMERIC[] data type.
+ *
+ * Array items are handled as numeric strings so the exact precision and scale
+ * of the values survive the round-trip (e.g. trailing zeros like "502.00").
+ * PHP integers and floats are rejected as array items - floats cannot represent
+ * arbitrary-precision decimals without data loss. PostgreSQL treats DECIMAL[]
+ * as an alias of NUMERIC[], so this type covers both.
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class NumericArray extends BaseStringArray
+{
+    /**
+     * Scientific notation, a leading plus sign and a bare decimal point (".5") are
+     * accepted by PostgreSQL on input but never appear in its output, so allowing
+     * them would break string round-trips.
+     *
+     * @var string
+     */
+    private const NUMERIC_REGEX = '/^-?\d+(\.\d+)?$/';
+
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::NUMERIC_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        if ($item === null) {
+            return true;
+        }
+
+        if (!\is_string($item)) {
+            return false;
+        }
+
+        return \preg_match(self::NUMERIC_REGEX, $item) === 1;
+    }
+
+    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
+    {
+        // PostgreSQL returns numeric array items unquoted; type inference would
+        // convert them to floats and lose exact precision (see GitHub issue #482).
+        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray(
+            $postgresArray,
+            preserveStringTypes: true
+        );
+    }
+
+    public function transformArrayItemForPHP(mixed $item): ?string
+    {
+        // String-preserving parsing skips NULL token inference; mapping it here is
+        // unambiguous because "NULL" can never appear as a value of a numeric column.
+        if ($item === 'NULL') {
+            return null;
+        }
+
+        return parent::transformArrayItemForPHP($item);
+    }
+
+    protected function createInvalidTypeExceptionForPHP(mixed $item): InvalidNumericArrayItemForPHPException
+    {
+        return InvalidNumericArrayItemForPHPException::forInvalidType($item);
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidNumericArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidNumericArrayItemForDatabaseException::forInvalidFormat($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
@@ -25,9 +25,8 @@ use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
 class NumericArray extends BaseStringArray
 {
     /**
-     * Scientific notation, a leading plus sign and a bare decimal point (".5") are
-     * accepted by PostgreSQL on input but never appear in its output, so allowing
-     * them would break string round-trips.
+     * Scientific notation, a leading plus sign and a bare decimal point (".5") are accepted by PostgreSQL on input
+     * but never appear in its output, so allowing them would break string round-trips.
      *
      * @var string
      */
@@ -53,8 +52,6 @@ class NumericArray extends BaseStringArray
 
     protected function transformPostgresArrayToPHPArray(string $postgresArray): array
     {
-        // PostgreSQL returns numeric array items unquoted; type inference would
-        // convert them to floats and lose exact precision (see GitHub issue #482).
         return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray(
             $postgresArray,
             preserveStringTypes: true
@@ -63,8 +60,6 @@ class NumericArray extends BaseStringArray
 
     public function transformArrayItemForPHP(mixed $item): ?string
     {
-        // String-preserving parsing skips NULL token inference; mapping it here is
-        // unambiguous because "NULL" can never appear as a value of a numeric column.
         if ($item === 'NULL') {
             return null;
         }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/TimeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/TimeArray.php
@@ -11,8 +11,8 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimeArrayItemForPHPExce
 /**
  * Implementation of PostgreSQL TIME[] data type.
  *
- * Covers the TIME WITHOUT TIME ZONE[] alias as well. Array items are handled
- * as strings (e.g. "10:30:00"), mirroring the TIMETZ[] type.
+ * Covers the TIME WITHOUT TIME ZONE[] alias as well.
+ * Array items are handled as strings (e.g. "10:30:00"), mirroring the TIMETZ[] type.
  *
  * @see https://www.postgresql.org/docs/18/datatype-datetime.html
  * @since 4.8

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/TimeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/TimeArray.php
@@ -11,8 +11,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimeArrayItemForPHPExce
 /**
  * Implementation of PostgreSQL TIME[] data type.
  *
- * Covers the TIME WITHOUT TIME ZONE[] alias as well.
- * Array items are handled as strings (e.g. "10:30:00"), mirroring the TIMETZ[] type.
+ * Array items are handled as strings (e.g. "10:30:00").
  *
  * @see https://www.postgresql.org/docs/18/datatype-datetime.html
  * @since 4.8

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/TimeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/TimeArray.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimeArrayItemForPHPException;
+
+/**
+ * Implementation of PostgreSQL TIME[] data type.
+ *
+ * Covers the TIME WITHOUT TIME ZONE[] alias as well. Array items are handled
+ * as strings (e.g. "10:30:00"), mirroring the TIMETZ[] type.
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-datetime.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class TimeArray extends BaseStringArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::TIME_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        if ($item === null) {
+            return true;
+        }
+
+        if (!\is_string($item)) {
+            return false;
+        }
+
+        return $item !== '';
+    }
+
+    protected function createInvalidTypeExceptionForPHP(mixed $item): InvalidTimeArrayItemForPHPException
+    {
+        return InvalidTimeArrayItemForPHPException::forInvalidType($item);
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidTimeArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidTimeArrayItemForDatabaseException::forInvalidFormat($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Timetz.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Timetz.php
@@ -10,10 +10,9 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimetzForDatabaseExcept
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimetzForPHPException;
 
 /**
- * Implementation of PostgreSQL timetz (time with time zone) data type.
+ * Implementation of PostgreSQL TIMETZ (time with time zone) data type.
  *
- * Stores a time-of-day value with time zone offset. The PHP representation
- * is a string in the format returned by PostgreSQL (e.g. "12:34:56+02:00").
+ * Stores a time-of-day value with time zone offset. The PHP representation is a string in the PostgreSQL format (e.g. "12:34:56+02:00").
  *
  * @see https://www.postgresql.org/docs/18/datatype-datetime.html
  * @since 4.6

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/VarcharArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/VarcharArray.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+
+/**
+ * Implementation of PostgreSQL VARCHAR[] data type.
+ *
+ * Covers the CHARACTER VARYING[] alias as well. Behaves exactly like TEXT[]:
+ * all array items are preserved as PHP strings, including values PostgreSQL
+ * returns unquoted because they look numeric (see GitHub issues #424 and #482).
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-character.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class VarcharArray extends TextArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::VARCHAR_ARRAY;
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/VarcharArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/VarcharArray.php
@@ -9,9 +9,8 @@ use MartinGeorgiev\Doctrine\DBAL\Type;
 /**
  * Implementation of PostgreSQL VARCHAR[] data type.
  *
- * Covers the CHARACTER VARYING[] alias as well. Behaves exactly like TEXT[]:
- * all array items are preserved as PHP strings, including values PostgreSQL
- * returns unquoted because they look numeric (see GitHub issues #424 and #482).
+ * Covers the CHARACTER VARYING[] alias as well. Behaves exactly like TEXT[]: all array items are preserved as
+ * PHP strings, including values PostgreSQL returns unquoted because they look numeric (see GitHub issues #424 & #482).
  *
  * @see https://www.postgresql.org/docs/18/datatype-character.html
  * @since 4.8

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/VarcharArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/VarcharArray.php
@@ -9,8 +9,8 @@ use MartinGeorgiev\Doctrine\DBAL\Type;
 /**
  * Implementation of PostgreSQL VARCHAR[] data type.
  *
- * Covers the CHARACTER VARYING[] alias as well. Behaves exactly like TEXT[]: all array items are preserved as
- * PHP strings, including values PostgreSQL returns unquoted because they look numeric (see GitHub issues #424 & #482).
+ * Covers the CHARACTER VARYING[] alias as well. Behaves exactly like TEXT[]:
+ * all array items are preserved as PHP strings, including values PostgreSQL returns unquoted because they look numeric.
  *
  * @see https://www.postgresql.org/docs/18/datatype-character.html
  * @since 4.8

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTypeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+final class JsonArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'json[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, array<string, mixed>>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'simple json array' => [[
+                ['key1' => 'value1', 'key2' => false],
+                ['key1' => 'value2', 'key2' => true],
+            ]],
+            'json array with nested structures' => [[
+                [
+                    'user' => ['id' => 1, 'name' => 'John'],
+                    'meta' => ['active' => true, 'roles' => ['user']],
+                ],
+                [
+                    'user' => ['id' => 2, 'name' => 'Jane'],
+                    'meta' => ['active' => false, 'roles' => ['user']],
+                ],
+            ]],
+            'json array with mixed types' => [[
+                [
+                    'string' => 'value',
+                    'number' => 42,
+                    'float' => 3.14,
+                    'boolean' => false,
+                    'null' => null,
+                    'array' => [1, 2, 3],
+                ],
+                [
+                    'different' => 'structure',
+                    'count' => 999,
+                    'enabled' => true,
+                ],
+            ]],
+            'json array with big integers' => [[
+                [
+                    'bigint' => '9223372036854775807',
+                    'regular' => 123,
+                ],
+                [
+                    'huge_number' => '18446744073709551615',
+                    'small' => 1,
+                ],
+            ]],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTypeTest.php
@@ -46,7 +46,7 @@ final class JsonArrayTypeTest extends ArrayTypeTestCase
                     'enabled' => true,
                 ],
             ]],
-            'json array with big integers' => [[
+            'json array with large numeric strings' => [[
                 [
                     'bigint' => '9223372036854775807',
                     'regular' => 123,

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/NumericArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/NumericArrayTypeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+final class NumericArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'numeric[]';
+    }
+
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'integer-like numerics' => [['1', '42', '-7']],
+            'decimals with trailing zeros' => [['502.00', '505.00', '0.00']],
+            'high precision decimals' => [['1.0000000000000000000000000001', '-0.000000001']],
+            'array with null item' => [[null, '1.50']],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimeArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimeArrayTypeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+final class TimeArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'time[]';
+    }
+
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'simple time array' => [['10:30:00', '14:45:30']],
+            'midnight and end of day' => [['00:00:00', '23:59:59']],
+            'time with microseconds' => [['12:34:56.123456', '00:00:01.000001']],
+            'array with null item' => [[null, '10:30:00']],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/VarcharArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/VarcharArrayTypeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+final class VarcharArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'varchar[]';
+    }
+
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'simple varchar array' => [['foo', 'bar', 'baz']],
+            'varchar array with special chars' => [['foo"bar', 'baz\qux', 'with,comma']],
+            'varchar array with empty strings' => [['', 'not empty', '']],
+            'varchar array with unicode' => [['café', 'naïve', 'résumé']],
+            'varchar array with numbers as strings' => [['123', '456', '789']],
+            'varchar array with decimal strings with trailing zeros' => [['502.00', '505.00', '1.0']],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/TestCase.php
@@ -55,6 +55,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Int8RangeArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\IntegerArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Interval;
 use MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\JsonArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Jsonb;
 use MartinGeorgiev\Doctrine\DBAL\Types\JsonbArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Line;
@@ -69,6 +70,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Macaddr8Array;
 use MartinGeorgiev\Doctrine\DBAL\Types\MacaddrArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Money;
 use MartinGeorgiev\Doctrine\DBAL\Types\MoneyArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\NumericArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\NumMultirange;
 use MartinGeorgiev\Doctrine\DBAL\Types\NumMultirangeArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\NumRange;
@@ -83,6 +85,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\RealArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\SmallIntArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Sparsevec;
 use MartinGeorgiev\Doctrine\DBAL\Types\TextArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\TimeArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Timetz;
@@ -100,6 +103,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\TstzRangeArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Tsvector;
 use MartinGeorgiev\Doctrine\DBAL\Types\TsvectorArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\UuidArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\VarcharArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Vector;
 use MartinGeorgiev\Doctrine\DBAL\Types\Xml;
 use MartinGeorgiev\Doctrine\DBAL\Types\XmlArray;
@@ -302,6 +306,7 @@ abstract class TestCase extends BaseTestCase
             'integer[]' => IntegerArray::class,
             'interval' => Interval::class,
             'interval[]' => IntervalArray::class,
+            'json[]' => JsonArray::class,
             'jsonb' => Jsonb::class,
             'jsonb[]' => JsonbArray::class,
             'line' => Line::class,
@@ -320,6 +325,7 @@ abstract class TestCase extends BaseTestCase
             'macaddr[]' => MacaddrArray::class,
             'money' => Money::class,
             'money[]' => MoneyArray::class,
+            'numeric[]' => NumericArray::class,
             'numrange' => NumRange::class,
             'numrange[]' => NumRangeArray::class,
             'nummultirange' => NumMultirange::class,
@@ -333,6 +339,7 @@ abstract class TestCase extends BaseTestCase
             'real[]' => RealArray::class,
             'smallint[]' => SmallIntArray::class,
             'text[]' => TextArray::class,
+            'time[]' => TimeArray::class,
             'timestamp[]' => TimestampArray::class,
             'timestamptz[]' => TimestampTzArray::class,
             'timetz' => Timetz::class,
@@ -350,6 +357,7 @@ abstract class TestCase extends BaseTestCase
             'tsvector' => Tsvector::class,
             'tsvector[]' => TsvectorArray::class,
             'uuid[]' => UuidArray::class,
+            'varchar[]' => VarcharArray::class,
             'sparsevec' => Sparsevec::class,
             'vector' => Vector::class,
             'xml' => Xml::class,

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidJsonArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\JsonArray;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class JsonArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&Stub
+     */
+    private Stub $platform;
+
+    private JsonArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createStub(AbstractPlatform::class);
+        $this->fixture = new JsonArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('json[]', $this->fixture->getName());
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'multiple json objects' => [
+                'phpValue' => [
+                    [
+                        'key1' => 'value1',
+                        'key2' => false,
+                        'key3' => '15',
+                        'key4' => 15,
+                        'key5' => [112, 242, 309, 310],
+                    ],
+                    [
+                        'key1' => 'value2',
+                        'key2' => true,
+                        'key3' => '115',
+                        'key4' => 115,
+                        'key5' => [304, 404, 504, 604],
+                    ],
+                ],
+                'postgresValue' => '{"{\"key1\":\"value1\",\"key2\":false,\"key3\":\"15\",\"key4\":15,\"key5\":[112,242,309,310]}","{\"key1\":\"value2\",\"key2\":true,\"key3\":\"115\",\"key4\":115,\"key5\":[304,404,504,604]}"}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidJsonArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+        ];
+    }
+
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'associative array' => [['key' => 'value']],
+            'indexed array' => [[1, 2, 3]],
+            'nested array' => [['nested' => ['a', 'b']]],
+            'null' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(string $postgresValue): void
+    {
+        $this->expectException(InvalidJsonArrayItemForPHPException::class);
+        $this->expectExceptionMessage('Invalid JSON format in array');
+
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'non-array json' => ['"a string encoded as json"'],
+            'invalid json format' => ['{invalid json}'],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/NumericArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/NumericArrayTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidNumericArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidNumericArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\NumericArray;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class NumericArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&Stub
+     */
+    private Stub $platform;
+
+    private NumericArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createStub(AbstractPlatform::class);
+        $this->fixture = new NumericArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('numeric[]', $this->fixture->getName());
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single numeric' => [
+                'phpValue' => ['1.50'],
+                'postgresValue' => '{"1.50"}',
+            ],
+            'multiple numerics' => [
+                'phpValue' => ['1.50', '-2.75', '42'],
+                'postgresValue' => '{"1.50","-2.75","42"}',
+            ],
+            'high precision decimal' => [
+                'phpValue' => ['1.0000000000000000000000000001'],
+                'postgresValue' => '{"1.0000000000000000000000000001"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [null, '1.50'],
+                'postgresValue' => '{NULL,"1.50"}',
+            ],
+        ];
+    }
+
+    #[Test]
+    public function preserves_exact_precision_for_unquoted_database_values(): void
+    {
+        $postgresValue = '{502.00,505.00,0.00,-0.10,1.0000000000000000000000000001}';
+        $expectedResult = ['502.00', '505.00', '0.00', '-0.10', '1.0000000000000000000000000001'];
+
+        $result = $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidNumericArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'empty string item' => [['']],
+            'non-numeric string item' => [['abc']],
+            'integer item' => [[123]],
+            'float item' => [[1.5]],
+            'boolean item' => [[true]],
+            'scientific notation item' => [['1.5e3']],
+            'leading plus sign item' => [['+1.5']],
+            'NaN item' => [['NaN']],
+            'mixed valid and invalid' => [['1.50', 'not-a-number']],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidNumericArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+        ];
+    }
+
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'integer-like string' => ['42'],
+            'negative integer-like string' => ['-7'],
+            'decimal string' => ['1.50'],
+            'high precision decimal string' => ['1.0000000000000000000000000001'],
+            'null value' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'empty string' => [''],
+            'non-numeric string' => ['abc'],
+            'scientific notation' => ['1.5e3'],
+            'leading plus sign' => ['+1.5'],
+            'missing integer part' => ['.5'],
+            'trailing dot' => ['5.'],
+            'NaN' => ['NaN'],
+            'comma as decimal separator' => ['1,5'],
+            'integer' => [123],
+            'float' => [3.14],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function converts_null_item_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidNumericArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(123);
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimeArrayTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\TimeArray;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class TimeArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&Stub
+     */
+    private Stub $platform;
+
+    private TimeArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createStub(AbstractPlatform::class);
+        $this->fixture = new TimeArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('time[]', $this->fixture->getName());
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single time' => [
+                'phpValue' => ['12:34:56'],
+                'postgresValue' => '{"12:34:56"}',
+            ],
+            'multiple time values' => [
+                'phpValue' => ['12:34:56', '00:00:00'],
+                'postgresValue' => '{"12:34:56","00:00:00"}',
+            ],
+            'time with microseconds' => [
+                'phpValue' => ['12:34:56.123456'],
+                'postgresValue' => '{"12:34:56.123456"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [null, '12:34:56'],
+                'postgresValue' => '{NULL,"12:34:56"}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidTimeArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'empty string item' => [['']],
+            'integer item' => [[123]],
+            'boolean item' => [[true]],
+            'mixed valid and invalid' => [['12:34:56', '']],
+            'valid mixed with integer' => [['12:34:56', 123]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidTimeArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+        ];
+    }
+
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'simple time' => ['12:34:56'],
+            'midnight' => ['00:00:00'],
+            'time with microseconds' => ['12:34:56.123456'],
+            'null value' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'empty string' => [''],
+            'integer' => [123],
+            'float' => [3.14],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function converts_null_item_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidTimeArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(123);
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/VarcharArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/VarcharArrayTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\VarcharArray;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class VarcharArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&Stub
+     */
+    private Stub $platform;
+
+    private VarcharArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createStub(AbstractPlatform::class);
+        $this->fixture = new VarcharArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('varchar[]', $this->fixture->getName());
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single string' => [
+                'phpValue' => ['hello'],
+                'postgresValue' => '{"hello"}',
+            ],
+            'multiple strings' => [
+                'phpValue' => ['foo', 'bar', 'baz'],
+                'postgresValue' => '{"foo","bar","baz"}',
+            ],
+            'strings with special characters' => [
+                'phpValue' => ['with,comma', 'with "double-quotes"'],
+                'postgresValue' => '{"with,comma","with \"double-quotes\""}',
+            ],
+            'numbers as strings' => [
+                'phpValue' => ['1', '2.5'],
+                'postgresValue' => '{"1","2.5"}',
+            ],
+        ];
+    }
+
+    #[Test]
+    public function converts_unquoted_postgres_array_to_php_value(): void
+    {
+        $postgresValue = '{STRING_A,STRING_B,STRING_C,STRING_D}';
+        $expectedValue = ['STRING_A', 'STRING_B', 'STRING_C', 'STRING_D'];
+
+        $this->assertSame($expectedValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    #[DataProvider('provideStringPreservationTestCases')]
+    #[Test]
+    public function preserves_string_types_retrieved_from_database(string $postgresValue, array $expectedResult): void
+    {
+        $result = $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+
+        $this->assertSame($expectedResult, $result);
+
+        foreach ($result as $value) {
+            $this->assertIsString($value);
+        }
+    }
+
+    /**
+     * PostgreSQL omits quotes around varchar array items that look numeric or
+     * boolean; these must still come back as PHP strings (see GitHub issue #424).
+     *
+     * @return array<string, array{
+     *     postgresValue: string,
+     *     expectedResult: array<string>
+     * }>
+     */
+    public static function provideStringPreservationTestCases(): array
+    {
+        return [
+            'numeric values should be preserved as strings' => [
+                'postgresValue' => '{1,test}',
+                'expectedResult' => ['1', 'test'],
+            ],
+            'mixed values should be preserved as strings' => [
+                'postgresValue' => '{1,2.5,3.14,test,true,false}',
+                'expectedResult' => ['1', '2.5', '3.14', 'test', 'true', 'false'],
+            ],
+            'quoted boolean-like values should remain as strings' => [
+                'postgresValue' => '{"true","false","t","f"}',
+                'expectedResult' => ['true', 'false', 't', 'f'],
+            ],
+        ];
+    }
+
+    #[Test]
+    public function preserves_trailing_zeros_in_strings_that_look_like_decimals(): void
+    {
+        $postgresValue = '{42.00,123.50,0.00,999.99,502.00,505.00}';
+        $expectedResult = ['42.00', '123.50', '0.00', '999.99', '502.00', '505.00'];
+
+        $result = $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+
+        $this->assertSame($expectedResult, $result);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL array support for `json[]`, `numeric[]`, `time[]`, and `varchar[]`.
  * Numeric arrays preserve decimal precision by representing values as strings, including `decimal[]` aliases.
  * Added validation and clear conversion errors for invalid array values.
  * Added configuration guidance for Doctrine, Laravel, and Symfony integrations.

* **Documentation**
  * Expanded available type references and integration setup examples for the new array types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->