### PR TITLE
feat: add support for the `cube` data type

### DIFF
--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -292,7 +292,7 @@ A cube is a multidimensional value that is either a point — `(1, 2, 3)` — or
 ```php
 use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Cube;
 
-$point = Cube::point(1.0, 2.0, 3.0);            // (1, 2, 3)
+$point = Cube::point(1.0, 2.0, 3.0);               // (1, 2, 3)
 $box = new Cube([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]); // (1, 2, 3),(4, 5, 6)
 
 $box->getFirstCorner();  // [1.0, 2.0, 3.0]
@@ -300,7 +300,3 @@ $box->getSecondCorner(); // [4.0, 5.0, 6.0]
 $box->getDimensions();   // 3
 $point->isPoint();       // true
 ```
-
-PostgreSQL keeps the two corners in the order they were written, but renders a zero-volume box as a point. The value object normalizes the same way, so `new Cube([1.0, 2.0], [1.0, 2.0])` is a point and round-trips unchanged.
-
-PostgreSQL also accepts `NaN` and `Infinity` coordinates. Those are rejected by this library, because PHP cannot parse them back from the textual form PostgreSQL emits.

--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -98,6 +98,9 @@
 | geometry | geometry | `MartinGeorgiev\Doctrine\DBAL\Types\Geometry` |
 | geometry[] | _geometry | `MartinGeorgiev\Doctrine\DBAL\Types\GeometryArray` |
 |---|---|---|
+| cube | cube | `MartinGeorgiev\Doctrine\DBAL\Types\Cube` (see [note](#cube-type)) |
+| cube[] | _cube | `MartinGeorgiev\Doctrine\DBAL\Types\CubeArray` |
+|---|---|---|
 | hstore | hstore | `MartinGeorgiev\Doctrine\DBAL\Types\Hstore` (see [note](#hstore-type)) |
 | hstore[] | _hstore | `MartinGeorgiev\Doctrine\DBAL\Types\HstoreArray` |
 |---|---|---|
@@ -273,3 +276,31 @@ CREATE EXTENSION IF NOT EXISTS ulid;
 A ULID is a 26-character [Crockford base32](https://github.com/ulid/spec) identifier (uppercase, first character `0`–`7`) stored as a compact 128-bit binary value. It maps to `string` in PHP. PostgreSQL outputs the canonical uppercase form on retrieval; the DBAL type normalizes values to uppercase on write as well, so round-trips are stable even for lowercase input.
 
 Use `ulid` when you want sortable, timestamp-prefixed identifiers that are shorter and more index-friendly than UUIDs.
+
+---
+
+## Cube Type
+
+The `cube` type requires the PostgreSQL [`cube`](https://www.postgresql.org/docs/18/cube.html) extension. Enable it with:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS cube;
+```
+
+A cube is a multidimensional value that is either a point — `(1, 2, 3)` — or a box spanned by two opposite corners — `(1, 2, 3),(4, 5, 6)`. Both corners always carry the same number of dimensions. It maps to the `MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Cube` value object in PHP:
+
+```php
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Cube;
+
+$point = Cube::point(1.0, 2.0, 3.0);            // (1, 2, 3)
+$box = new Cube([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]); // (1, 2, 3),(4, 5, 6)
+
+$box->getFirstCorner();  // [1.0, 2.0, 3.0]
+$box->getSecondCorner(); // [4.0, 5.0, 6.0]
+$box->getDimensions();   // 3
+$point->isPoint();       // true
+```
+
+PostgreSQL keeps the two corners in the order they were written, but renders a zero-volume box as a point. The value object normalizes the same way, so `new Cube([1.0, 2.0], [1.0, 2.0])` is a point and round-trips unchanged.
+
+PostgreSQL also accepts `NaN` and `Infinity` coordinates. Those are rejected by this library, because PHP cannot parse them back from the textual form PostgreSQL emits.

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -82,6 +82,10 @@ Type::addType('point[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\PointArray");
 Type::addType('polygon', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Polygon");
 Type::addType('polygon[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\PolygonArray");
 
+// Cube types
+Type::addType('cube', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Cube");
+Type::addType('cube[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\CubeArray");
+
 // PostGIS spatial types
 Type::addType('geometry', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Geometry");
 Type::addType('geometry[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\GeometryArray");
@@ -570,6 +574,11 @@ $platform->registerDoctrineTypeMapping('_point', 'point[]');
 $platform->registerDoctrineTypeMapping('polygon', 'polygon');
 $platform->registerDoctrineTypeMapping('polygon[]', 'polygon[]');
 $platform->registerDoctrineTypeMapping('_polygon', 'polygon[]');
+
+// Cube type mappings
+$platform->registerDoctrineTypeMapping('cube', 'cube');
+$platform->registerDoctrineTypeMapping('cube[]', 'cube[]');
+$platform->registerDoctrineTypeMapping('_cube', 'cube[]');
 
 // PostGIS spatial type mappings
 $platform->registerDoctrineTypeMapping('geometry', 'geometry');

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -138,6 +138,11 @@ return [
                 'polygon[]' => 'polygon[]',
                 '_polygon' => 'polygon[]',
 
+                // Cube type mappings
+                'cube' => 'cube',
+                'cube[]' => 'cube[]',
+                '_cube' => 'cube[]',
+
                 // PostGIS spatial type mappings
                 'geometry' => 'geometry',
                 'geometry[]' => 'geometry[]',
@@ -293,6 +298,10 @@ return [
         'point[]' => MartinGeorgiev\Doctrine\DBAL\Types\PointArray::class,
         'polygon' => MartinGeorgiev\Doctrine\DBAL\Types\Polygon::class,
         'polygon[]' => MartinGeorgiev\Doctrine\DBAL\Types\PolygonArray::class,
+
+        // Cube types
+        'cube' => MartinGeorgiev\Doctrine\DBAL\Types\Cube::class,
+        'cube[]' => MartinGeorgiev\Doctrine\DBAL\Types\CubeArray::class,
 
         // PostGIS spatial types
         'geometry' => MartinGeorgiev\Doctrine\DBAL\Types\Geometry::class,

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -74,6 +74,10 @@ doctrine:
             polygon: MartinGeorgiev\Doctrine\DBAL\Types\Polygon
             'polygon[]': MartinGeorgiev\Doctrine\DBAL\Types\PolygonArray
 
+            # Cube types
+            cube: MartinGeorgiev\Doctrine\DBAL\Types\Cube
+            'cube[]': MartinGeorgiev\Doctrine\DBAL\Types\CubeArray
+
             # PostGIS spatial types
             geometry: MartinGeorgiev\Doctrine\DBAL\Types\Geometry
             'geometry[]': MartinGeorgiev\Doctrine\DBAL\Types\GeometryArray
@@ -263,6 +267,11 @@ doctrine:
                     polygon: !php/const MartinGeorgiev\Doctrine\DBAL\Type::POLYGON
                     'polygon[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::POLYGON_ARRAY
                     _polygon: !php/const MartinGeorgiev\Doctrine\DBAL\Type::POLYGON_ARRAY
+
+                    # Cube type mappings
+                    cube: !php/const MartinGeorgiev\Doctrine\DBAL\Type::CUBE
+                    'cube[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::CUBE_ARRAY
+                    _cube: !php/const MartinGeorgiev\Doctrine\DBAL\Type::CUBE_ARRAY
 
                     # PostGIS spatial type mappings
                     geometry: !php/const MartinGeorgiev\Doctrine\DBAL\Type::GEOMETRY

--- a/src/MartinGeorgiev/Doctrine/DBAL/Type.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Type.php
@@ -89,6 +89,16 @@ final class Type
     /**
      * @var string
      */
+    public const CUBE = 'cube';
+
+    /**
+     * @var string
+     */
+    public const CUBE_ARRAY = 'cube[]';
+
+    /**
+     * @var string
+     */
     public const DATE_ARRAY = 'date[]';
 
     /**

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Cube.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Cube.php
@@ -12,10 +12,9 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Cube as CubeValueObject;
 use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidCubeException;
 
 /**
- * Implementation of PostgreSQL cube extension type.
+ * Implementation of PostgreSQL CUBE data type.
  *
- * Multidimensional cube, either a point or a box spanned by two opposite
- * corners. Requires the cube extension.
+ * Multidimensional cube, either a point or a box spanned by two opposite corners.
  *
  * @see https://www.postgresql.org/docs/18/cube.html
  * @since 4.8

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Cube.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Cube.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCubeForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCubeForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Cube as CubeValueObject;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidCubeException;
+
+/**
+ * Implementation of PostgreSQL cube extension type.
+ *
+ * Multidimensional cube, either a point or a box spanned by two opposite
+ * corners. Requires the cube extension.
+ *
+ * @see https://www.postgresql.org/docs/18/cube.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class Cube extends BaseType
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::CUBE;
+
+    /**
+     * @throws InvalidCubeForDatabaseException
+     */
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!$value instanceof CubeValueObject) {
+            throw InvalidCubeForDatabaseException::forInvalidType($value);
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * @throws InvalidCubeForPHPException
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?CubeValueObject
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidCubeForPHPException::forInvalidType($value);
+        }
+
+        try {
+            return CubeValueObject::fromString($value);
+        } catch (InvalidCubeException) {
+            throw InvalidCubeForPHPException::forInvalidFormat($value);
+        }
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/CubeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/CubeArray.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCubeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCubeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Cube as CubeValueObject;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidCubeException;
+use MartinGeorgiev\Utils\Exception\InvalidArrayFormatException;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
+
+/**
+ * Implementation of PostgreSQL cube[] data type.
+ *
+ * Unlike the geometric array types this one cannot rely on every element being
+ * quoted: PostgreSQL omits the quotes for one-dimensional cubes such as (1),
+ * because they contain no comma. The general array parser is used instead.
+ *
+ * @see https://www.postgresql.org/docs/18/cube.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class CubeArray extends BaseArray
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::CUBE_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        return $item instanceof CubeValueObject;
+    }
+
+    protected function transformArrayItemForPostgres(mixed $item): string
+    {
+        if (!$item instanceof CubeValueObject) {
+            $this->throwInvalidItemException($item);
+        }
+
+        return $this->quoteAndEscapeArrayItem((string) $item);
+    }
+
+    public function transformArrayItemForPHP(mixed $item): ?CubeValueObject
+    {
+        if ($item === null) {
+            return null;
+        }
+
+        if (!\is_string($item)) {
+            throw InvalidCubeArrayItemForPHPException::forInvalidFormat($item);
+        }
+
+        try {
+            return CubeValueObject::fromString($item);
+        } catch (InvalidCubeException) {
+            throw InvalidCubeArrayItemForPHPException::forInvalidFormat($item);
+        }
+    }
+
+    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
+    {
+        try {
+            return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray);
+        } catch (InvalidArrayFormatException) {
+            throw InvalidCubeArrayItemForPHPException::forInvalidFormat($postgresArray);
+        }
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidCubeArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidCubeArrayItemForDatabaseException::forInvalidType($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/CubeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/CubeArray.php
@@ -13,11 +13,7 @@ use MartinGeorgiev\Utils\Exception\InvalidArrayFormatException;
 use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
 
 /**
- * Implementation of PostgreSQL cube[] data type.
- *
- * Unlike the geometric array types this one cannot rely on every element being
- * quoted: PostgreSQL omits the quotes for one-dimensional cubes such as (1),
- * because they contain no comma. The general array parser is used instead.
+ * Implementation of PostgreSQL CUBE[] data type.
  *
  * @see https://www.postgresql.org/docs/18/cube.html
  * @since 4.8

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCubeArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Cannot convert cube array item to database value. Expected a Cube value object, got %s.', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeArrayItemForPHPException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCubeArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Cannot convert cube array item to PHP value. Value %s is not a valid cube.', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Cannot convert cube array to PHP value. Expected a string or null, got %s.', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCubeForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Value must be a Cube value object, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeForPHPException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCubeForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Database value must be a string, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid cube format in database: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Cube.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Cube.php
@@ -24,6 +24,11 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidCubeExcepti
 final readonly class Cube implements \Stringable
 {
     /**
+     * PostgreSQL rejects anything above this with "A cube cannot have more than 100 dimensions".
+     */
+    private const MAX_DIMENSIONS = 100;
+
+    /**
      * PostgreSQL accepts non-finite coordinates in several spellings (nan, inf, -inf, infinity).
      * PostgreSQL always emits these as NaN, Infinity or -Infinity.
      *
@@ -75,13 +80,15 @@ final readonly class Cube implements \Stringable
     public function __construct(array $firstCorner, ?array $secondCorner = null)
     {
         if ($firstCorner === []) {
-            throw InvalidCubeException::forEmptyCoordinates(\count($firstCorner));
+            throw InvalidCubeException::forEmptyCoordinates();
+        }
+
+        if (\count($firstCorner) > self::MAX_DIMENSIONS) {
+            throw InvalidCubeException::forTooManyDimensions(\count($firstCorner));
         }
 
         if ($secondCorner !== null && \count($secondCorner) !== \count($firstCorner)) {
-            throw InvalidCubeException::forMismatchedDimensions(
-                \sprintf('%d and %d', \count($firstCorner), \count($secondCorner))
-            );
+            throw InvalidCubeException::forMismatchedDimensions(\count($firstCorner), \count($secondCorner));
         }
 
         $this->firstCorner = $firstCorner;

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Cube.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Cube.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\ValueObject;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidCubeException;
+
+/**
+ * Represents a PostgreSQL cube value, provided by the cube extension.
+ *
+ * A cube is either a point, written as a single coordinate group — (1, 2, 3) —
+ * or a box spanned by two opposite corners — (1, 2, 3),(4, 5, 6). Both corners
+ * always carry the same number of dimensions.
+ *
+ * PostgreSQL keeps the two corners in the order they were written and collapses
+ * a zero-volume box back into a point, so this value object normalizes the same
+ * way: equal corners are stored as a point and never re-emitted as a box.
+ *
+ * PostgreSQL also accepts NaN and Infinity coordinates. Those are rejected here,
+ * because PHP cannot parse them back from the textual form PostgreSQL emits,
+ * which would break the round-trip guarantee.
+ *
+ * @see https://www.postgresql.org/docs/18/cube.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final readonly class Cube implements \Stringable
+{
+    /**
+     * @var string
+     */
+    private const COORDINATE_PATTERN = '[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?';
+
+    /**
+     * @var string
+     */
+    private const COORDINATE_LIST_PATTERN = self::COORDINATE_PATTERN.'(?:\s*,\s*'.self::COORDINATE_PATTERN.')*';
+
+    /**
+     * @var string
+     */
+    private const CORNER_PATTERN = '\(\s*('.self::COORDINATE_LIST_PATTERN.')\s*\)';
+
+    /**
+     * @var string
+     */
+    private const BOX_REGEX = '/^'.self::CORNER_PATTERN.'\s*,\s*'.self::CORNER_PATTERN.'$/';
+
+    /**
+     * @var string
+     */
+    private const POINT_REGEX = '/^'.self::CORNER_PATTERN.'$/';
+
+    /**
+     * @var string
+     */
+    private const BARE_POINT_REGEX = '/^('.self::COORDINATE_LIST_PATTERN.')$/';
+
+    /**
+     * @var list<float>
+     */
+    private array $firstCorner;
+
+    /**
+     * @var list<float>|null
+     */
+    private ?array $secondCorner;
+
+    /**
+     * @param list<float> $firstCorner
+     * @param list<float>|null $secondCorner
+     *
+     * @throws InvalidCubeException
+     */
+    public function __construct(array $firstCorner, ?array $secondCorner = null)
+    {
+        if ($firstCorner === []) {
+            throw InvalidCubeException::forEmptyCoordinates(\count($firstCorner));
+        }
+
+        $this->assertFiniteCoordinates($firstCorner);
+
+        if ($secondCorner !== null) {
+            $this->assertFiniteCoordinates($secondCorner);
+
+            if (\count($secondCorner) !== \count($firstCorner)) {
+                throw InvalidCubeException::forMismatchedDimensions(
+                    \sprintf('%d and %d', \count($firstCorner), \count($secondCorner))
+                );
+            }
+        }
+
+        $this->firstCorner = $firstCorner;
+        // PostgreSQL renders a zero-volume box as a point, so collapse it here as
+        // well — otherwise a stored value would never equal the one read back.
+        $this->secondCorner = $secondCorner === $firstCorner ? null : $secondCorner;
+    }
+
+    public function __toString(): string
+    {
+        $firstCorner = $this->formatCorner($this->firstCorner);
+        if ($this->secondCorner === null) {
+            return $firstCorner;
+        }
+
+        return $firstCorner.','.$this->formatCorner($this->secondCorner);
+    }
+
+    /**
+     * @return list<float>
+     */
+    public function getFirstCorner(): array
+    {
+        return $this->firstCorner;
+    }
+
+    /**
+     * @return list<float>|null
+     */
+    public function getSecondCorner(): ?array
+    {
+        return $this->secondCorner;
+    }
+
+    public function getDimensions(): int
+    {
+        return \count($this->firstCorner);
+    }
+
+    public function isPoint(): bool
+    {
+        return $this->secondCorner === null;
+    }
+
+    /**
+     * @throws InvalidCubeException
+     */
+    public static function point(float ...$coordinates): self
+    {
+        return new self(\array_values($coordinates));
+    }
+
+    /**
+     * @throws InvalidCubeException
+     */
+    public static function fromString(string $value): self
+    {
+        $trimmed = \trim($value);
+        // PostgreSQL accepts an optional bracketed box form, [(1,2),(3,4)], and
+        // drops the brackets on output.
+        if (\str_starts_with($trimmed, '[') && \str_ends_with($trimmed, ']')) {
+            $trimmed = \trim(\mb_substr($trimmed, 1, -1));
+        }
+
+        if (\preg_match(self::BOX_REGEX, $trimmed, $matches) === 1) {
+            return new self(self::parseCoordinates($matches[1]), self::parseCoordinates($matches[2]));
+        }
+
+        if (\preg_match(self::POINT_REGEX, $trimmed, $matches) === 1) {
+            return new self(self::parseCoordinates($matches[1]));
+        }
+
+        if (\preg_match(self::BARE_POINT_REGEX, $trimmed, $matches) === 1) {
+            return new self(self::parseCoordinates($matches[1]));
+        }
+
+        throw InvalidCubeException::forInvalidFormat($value);
+    }
+
+    /**
+     * @param list<float> $coordinates
+     *
+     * @throws InvalidCubeException
+     */
+    private function assertFiniteCoordinates(array $coordinates): void
+    {
+        foreach ($coordinates as $coordinate) {
+            if (!\is_finite($coordinate)) {
+                throw InvalidCubeException::forNonFiniteCoordinate($coordinate);
+            }
+        }
+    }
+
+    /**
+     * @return list<float>
+     */
+    private static function parseCoordinates(string $coordinateList): array
+    {
+        $parts = \preg_split('/\s*,\s*/', \trim($coordinateList));
+        \assert(\is_array($parts));
+
+        return \array_map(static fn (string $part): float => (float) $part, $parts);
+    }
+
+    /**
+     * @param list<float> $coordinates
+     */
+    private function formatCorner(array $coordinates): string
+    {
+        return '('.\implode(', ', \array_map($this->formatCoordinate(...), $coordinates)).')';
+    }
+
+    private function formatCoordinate(float $coordinate): string
+    {
+        // Casting a float to string uses the `precision` ini setting (14 significant
+        // digits by default), which silently rewrites values PostgreSQL stores in
+        // full float8 precision. Fall back to the 17-digit form, which always
+        // round-trips, whenever the short one does not.
+        $shortForm = (string) $coordinate;
+
+        return (float) $shortForm === $coordinate ? $shortForm : \sprintf('%.17G', $coordinate);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Cube.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Cube.php
@@ -9,17 +9,12 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidCubeExcepti
 /**
  * Represents a PostgreSQL cube value, provided by the cube extension.
  *
- * A cube is either a point, written as a single coordinate group — (1, 2, 3) —
- * or a box spanned by two opposite corners — (1, 2, 3),(4, 5, 6). Both corners
- * always carry the same number of dimensions.
+ * A cube is either of:
+ * - a point, written as a single coordinate group, e.g. (1, 2, 3); or
+ * - a box spanned by two opposite corners, e.g. (1, 2, 3),(4, 5, 6).
  *
- * PostgreSQL keeps the two corners in the order they were written and collapses
- * a zero-volume box back into a point, so this value object normalizes the same
- * way: equal corners are stored as a point and never re-emitted as a box.
- *
- * PostgreSQL also accepts NaN and Infinity coordinates. Those are rejected here,
- * because PHP cannot parse them back from the textual form PostgreSQL emits,
- * which would break the round-trip guarantee.
+ * PostgreSQL preserves the corners order and collapses a zero-volume box back into a point,
+ * so this value object normalizes the same way: equal corners are stored as a point and never re-emitted as a box.
  *
  * @see https://www.postgresql.org/docs/18/cube.html
  * @since 4.8
@@ -29,9 +24,12 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidCubeExcepti
 final readonly class Cube implements \Stringable
 {
     /**
+     * PostgreSQL accepts non-finite coordinates in several spellings (nan, inf, -inf, infinity).
+     * PostgreSQL always emits these as NaN, Infinity or -Infinity.
+     *
      * @var string
      */
-    private const COORDINATE_PATTERN = '[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?';
+    private const COORDINATE_PATTERN = '(?:[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?|[+-]?(?i:inf(?:inity)?|nan))';
 
     /**
      * @var string
@@ -80,21 +78,15 @@ final readonly class Cube implements \Stringable
             throw InvalidCubeException::forEmptyCoordinates(\count($firstCorner));
         }
 
-        $this->assertFiniteCoordinates($firstCorner);
-
-        if ($secondCorner !== null) {
-            $this->assertFiniteCoordinates($secondCorner);
-
-            if (\count($secondCorner) !== \count($firstCorner)) {
-                throw InvalidCubeException::forMismatchedDimensions(
-                    \sprintf('%d and %d', \count($firstCorner), \count($secondCorner))
-                );
-            }
+        if ($secondCorner !== null && \count($secondCorner) !== \count($firstCorner)) {
+            throw InvalidCubeException::forMismatchedDimensions(
+                \sprintf('%d and %d', \count($firstCorner), \count($secondCorner))
+            );
         }
 
         $this->firstCorner = $firstCorner;
-        // PostgreSQL renders a zero-volume box as a point, so collapse it here as
-        // well — otherwise a stored value would never equal the one read back.
+        // PostgreSQL renders a zero-volume box as a point, so collapse it here as well.
+        // Otherwise, a stored value would never equal the one read back.
         $this->secondCorner = $secondCorner === $firstCorner ? null : $secondCorner;
     }
 
@@ -148,8 +140,7 @@ final readonly class Cube implements \Stringable
     public static function fromString(string $value): self
     {
         $trimmed = \trim($value);
-        // PostgreSQL accepts an optional bracketed box form, [(1,2),(3,4)], and
-        // drops the brackets on output.
+        // PostgreSQL accepts an optional bracketed box form, [(1,2),(3,4)], and drops the brackets on output.
         if (\str_starts_with($trimmed, '[') && \str_ends_with($trimmed, ']')) {
             $trimmed = \trim(\mb_substr($trimmed, 1, -1));
         }
@@ -170,20 +161,6 @@ final readonly class Cube implements \Stringable
     }
 
     /**
-     * @param list<float> $coordinates
-     *
-     * @throws InvalidCubeException
-     */
-    private function assertFiniteCoordinates(array $coordinates): void
-    {
-        foreach ($coordinates as $coordinate) {
-            if (!\is_finite($coordinate)) {
-                throw InvalidCubeException::forNonFiniteCoordinate($coordinate);
-            }
-        }
-    }
-
-    /**
      * @return list<float>
      */
     private static function parseCoordinates(string $coordinateList): array
@@ -191,7 +168,20 @@ final readonly class Cube implements \Stringable
         $parts = \preg_split('/\s*,\s*/', \trim($coordinateList));
         \assert(\is_array($parts));
 
-        return \array_map(static fn (string $part): float => (float) $part, $parts);
+        return \array_map(self::parseCoordinate(...), $parts);
+    }
+
+    /**
+     * Casting a string to float yields 0.0 for every non-finite spelling PostgreSQL uses. Those are matched explicitly.
+     */
+    private static function parseCoordinate(string $coordinate): float
+    {
+        return match (\mb_strtolower(\ltrim($coordinate, '+'))) {
+            'nan', '-nan' => \NAN,
+            'inf', 'infinity' => \INF,
+            '-inf', '-infinity' => -\INF,
+            default => (float) $coordinate,
+        };
     }
 
     /**
@@ -202,12 +192,20 @@ final readonly class Cube implements \Stringable
         return '('.\implode(', ', \array_map($this->formatCoordinate(...), $coordinates)).')';
     }
 
+    /**
+     * Casting a float to string uses the `precision` ini setting, which silently rewrites stored values in full float8
+     * precision. Fall back to the 17-digit form, which always round-trips, whenever the short one does not.
+     */
     private function formatCoordinate(float $coordinate): string
     {
-        // Casting a float to string uses the `precision` ini setting (14 significant
-        // digits by default), which silently rewrites values PostgreSQL stores in
-        // full float8 precision. Fall back to the 17-digit form, which always
-        // round-trips, whenever the short one does not.
+        if (\is_nan($coordinate)) {
+            return 'NaN';
+        }
+
+        if (\is_infinite($coordinate)) {
+            return $coordinate > 0 ? 'Infinity' : '-Infinity';
+        }
+
         $shortForm = (string) $coordinate;
 
         return (float) $shortForm === $coordinate ? $shortForm : \sprintf('%.17G', $coordinate);

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Exceptions/InvalidCubeException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Exceptions/InvalidCubeException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidCubeException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid cube format: %s', $value);
+    }
+
+    public static function forEmptyCoordinates(mixed $value): self
+    {
+        return self::create('A cube must have at least one dimension, %s given', $value);
+    }
+
+    public static function forNonFiniteCoordinate(mixed $value): self
+    {
+        return self::create('Cube coordinates must be finite numbers, %s given', $value);
+    }
+
+    public static function forMismatchedDimensions(mixed $value): self
+    {
+        return self::create('Both cube corners must have the same number of dimensions, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Exceptions/InvalidCubeException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Exceptions/InvalidCubeException.php
@@ -18,18 +18,27 @@ final class InvalidCubeException extends ConversionException
         return new self(\sprintf($message, \var_export($value, true)));
     }
 
-    public static function forInvalidFormat(mixed $value): self
+    public static function forInvalidFormat(string $value): self
     {
         return self::create('Invalid cube format: %s', $value);
     }
 
-    public static function forEmptyCoordinates(mixed $value): self
+    public static function forEmptyCoordinates(): self
     {
-        return self::create('A cube must have at least one dimension, %s given', $value);
+        return new self('A cube must have at least one dimension, none given');
     }
 
-    public static function forMismatchedDimensions(mixed $value): self
+    public static function forTooManyDimensions(int $dimensions): self
     {
-        return self::create('Both cube corners must have the same number of dimensions, %s given', $value);
+        return new self(\sprintf('A cube cannot have more than 100 dimensions, %d given', $dimensions));
+    }
+
+    public static function forMismatchedDimensions(int $firstCornerDimensions, int $secondCornerDimensions): self
+    {
+        return new self(\sprintf(
+            'Both cube corners must have the same number of dimensions, %d and %d given',
+            $firstCornerDimensions,
+            $secondCornerDimensions
+        ));
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Exceptions/InvalidCubeException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Exceptions/InvalidCubeException.php
@@ -28,11 +28,6 @@ final class InvalidCubeException extends ConversionException
         return self::create('A cube must have at least one dimension, %s given', $value);
     }
 
-    public static function forNonFiniteCoordinate(mixed $value): self
-    {
-        return self::create('Cube coordinates must be finite numbers, %s given', $value);
-    }
-
     public static function forMismatchedDimensions(mixed $value): self
     {
         return self::create('Both cube corners must have the same number of dimensions, %s given', $value);

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CubeArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CubeArrayTypeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCubeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Cube as CubeValueObject;
+use PHPUnit\Framework\Attributes\Test;
+
+final class CubeArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensurePostgresExtensionInSchema('cube');
+    }
+
+    protected function getTypeName(): string
+    {
+        return 'cube[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, CubeValueObject>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'single point' => [[
+                CubeValueObject::point(1.0, 2.0),
+            ]],
+            'multiple boxes' => [[
+                new CubeValueObject([1.0, 2.0], [3.0, 4.0]),
+                new CubeValueObject([-1.5, -2.5], [-0.5, -0.25]),
+            ]],
+            // PostgreSQL leaves a one-dimensional cube unquoted in the array
+            // output because it contains no comma, unlike its neighbours.
+            'one-dimensional points mixed with multi-dimensional ones' => [[
+                CubeValueObject::point(1.0),
+                CubeValueObject::point(2.0, 3.0),
+                CubeValueObject::point(4.0),
+            ]],
+        ];
+    }
+
+    #[Test]
+    public function rejects_string_instead_of_value_object(): void
+    {
+        $this->expectException(InvalidCubeArrayItemForDatabaseException::class);
+
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, ['(1, 2)']);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CubeTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CubeTypeTest.php
@@ -46,7 +46,34 @@ final class CubeTypeTest extends ScalarTypeTestCase
             'reversed corner order' => [new CubeValueObject([4.0, 5.0, 6.0], [1.0, 2.0, 3.0])],
             'high precision coordinates' => [CubeValueObject::point(0.12345678901234568, 1.0)],
             'exponent scale coordinates' => [CubeValueObject::point(1.0E+300, 1.0E-10)],
+            'infinite coordinates' => [new CubeValueObject([-\INF, 1.0], [\INF, 2.0])],
         ];
+    }
+
+    #[Test]
+    public function roundtrips_nan_coordinate(): void
+    {
+        // NaN never equals itself, so the round-trip is asserted on the emitted representation.
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        [$tableName, $columnName] = $this->prepareTestTable($columnType);
+
+        try {
+            $this->connection->createQueryBuilder()
+                ->insert(self::DATABASE_SCHEMA.'.'.$tableName)
+                ->values([$columnName => ':value'])
+                ->setParameter('value', new CubeValueObject([\NAN, 1.0]), $typeName)
+                ->executeStatement();
+
+            $retrieved = $this->fetchConvertedValue($typeName, $tableName, $columnName);
+
+            $this->assertInstanceOf(CubeValueObject::class, $retrieved);
+            $this->assertSame('(NaN, 1)', (string) $retrieved);
+            $this->assertNan($retrieved->getFirstCorner()[0]);
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CubeTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CubeTypeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCubeForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Cube as CubeValueObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class CubeTypeTest extends ScalarTypeTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensurePostgresExtensionInSchema('cube');
+    }
+
+    protected function getTypeName(): string
+    {
+        return 'cube';
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function roundtrips_value(CubeValueObject $cubeValueObject): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $cubeValueObject);
+    }
+
+    /**
+     * @return array<string, array{CubeValueObject}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'point' => [CubeValueObject::point(1.0, 2.0, 3.0)],
+            'box' => [new CubeValueObject([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])],
+            'one-dimensional point' => [CubeValueObject::point(42.0)],
+            'negative coordinates' => [new CubeValueObject([-1.5, -2.5], [-0.5, -0.25])],
+            'reversed corner order' => [new CubeValueObject([4.0, 5.0, 6.0], [1.0, 2.0, 3.0])],
+            'high precision coordinates' => [CubeValueObject::point(0.12345678901234568, 1.0)],
+            'exponent scale coordinates' => [CubeValueObject::point(1.0E+300, 1.0E-10)],
+        ];
+    }
+
+    #[Test]
+    public function normalizes_zero_volume_box_to_point(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, new CubeValueObject([1.0, 2.0], [1.0, 2.0]));
+    }
+
+    #[Test]
+    public function rejects_string_instead_of_value_object(): void
+    {
+        $this->expectException(InvalidCubeForDatabaseException::class);
+
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, '(1, 2, 3)');
+    }
+}

--- a/tests/Integration/MartinGeorgiev/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/TestCase.php
@@ -29,6 +29,8 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Circle;
 use MartinGeorgiev\Doctrine\DBAL\Types\CircleArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Citext;
 use MartinGeorgiev\Doctrine\DBAL\Types\CitextArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Cube;
+use MartinGeorgiev\Doctrine\DBAL\Types\CubeArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateMultirange;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateMultirangeArray;
@@ -286,6 +288,8 @@ abstract class TestCase extends BaseTestCase
             'cidr[]' => CidrArray::class,
             'citext' => Citext::class,
             'citext[]' => CitextArray::class,
+            'cube' => Cube::class,
+            'cube[]' => CubeArray::class,
             'date[]' => DateArray::class,
             'daterange' => DateRange::class,
             'daterange[]' => DateRangeArray::class,

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CubeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CubeArrayTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\CubeArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCubeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCubeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Cube as CubeValueObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class CubeArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&Stub
+     */
+    private Stub $platform;
+
+    private CubeArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createStub(AbstractPlatform::class);
+        $this->fixture = new CubeArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('cube[]', $this->fixture->getName());
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array<CubeValueObject>|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single point' => [
+                'phpValue' => [CubeValueObject::point(1.0, 2.0)],
+                'postgresValue' => '{"(1, 2)"}',
+            ],
+            'mixed points and boxes' => [
+                'phpValue' => [
+                    CubeValueObject::point(1.0, 2.0),
+                    new CubeValueObject([3.0, 4.0], [5.0, 6.0]),
+                    CubeValueObject::point(-1.5),
+                ],
+                'postgresValue' => '{"(1, 2)","(3, 4),(5, 6)","(-1.5)"}',
+            ],
+        ];
+    }
+
+    #[Test]
+    public function converts_unquoted_one_dimensional_item_to_php_value(): void
+    {
+        // PostgreSQL does not quote a cube element that contains no comma, so a
+        // one-dimensional cube comes back bare while its neighbours are quoted.
+        $result = $this->fixture->convertToPHPValue('{(1),"(2, 3)",(4)}', $this->platform);
+
+        $expected = [
+            CubeValueObject::point(1.0),
+            CubeValueObject::point(2.0, 3.0),
+            CubeValueObject::point(4.0),
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    #[Test]
+    public function converts_null_item_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
+    #[Test]
+    public function converts_null_item_from_database_to_php_value(): void
+    {
+        $result = $this->fixture->convertToPHPValue('{NULL,"(1, 2)"}', $this->platform);
+
+        $this->assertEquals([null, CubeValueObject::point(1.0, 2.0)], $result);
+    }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidCubeArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(123);
+    }
+
+    #[Test]
+    public function throws_exception_when_invalid_cube_format_provided(): void
+    {
+        $this->expectException(InvalidCubeArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP('(invalid,cube)');
+    }
+
+    #[Test]
+    public function throws_exception_for_malformed_cube_strings_in_database(): void
+    {
+        $this->expectException(InvalidCubeArrayItemForPHPException::class);
+        $this->fixture->convertToPHPValue('{"(invalid,cube)"}', $this->platform);
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(string $postgresValue): void
+    {
+        $this->expectException(InvalidCubeArrayItemForPHPException::class);
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'unparsable item' => ['{invalid}'],
+            'empty item' => ['{""}'],
+            'non-numeric coordinates' => ['{"(abc, 1)"}'],
+            'multi-dimensional array' => ['{{"(1, 2)"},{"(3, 4)"}}'],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidCubeArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueTypes')]
+    #[Test]
+    public function throws_exception_for_non_string_inputs_to_database_conversion(mixed $value): void
+    {
+        $this->expectException(InvalidCubeArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($value, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidPHPValueTypes(): array
+    {
+        return [
+            'integer' => [123],
+            'object' => [new \stdClass()],
+            'boolean' => [true],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidCubeArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'array containing non-value-object items' => [[1, 2, 3]],
+            'array containing cube strings' => [['(1, 2)']],
+            'mixed array (valid and invalid)' => [
+                [
+                    CubeValueObject::point(1.0, 2.0),
+                    'invalid',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidCubeArrayItems')]
+    #[Test]
+    public function throws_exception_for_invalid_cube_array_items(array $invalidArray): void
+    {
+        $this->expectException(InvalidCubeArrayItemForDatabaseException::class);
+
+        $this->fixture->convertToDatabaseValue($invalidArray, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{array}>
+     */
+    public static function provideInvalidCubeArrayItems(): array
+    {
+        return [
+            'integer item' => [[123]],
+            'string item' => [['not-a-cube']],
+            'boolean item' => [[true]],
+            'object item' => [[new \stdClass()]],
+            'null item' => [[null]],
+            'mixed invalid items' => [[123, 'not-a-cube', true]],
+        ];
+    }
+
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'point' => [CubeValueObject::point(1.0, 2.0)],
+            'box' => [new CubeValueObject([1.0, 2.0], [3.0, 4.0])],
+            'one-dimensional point' => [CubeValueObject::point(42.0)],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'string cube format' => ['(1, 2)'],
+            'invalid string' => ['invalid'],
+            'integer' => [123],
+            'null' => [null],
+            'empty string' => [''],
+            'boolean' => [true],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CubeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CubeTest.php
@@ -126,7 +126,6 @@ final class CubeTest extends TestCase
             'empty parentheses' => ['()'],
             'invalid format' => ['not a cube'],
             'mismatched dimensions' => ['(1,2),(3)'],
-            'non-finite coordinate' => ['(NaN, 1)'],
             'integer input' => [123],
             'array input' => [[1, 2, 3]],
             'boolean input' => [false],

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CubeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CubeTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Cube;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCubeForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCubeForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Cube as CubeValueObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class CubeTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&Stub
+     */
+    private Stub $platform;
+
+    private Cube $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createStub(AbstractPlatform::class);
+        $this->fixture = new Cube();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('cube', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function converts_null_to_database_value(): void
+    {
+        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+    }
+
+    #[Test]
+    public function converts_null_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(CubeValueObject $cubeValueObject, string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($cubeValueObject, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(CubeValueObject $cubeValueObject, string $postgresValue): void
+    {
+        $this->assertEquals($cubeValueObject, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{cubeValueObject: CubeValueObject, postgresValue: string}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'point' => [
+                'cubeValueObject' => CubeValueObject::point(1.0, 2.0, 3.0),
+                'postgresValue' => '(1, 2, 3)',
+            ],
+            'box' => [
+                'cubeValueObject' => new CubeValueObject([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),
+                'postgresValue' => '(1, 2, 3),(4, 5, 6)',
+            ],
+            'one-dimensional point' => [
+                'cubeValueObject' => CubeValueObject::point(42.0),
+                'postgresValue' => '(42)',
+            ],
+            'negative coordinates' => [
+                'cubeValueObject' => new CubeValueObject([-1.5, -2.5], [-0.5, -0.25]),
+                'postgresValue' => '(-1.5, -2.5),(-0.5, -0.25)',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidCubeForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'string input' => ['(1, 2, 3)'],
+            'integer input' => [123],
+            'array input' => [[1, 2, 3]],
+            'boolean input' => [true],
+            'object input' => [new \stdClass()],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(mixed $databaseValue): void
+    {
+        $this->expectException(InvalidCubeForPHPException::class);
+        $this->fixture->convertToPHPValue($databaseValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'empty string' => [''],
+            'empty parentheses' => ['()'],
+            'invalid format' => ['not a cube'],
+            'mismatched dimensions' => ['(1,2),(3)'],
+            'non-finite coordinate' => ['(NaN, 1)'],
+            'integer input' => [123],
+            'array input' => [[1, 2, 3]],
+            'boolean input' => [false],
+            'object input' => [new \stdClass()],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/CubeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/CubeTest.php
@@ -67,6 +67,34 @@ final class CubeTest extends TestCase
                 'input' => '(1.0, 2.0)',
                 'expectedStringRepresentation' => '(1, 2)',
             ],
+            'NaN coordinate' => [
+                'input' => '(NaN)',
+                'expectedStringRepresentation' => '(NaN)',
+            ],
+            'positive infinity coordinate' => [
+                'input' => '(Infinity)',
+                'expectedStringRepresentation' => '(Infinity)',
+            ],
+            'negative infinity coordinate' => [
+                'input' => '(-Infinity)',
+                'expectedStringRepresentation' => '(-Infinity)',
+            ],
+            'lowercase non-finite spellings' => [
+                'input' => '(nan),(inf)',
+                'expectedStringRepresentation' => '(NaN),(Infinity)',
+            ],
+            'abbreviated negative infinity' => [
+                'input' => '(-inf)',
+                'expectedStringRepresentation' => '(-Infinity)',
+            ],
+            'explicitly signed infinity' => [
+                'input' => '(+Infinity)',
+                'expectedStringRepresentation' => '(Infinity)',
+            ],
+            'non-finite mixed with finite coordinates' => [
+                'input' => '(1, NaN),(3, Infinity)',
+                'expectedStringRepresentation' => '(1, NaN),(3, Infinity)',
+            ],
         ];
     }
 
@@ -138,6 +166,9 @@ final class CubeTest extends TestCase
             'very large coordinate' => [Cube::point(1.0E+300)],
             'very small coordinate' => [Cube::point(1.0E-10)],
             'high precision coordinate' => [Cube::point(0.12345678901234568, 1.0)],
+            // NaN is absent on purpose: it never equals itself, so it cannot be asserted by value equality.
+            // It is covered by does_not_collapse_a_box_of_equal_nan_corners() instead.
+            'infinite coordinates' => [new Cube([-\INF, 1.0], [\INF, 2.0])],
         ];
     }
 
@@ -162,8 +193,6 @@ final class CubeTest extends TestCase
             'non-numeric coordinate' => ['(a,b)'],
             'three corners' => ['(1,2),(3,4),(5,6)'],
             'not a cube' => ['not a cube'],
-            'NaN coordinate' => ['(NaN, 1)'],
-            'infinite coordinate' => ['(Infinity, 1)'],
             'wrong separator' => ['(1;2)'],
         ];
     }
@@ -184,24 +213,17 @@ final class CubeTest extends TestCase
         new Cube([1.0, 2.0], [3.0]);
     }
 
-    #[DataProvider('provideNonFiniteCoordinates')]
     #[Test]
-    public function throws_exception_for_non_finite_coordinates(float $coordinate): void
+    public function keeps_non_finite_coordinates_when_constructed_from_floats(): void
     {
-        $this->expectException(InvalidCubeException::class);
-
-        Cube::point($coordinate);
+        $this->assertSame('(NaN, Infinity, -Infinity)', (string) Cube::point(\NAN, \INF, -\INF));
     }
 
-    /**
-     * @return array<string, array{float}>
-     */
-    public static function provideNonFiniteCoordinates(): array
+    #[Test]
+    public function does_not_collapse_a_box_of_equal_nan_corners(): void
     {
-        return [
-            'NaN' => [NAN],
-            'positive infinity' => [INF],
-            'negative infinity' => [-INF],
-        ];
+        // NaN never equals itself, so PostgreSQL keeps this as a box while collapsing an infinite one to a point.
+        $this->assertSame('(NaN),(NaN)', (string) new Cube([\NAN], [\NAN]));
+        $this->assertSame('(Infinity)', (string) new Cube([\INF], [\INF]));
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/CubeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/CubeTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types\ValueObject;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Cube;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidCubeException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CubeTest extends TestCase
+{
+    #[DataProvider('provideFromStringTestCases')]
+    #[Test]
+    public function parses_from_string(string $input, string $expectedStringRepresentation): void
+    {
+        $cube = Cube::fromString($input);
+
+        $this->assertSame($expectedStringRepresentation, (string) $cube);
+    }
+
+    /**
+     * @return array<string, array{input: string, expectedStringRepresentation: string}>
+     */
+    public static function provideFromStringTestCases(): array
+    {
+        return [
+            'point' => [
+                'input' => '(1, 2, 3)',
+                'expectedStringRepresentation' => '(1, 2, 3)',
+            ],
+            'box' => [
+                'input' => '(1, 2, 3),(4, 5, 6)',
+                'expectedStringRepresentation' => '(1, 2, 3),(4, 5, 6)',
+            ],
+            'one-dimensional point' => [
+                'input' => '(1)',
+                'expectedStringRepresentation' => '(1)',
+            ],
+            'bare one-dimensional point' => [
+                'input' => '1',
+                'expectedStringRepresentation' => '(1)',
+            ],
+            'bare coordinate list' => [
+                'input' => '1,2,3',
+                'expectedStringRepresentation' => '(1, 2, 3)',
+            ],
+            'bracketed box' => [
+                'input' => '[(1,2),(3,4)]',
+                'expectedStringRepresentation' => '(1, 2),(3, 4)',
+            ],
+            'negative coordinates' => [
+                'input' => '(-1.5, -2.25)',
+                'expectedStringRepresentation' => '(-1.5, -2.25)',
+            ],
+            'exponent notation' => [
+                'input' => '(1e3, 2)',
+                'expectedStringRepresentation' => '(1000, 2)',
+            ],
+            'surrounding whitespace' => [
+                'input' => '  ( 1 , 2 ) ',
+                'expectedStringRepresentation' => '(1, 2)',
+            ],
+            'trailing zeroes' => [
+                'input' => '(1.0, 2.0)',
+                'expectedStringRepresentation' => '(1, 2)',
+            ],
+        ];
+    }
+
+    #[Test]
+    public function normalizes_zero_volume_box_to_point(): void
+    {
+        $cube = new Cube([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]);
+
+        $this->assertTrue($cube->isPoint());
+        $this->assertNull($cube->getSecondCorner());
+        $this->assertSame('(1, 2, 3)', (string) $cube);
+    }
+
+    #[Test]
+    public function preserves_corner_order(): void
+    {
+        $cube = new Cube([4.0, 5.0, 6.0], [1.0, 2.0, 3.0]);
+
+        $this->assertSame([4.0, 5.0, 6.0], $cube->getFirstCorner());
+        $this->assertSame([1.0, 2.0, 3.0], $cube->getSecondCorner());
+        $this->assertSame('(4, 5, 6),(1, 2, 3)', (string) $cube);
+    }
+
+    #[Test]
+    public function returns_correct_dimensions(): void
+    {
+        $this->assertSame(1, Cube::point(1.0)->getDimensions());
+        $this->assertSame(3, Cube::point(1.0, 2.0, 3.0)->getDimensions());
+        $this->assertSame(2, (new Cube([1.0, 2.0], [3.0, 4.0]))->getDimensions());
+    }
+
+    #[Test]
+    public function creates_point_from_variadic_coordinates(): void
+    {
+        $cube = Cube::point(1.0, 2.0, 3.0);
+
+        $this->assertTrue($cube->isPoint());
+        $this->assertSame('(1, 2, 3)', (string) $cube);
+    }
+
+    #[Test]
+    public function preserves_full_float_precision(): void
+    {
+        $coordinate = 0.12345678901234568;
+
+        $cube = Cube::point($coordinate);
+
+        $this->assertSame('(0.12345678901234568)', (string) $cube);
+        $this->assertSame([$coordinate], Cube::fromString((string) $cube)->getFirstCorner());
+    }
+
+    #[DataProvider('provideRoundtripTestCases')]
+    #[Test]
+    public function roundtrips_string_representation(Cube $cube): void
+    {
+        $this->assertEquals($cube, Cube::fromString((string) $cube));
+    }
+
+    /**
+     * @return array<string, array{Cube}>
+     */
+    public static function provideRoundtripTestCases(): array
+    {
+        return [
+            'point' => [Cube::point(1.0, 2.0, 3.0)],
+            'box' => [new Cube([1.0, 2.0], [3.0, 4.0])],
+            'one-dimensional point' => [Cube::point(42.0)],
+            'negative coordinates' => [new Cube([-1.5, -2.5], [-0.5, -0.25])],
+            'very large coordinate' => [Cube::point(1.0E+300)],
+            'very small coordinate' => [Cube::point(1.0E-10)],
+            'high precision coordinate' => [Cube::point(0.12345678901234568, 1.0)],
+        ];
+    }
+
+    #[DataProvider('provideInvalidStringRepresentations')]
+    #[Test]
+    public function throws_exception_for_invalid_string_representations(string $value): void
+    {
+        $this->expectException(InvalidCubeException::class);
+
+        Cube::fromString($value);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidStringRepresentations(): array
+    {
+        return [
+            'empty string' => [''],
+            'empty parentheses' => ['()'],
+            'unclosed parenthesis' => ['(1,2'],
+            'non-numeric coordinate' => ['(a,b)'],
+            'three corners' => ['(1,2),(3,4),(5,6)'],
+            'not a cube' => ['not a cube'],
+            'NaN coordinate' => ['(NaN, 1)'],
+            'infinite coordinate' => ['(Infinity, 1)'],
+            'wrong separator' => ['(1;2)'],
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_empty_coordinates(): void
+    {
+        $this->expectException(InvalidCubeException::class);
+
+        new Cube([]);
+    }
+
+    #[Test]
+    public function throws_exception_for_mismatched_dimensions(): void
+    {
+        $this->expectException(InvalidCubeException::class);
+
+        new Cube([1.0, 2.0], [3.0]);
+    }
+
+    #[DataProvider('provideNonFiniteCoordinates')]
+    #[Test]
+    public function throws_exception_for_non_finite_coordinates(float $coordinate): void
+    {
+        $this->expectException(InvalidCubeException::class);
+
+        Cube::point($coordinate);
+    }
+
+    /**
+     * @return array<string, array{float}>
+     */
+    public static function provideNonFiniteCoordinates(): array
+    {
+        return [
+            'NaN' => [NAN],
+            'positive infinity' => [INF],
+            'negative infinity' => [-INF],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/CubeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/CubeTest.php
@@ -214,6 +214,31 @@ final class CubeTest extends TestCase
     }
 
     #[Test]
+    public function accepts_the_maximum_number_of_dimensions(): void
+    {
+        $coordinates = \array_fill(0, 100, 1.0);
+
+        $this->assertSame(100, (new Cube($coordinates))->getDimensions());
+        $this->assertSame(100, Cube::fromString('('.\implode(',', $coordinates).')')->getDimensions());
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_dimensions(): void
+    {
+        $this->expectException(InvalidCubeException::class);
+
+        new Cube(\array_fill(0, 101, 1.0));
+    }
+
+    #[Test]
+    public function throws_exception_for_too_many_dimensions_when_parsed_from_string(): void
+    {
+        $this->expectException(InvalidCubeException::class);
+
+        Cube::fromString('('.\implode(',', \array_fill(0, 101, 1.0)).')');
+    }
+
+    #[Test]
     public function keeps_non_finite_coordinates_when_constructed_from_floats(): void
     {
         $this->assertSame('(NaN, Infinity, -Infinity)', (string) Cube::point(\NAN, \INF, -\INF));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PostgreSQL `cube` and `cube[]` support for Doctrine DBAL.
  - Added immutable cube values for points, boxes, multidimensional coordinates, and special numeric values.
  - Added conversion and validation between PHP and PostgreSQL representations.

- **Documentation**
  - Added usage and configuration guidance for available types and Doctrine, Laravel, and Symfony integrations.

- **Tests**
  - Added unit and integration coverage for cube values, arrays, conversions, validation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->