### PR TITLE
feat: add support for `GEN_RANDOM_UUID()`

### DIFF
--- a/docs/AVAILABLE-FUNCTIONS-AND-OPERATORS.md
+++ b/docs/AVAILABLE-FUNCTIONS-AND-OPERATORS.md
@@ -142,6 +142,7 @@ Distance functions for fixed-dimension float vectors stored with the `vector` ty
 - `CAST` - General type conversion
 - `TO_CHAR` - Convert numbers and dates to formatted strings
 - `TO_NUMBER` - Parse formatted text as numbers
+- `GEN_RANDOM_UUID` - Generate a random UUID (version 4)
 - `UUIDV4` - Explicit UUID version 4 generation
 - `UUIDV7` - Generate timestamp-ordered UUIDs (version 7) for better database performance
 - `UUID_EXTRACT_TIMESTAMP` - Extract timestamp from UUID v1 or v7
@@ -236,7 +237,7 @@ Distance functions for fixed-dimension float vectors stored with the `vector` ty
 ### **Utility Functions**
 - **Type Conversion**: `CAST` for general type conversion
 - **Formatting**: `TO_CHAR` for numbers and dates, `TO_NUMBER` for parsing
-- **UUID**: Generation (`UUIDV4`, `UUIDV7`) and inspection (`UUID_EXTRACT_TIMESTAMP`, `UUID_EXTRACT_VERSION`)
+- **UUID**: Generation (`GEN_RANDOM_UUID`, `UUIDV4`, `UUIDV7`) and inspection (`UUID_EXTRACT_TIMESTAMP`, `UUID_EXTRACT_VERSION`)
 
 ### **XML Functions**
 - **Aggregation**: `XMLAGG` — aggregate XML values with optional ordering

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -441,6 +441,7 @@ $configuration->addCustomStringFunction('SHA384', MartinGeorgiev\Doctrine\ORM\Qu
 $configuration->addCustomStringFunction('SHA512', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Sha512::class);
 
 # uuid functions
+$configuration->addCustomStringFunction('GEN_RANDOM_UUID', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\GenRandomUuid::class);
 $configuration->addCustomStringFunction('UUID_EXTRACT_TIMESTAMP', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\UuidExtractTimestamp::class);
 $configuration->addCustomStringFunction('UUID_EXTRACT_VERSION', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\UuidExtractVersion::class);
 $configuration->addCustomStringFunction('UUIDV4', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Uuidv4::class);

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -658,6 +658,7 @@ return [
         'SHA512' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Sha512::class,
 
         # uuid functions
+        'GEN_RANDOM_UUID' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\GenRandomUuid::class,
         'UUID_EXTRACT_TIMESTAMP' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\UuidExtractTimestamp::class,
         'UUID_EXTRACT_VERSION' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\UuidExtractVersion::class,
         'UUIDV4' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Uuidv4::class,

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -639,6 +639,7 @@ doctrine:
                         SHA512: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Sha512
 
                         # uuid functions
+                        GEN_RANDOM_UUID: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\GenRandomUuid
                         UUID_EXTRACT_TIMESTAMP: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\UuidExtractTimestamp
                         UUID_EXTRACT_VERSION: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\UuidExtractVersion
                         UUIDV4: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Uuidv4

--- a/docs/UTILITY-FUNCTIONS.md
+++ b/docs/UTILITY-FUNCTIONS.md
@@ -5,6 +5,7 @@
 | cast | CAST | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Cast` |
 | to_char | TO_CHAR | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ToChar` |
 | to_number | TO_NUMBER | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\ToNumber` |
+| gen_random_uuid | GEN_RANDOM_UUID | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\GenRandomUuid` |
 | uuidv4 | UUIDV4 | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Uuidv4` |
 | uuidv7 | UUIDV7 | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Uuidv7` |
 | uuid_extract_timestamp | UUID_EXTRACT_TIMESTAMP | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\UuidExtractTimestamp` |

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GenRandomUuid.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GenRandomUuid.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+/**
+ * Implementation of PostgreSQL GEN_RANDOM_UUID().
+ *
+ * Generates a random UUID v4.
+ *
+ * @see https://www.postgresql.org/docs/18/functions-uuid.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL: "SELECT GEN_RANDOM_UUID() FROM Entity e"
+ */
+class GenRandomUuid extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        $this->setFunctionPrototype('gen_random_uuid()');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GenRandomUuid.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GenRandomUuid.php
@@ -7,8 +7,6 @@ namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 /**
  * Implementation of PostgreSQL GEN_RANDOM_UUID().
  *
- * Generates a random UUID v4.
- *
  * @see https://www.postgresql.org/docs/18/functions-uuid.html
  * @since 4.8
  *

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GenRandomUuidTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GenRandomUuidTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\GenRandomUuid;
+use PHPUnit\Framework\Attributes\Test;
+
+final class GenRandomUuidTest extends NumericTestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'GEN_RANDOM_UUID' => GenRandomUuid::class,
+        ];
+    }
+
+    #[Test]
+    public function generates_random_uuid(): void
+    {
+        $dql = 'SELECT GEN_RANDOM_UUID() as result
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t
+                WHERE t.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $uuid = $result[0]['result'];
+
+        $this->assertIsString($uuid);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i', $uuid);
+    }
+
+    #[Test]
+    public function generates_unique_uuids(): void
+    {
+        $dql = 'SELECT GEN_RANDOM_UUID() as uuid1, GEN_RANDOM_UUID() as uuid2
+                FROM Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsNumerics t
+                WHERE t.id = 1';
+
+        $result = $this->executeDqlQuery($dql);
+        $uuid1 = $result[0]['uuid1'];
+        $uuid2 = $result[0]['uuid2'];
+
+        $this->assertNotEquals($uuid1, $uuid2);
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GenRandomUuidTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/GenRandomUuidTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\GenRandomUuid;
+
+final class GenRandomUuidTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'GEN_RANDOM_UUID' => GenRandomUuid::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'generates random uuid' => 'SELECT gen_random_uuid() AS sclr_0 FROM ContainsTexts c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'generates random uuid' => \sprintf('SELECT GEN_RANDOM_UUID() FROM %s e', ContainsTexts::class),
+        ];
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for PostgreSQL’s `GEN_RANDOM_UUID()` function in Doctrine DQL to generate random UUIDs.
* **Documentation**
  * Added usage and registration guidance for `GEN_RANDOM_UUID` in the utility, Doctrine, Laravel, and Symfony integration documentation.
* **Tests**
  * Added coverage for UUID generation, uniqueness, format validation, and SQL translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->