### PR TITLE
feat: add support for the `lquery` and `ltxtquery` data types and the `ltree` match operators

### DIFF
--- a/docs/AVAILABLE-FUNCTIONS-AND-OPERATORS.md
+++ b/docs/AVAILABLE-FUNCTIONS-AND-OPERATORS.md
@@ -165,6 +165,9 @@ Distance functions for fixed-dimension float vectors stored with the `vector` ty
 - `NLEVEL` - Get number of labels in path
 - `INDEX` - Find position of ltree in another ltree
 - `LCA` - Find longest common ancestor
+- `MATCHES_LQUERY` - Check whether a path matches an `lquery` pattern (`~`)
+- `MATCHES_ANY_LQUERY` - Check whether a path matches any `lquery` pattern in an array (`?`)
+- `MATCHES_LTXTQUERY` - Check whether a path matches an `ltxtquery` label query (`@`)
 
 **Vector Distance Operations:**
 - `L2_DISTANCE` - Euclidean distance between vectors

--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -104,8 +104,12 @@
 | hstore | hstore | `MartinGeorgiev\Doctrine\DBAL\Types\Hstore` (see [note](#hstore-type)) |
 | hstore[] | _hstore | `MartinGeorgiev\Doctrine\DBAL\Types\HstoreArray` |
 |---|---|---|
+| lquery | lquery | `MartinGeorgiev\Doctrine\DBAL\Types\Lquery` |
+| lquery[] | _lquery | `MartinGeorgiev\Doctrine\DBAL\Types\LqueryArray` |
 | ltree | ltree | `MartinGeorgiev\Doctrine\DBAL\Types\Ltree` |
 | ltree[] | _ltree | `MartinGeorgiev\Doctrine\DBAL\Types\LtreeArray` |
+| ltxtquery | ltxtquery | `MartinGeorgiev\Doctrine\DBAL\Types\Ltxtquery` |
+| ltxtquery[] | _ltxtquery | `MartinGeorgiev\Doctrine\DBAL\Types\LtxtqueryArray` |
 |---|---|---|
 | money | money | `MartinGeorgiev\Doctrine\DBAL\Types\Money` (see [note](#money-type)) |
 | money[] | _money | `MartinGeorgiev\Doctrine\DBAL\Types\MoneyArray` |

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -135,8 +135,12 @@ Type::addType('hstore', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Hstore");
 Type::addType('hstore[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\HstoreArray");
 
 // Hierarchical types
+Type::addType('lquery', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Lquery");
+Type::addType('lquery[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\LqueryArray");
 Type::addType('ltree', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Ltree");
 Type::addType('ltree[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\LtreeArray");
+Type::addType('ltxtquery', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Ltxtquery");
+Type::addType('ltxtquery[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\LtxtqueryArray");
 
 // XML types
 Type::addType('xml', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Xml");
@@ -389,6 +393,11 @@ $configuration->addCustomStringFunction('DISTANCE', MartinGeorgiev\Doctrine\ORM\
 $configuration->addCustomStringFunction('COSINE_DISTANCE', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Vector\CosineDistance::class);
 $configuration->addCustomStringFunction('INNER_PRODUCT', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Vector\InnerProduct::class);
 $configuration->addCustomStringFunction('L2_DISTANCE', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Vector\L2Distance::class);
+
+# ltree match operators
+$configuration->addCustomStringFunction('MATCHES_LQUERY', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLquery::class); # ~
+$configuration->addCustomStringFunction('MATCHES_LTXTQUERY', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLtxtquery::class); # @
+$configuration->addCustomStringFunction('MATCHES_ANY_LQUERY', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesAnyLquery::class); # ?
 
 # hstore functions
 $configuration->addCustomStringFunction('HSTORE_AKEYS', MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Hstore\Akeys::class);
@@ -648,9 +657,15 @@ $platform->registerDoctrineTypeMapping('hstore[]', 'hstore[]');
 $platform->registerDoctrineTypeMapping('_hstore', 'hstore[]');
 
 // Hierarchical mappings
+$platform->registerDoctrineTypeMapping('lquery', 'lquery');
+$platform->registerDoctrineTypeMapping('lquery[]', 'lquery[]');
+$platform->registerDoctrineTypeMapping('_lquery', 'lquery[]');
 $platform->registerDoctrineTypeMapping('ltree','ltree');
 $platform->registerDoctrineTypeMapping('ltree[]', 'ltree[]');
 $platform->registerDoctrineTypeMapping('_ltree', 'ltree[]');
+$platform->registerDoctrineTypeMapping('ltxtquery', 'ltxtquery');
+$platform->registerDoctrineTypeMapping('ltxtquery[]', 'ltxtquery[]');
+$platform->registerDoctrineTypeMapping('_ltxtquery', 'ltxtquery[]');
 
 // XML mappings
 $platform->registerDoctrineTypeMapping('xml', 'xml');

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -210,9 +210,15 @@ return [
                 '_hstore' => 'hstore[]',
 
                 // Hierarchical type mappings
+                'lquery' => 'lquery',
+                'lquery[]' => 'lquery[]',
+                '_lquery' => 'lquery[]',
                 'ltree' => 'ltree',
                 'ltree[]' => 'ltree[]',
                 '_ltree' => 'ltree[]',
+                'ltxtquery' => 'ltxtquery',
+                'ltxtquery[]' => 'ltxtquery[]',
+                '_ltxtquery' => 'ltxtquery[]',
 
                 // XML type mappings
                 'xml' => 'xml',
@@ -354,8 +360,12 @@ return [
         'hstore[]' => MartinGeorgiev\Doctrine\DBAL\Types\HstoreArray::class,
 
         // Hierarchical types
+        'lquery' => MartinGeorgiev\Doctrine\DBAL\Types\Lquery::class,
+        'lquery[]' => MartinGeorgiev\Doctrine\DBAL\Types\LqueryArray::class,
         'ltree' => MartinGeorgiev\Doctrine\DBAL\Types\Ltree::class,
         'ltree[]' => MartinGeorgiev\Doctrine\DBAL\Types\LtreeArray::class,
+        'ltxtquery' => MartinGeorgiev\Doctrine\DBAL\Types\Ltxtquery::class,
+        'ltxtquery[]' => MartinGeorgiev\Doctrine\DBAL\Types\LtxtqueryArray::class,
 
         // XML types
         'xml' => MartinGeorgiev\Doctrine\DBAL\Types\Xml::class,
@@ -611,6 +621,11 @@ return [
         'COSINE_DISTANCE' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Vector\CosineDistance::class,
         'INNER_PRODUCT' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Vector\InnerProduct::class,
         'L2_DISTANCE' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Vector\L2Distance::class,
+
+        # ltree match operators
+        'MATCHES_LQUERY' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLquery::class, # ~
+        'MATCHES_LTXTQUERY' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLtxtquery::class, # @
+        'MATCHES_ANY_LQUERY' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesAnyLquery::class, # ?
 
         # hstore functions
         'HSTORE_AKEYS' => MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Hstore\Akeys::class,

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -135,8 +135,12 @@ doctrine:
             'hstore[]': MartinGeorgiev\Doctrine\DBAL\Types\HstoreArray
 
             # Hierarchical types
+            lquery: MartinGeorgiev\Doctrine\DBAL\Types\Lquery
+            'lquery[]': MartinGeorgiev\Doctrine\DBAL\Types\LqueryArray
             ltree: MartinGeorgiev\Doctrine\DBAL\Types\Ltree
             'ltree[]': MartinGeorgiev\Doctrine\DBAL\Types\LtreeArray
+            ltxtquery: MartinGeorgiev\Doctrine\DBAL\Types\Ltxtquery
+            'ltxtquery[]': MartinGeorgiev\Doctrine\DBAL\Types\LtxtqueryArray
 
             # XML types
             xml: MartinGeorgiev\Doctrine\DBAL\Types\Xml
@@ -340,9 +344,15 @@ doctrine:
                     _hstore: !php/const MartinGeorgiev\Doctrine\DBAL\Type::HSTORE_ARRAY
 
                     # Hierarchical type mappings
+                    lquery: !php/const MartinGeorgiev\Doctrine\DBAL\Type::LQUERY
+                    'lquery[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::LQUERY_ARRAY
+                    _lquery: !php/const MartinGeorgiev\Doctrine\DBAL\Type::LQUERY_ARRAY
                     ltree: !php/const MartinGeorgiev\Doctrine\DBAL\Type::LTREE
                     'ltree[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::LTREE_ARRAY
                     _ltree: !php/const MartinGeorgiev\Doctrine\DBAL\Type::LTREE_ARRAY
+                    ltxtquery: !php/const MartinGeorgiev\Doctrine\DBAL\Type::LTXTQUERY
+                    'ltxtquery[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::LTXTQUERY_ARRAY
+                    _ltxtquery: !php/const MartinGeorgiev\Doctrine\DBAL\Type::LTXTQUERY_ARRAY
 
                     # XML type mappings
                     xml: !php/const MartinGeorgiev\Doctrine\DBAL\Type::XML
@@ -592,6 +602,11 @@ doctrine:
                         COSINE_DISTANCE: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Vector\CosineDistance
                         INNER_PRODUCT: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Vector\InnerProduct
                         L2_DISTANCE: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Vector\L2Distance
+
+                        # ltree match operators
+                        MATCHES_LQUERY: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLquery # ~
+                        MATCHES_LTXTQUERY: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLtxtquery # @
+                        MATCHES_ANY_LQUERY: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesAnyLquery # ?
 
                         # hstore functions
                         HSTORE_AKEYS: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Hstore\Akeys

--- a/docs/LTREE-TYPE.md
+++ b/docs/LTREE-TYPE.md
@@ -1,6 +1,6 @@
 # PostgreSQL ltree Types
 
-PostgreSQL's `ltree` extension stores hierarchical label-tree paths (e.g. `Top.Sports.Football`) and supports ancestor/descendant queries with GiST/GIN indexes.
+PostgreSQL's `ltree` extension stores hierarchical label-tree paths (e.g. `Top.Sports.Football`) and supports ancestor/descendant queries with GiST/GIN indexes. It also ships two companion query types — `lquery` for path patterns and `ltxtquery` for full-text style label queries.
 
 > 📖 **See also**: [Available Types](AVAILABLE-TYPES.md) | [Ltree Functions and Operators](AVAILABLE-FUNCTIONS-AND-OPERATORS.md#-ltree-functions) | [Hierarchical Data with `ltree`](USE-CASES-AND-EXAMPLES.md#hierarchical-data-with-ltree)
 
@@ -22,11 +22,19 @@ $this->addSql('CREATE EXTENSION IF NOT EXISTS ltree');
 
 ```php
 use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Lquery;
+use MartinGeorgiev\Doctrine\DBAL\Types\LqueryArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Ltree;
 use MartinGeorgiev\Doctrine\DBAL\Types\LtreeArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Ltxtquery;
+use MartinGeorgiev\Doctrine\DBAL\Types\LtxtqueryArray;
 
+Type::addType(Type::LQUERY, Lquery::class);
+Type::addType(Type::LQUERY_ARRAY, LqueryArray::class);
 Type::addType(Type::LTREE, Ltree::class);
 Type::addType(Type::LTREE_ARRAY, LtreeArray::class);
+Type::addType(Type::LTXTQUERY, Ltxtquery::class);
+Type::addType(Type::LTXTQUERY_ARRAY, LtxtqueryArray::class);
 ```
 
 ## ltree
@@ -85,6 +93,77 @@ $article->tags = [
     Ltree::fromString('Top.Sports.Basketball'),
 ];
 ```
+
+## lquery
+
+Stores a path-matching pattern for `ltree` values. Maps to `string` in PHP.
+
+```php
+use Doctrine\ORM\Mapping as ORM;
+use MartinGeorgiev\Doctrine\DBAL\Type;
+
+#[ORM\Entity]
+class SavedFilter
+{
+    #[ORM\Column(type: Type::LQUERY)]
+    private string $pattern;
+}
+
+$filter->pattern = 'Top.*{1,2}.sport@*.!football|tennis';
+```
+
+Pattern syntax, as accepted by PostgreSQL:
+
+| Element | Meaning |
+|---------|---------|
+| `Top` | Matches the label `Top` exactly |
+| `*` | Matches any sequence of labels |
+| `*{1,2}` | Matches 1 to 2 labels; `*{2}`, `*{2,}` and `*{,2}` are also valid |
+| `a\|b` | Matches label `a` or label `b` |
+| `!a\|b` | Matches any label that is neither `a` nor `b` |
+| `a{1,2}` | Quantifiers also apply to non-star items |
+| `a@` | Case-insensitive match |
+| `a*` | Prefix match |
+| `a%` | Match against a `_`-separated word inside the label |
+
+🗃️ PostgreSQL normalises the modifier order on storage, so `sport*@` is read back as `sport@*`.
+
+## lquery[]
+
+Stores an array of `lquery` patterns. Maps to `array<string>` in PHP. Null elements are supported.
+The array form is what the `MATCHES_ANY_LQUERY` operator consumes.
+
+```php
+$filter->patterns = ['Top.*', '!football|tennis'];
+```
+
+## ltxtquery
+
+Stores a full-text style query over the labels of an `ltree` value. Maps to `string` in PHP.
+
+```php
+use Doctrine\ORM\Mapping as ORM;
+use MartinGeorgiev\Doctrine\DBAL\Type;
+
+#[ORM\Entity]
+class SavedFilter
+{
+    #[ORM\Column(type: Type::LTXTQUERY)]
+    private string $query;
+}
+
+$filter->query = 'Earth & Moon@* & !Transportation';
+```
+
+Words are combined with `&` (and), `|` (or) and `!` (not), and may be grouped with parentheses.
+Each word accepts the same `@`, `*` and `%` modifiers as `lquery` labels.
+
+🗃️ PostgreSQL normalizes operator spacing on storage, so `Earth&Moon` is read back as `Earth & Moon`.
+
+## ltxtquery[]
+
+Stores an array of `ltxtquery` queries. Maps to `array<string>` in PHP. Null elements are supported.
+No PostgreSQL operator consumes this type — it is provided so that collections of saved queries can be persisted in a single column.
 
 ## Label-tree Functions
 
@@ -170,6 +249,40 @@ Casts ltree to text.
 $dql = "SELECT LTREE2TEXT(e.path) FROM Entity e";
 ```
 
+### Match Operators
+
+| PostgreSQL operator | DQL function | Implementation |
+|---------------------|--------------|----------------|
+| `ltree ~ lquery` | `MATCHES_LQUERY` | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLquery` |
+| `ltree ? lquery[]` | `MATCHES_ANY_LQUERY` | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesAnyLquery` |
+| `ltree @ ltxtquery` | `MATCHES_LTXTQUERY` | `MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLtxtquery` |
+
+All three return a boolean and must be compared with `= TRUE` or `= FALSE` when used in a DQL `WHERE` clause.
+The pattern argument is cast to `lquery` / `ltxtquery` in the generated SQL, so plain DQL string literals and bound parameters work without any further ceremony.
+
+#### `MATCHES_LQUERY(ltree, lquery)`
+Checks whether the path matches a single `lquery` pattern.
+
+```php
+$dql = "SELECT e FROM Entity e WHERE MATCHES_LQUERY(e.path, 'Top.*{1,2}.Football') = TRUE";
+// 'Top.Sports.Football' ~ 'Top.*{1,2}.Football' → true
+```
+
+#### `MATCHES_ANY_LQUERY(ltree, lquery[])`
+Checks whether the path matches any pattern in an array of `lquery` patterns.
+
+```php
+$dql = "SELECT e FROM Entity e WHERE MATCHES_ANY_LQUERY(e.path, ARRAY('Top.Sports.*', 'Top.Culture.*')) = TRUE";
+```
+
+#### `MATCHES_LTXTQUERY(ltree, ltxtquery)`
+Checks whether the labels of the path satisfy an `ltxtquery`.
+
+```php
+$dql = "SELECT e FROM Entity e WHERE MATCHES_LTXTQUERY(e.path, 'Sports & !Football') = TRUE";
+// 'Top.Sports.Basketball' @ 'Sports & !Football' → true
+```
+
 ### DQL Examples
 
 ```php
@@ -187,11 +300,20 @@ $dql = "SELECT SUBPATH(e.path, 0, NLEVEL(e.path) - 1) FROM Entity e";
 
 // Longest common ancestor of two entities
 $dql = "SELECT LCA(e1.path, e2.path) FROM Entity e1, Entity e2 WHERE e1.id = 1 AND e2.id = 2";
+
+// Everything under Top.Sports, at most two levels deep
+$dql = "SELECT e FROM Entity e WHERE MATCHES_LQUERY(e.path, 'Top.Sports.*{1,2}') = TRUE";
+
+// Paths mentioning Sports but not Football
+$dql = "SELECT e FROM Entity e WHERE MATCHES_LTXTQUERY(e.path, 'Sports & !Football') = TRUE";
+
+// Pattern supplied as a bound parameter
+$dql = "SELECT e FROM Entity e WHERE MATCHES_LQUERY(e.path, :pattern) = TRUE";
 ```
 
 ### Performance
 
 - Use GiST or GIN indexes on `ltree` columns
-- `<@` and `@>` operators use those indexes automatically
+- `<@` and `@>` operators use those indexes automatically, as do the `~`, `?` and `@` match operators
 - `SUBPATH` with negative offsets is efficient for parent extraction
 - `LCA` is well-suited for finding shared ancestors in hierarchical queries

--- a/docs/LTREE-TYPE.md
+++ b/docs/LTREE-TYPE.md
@@ -1,6 +1,6 @@
 # PostgreSQL ltree Types
 
-PostgreSQL's `ltree` extension stores hierarchical label-tree paths (e.g. `Top.Sports.Football`) and supports ancestor/descendant queries with GiST/GIN indexes. It also ships two companion query types — `lquery` for path patterns and `ltxtquery` for full-text style label queries.
+PostgreSQL's `ltree` extension stores hierarchical label-tree paths (e.g. `Top.Sports.Football`) and supports ancestor/descendant queries with GiST indexes. It also ships two companion query types — `lquery` for path patterns and `ltxtquery` for full-text style label queries.
 
 > 📖 **See also**: [Available Types](AVAILABLE-TYPES.md) | [Ltree Functions and Operators](AVAILABLE-FUNCTIONS-AND-OPERATORS.md#-ltree-functions) | [Hierarchical Data with `ltree`](USE-CASES-AND-EXAMPLES.md#hierarchical-data-with-ltree)
 
@@ -63,12 +63,10 @@ $path->getParent();                                     // Top.Sports
 $path->withLeaf('UEFA');                                // Top.Sports.Football.UEFA
 ```
 
-🗃️ Doctrine can't define GiST or GIN indexes with the required ltree operator classes. Create the index manually in a migration:
+🗃️ Doctrine can't define GiST indexes with the required ltree operator classes. Create the index manually in a migration:
 
 ```sql
 CREATE INDEX category_path_gist_idx ON category USING GIST (path gist_ltree_ops(siglen=100));
--- or
-CREATE INDEX category_path_gin_idx ON category USING GIN (path gin_ltree_ops);
 ```
 
 ## ltree[]
@@ -313,7 +311,7 @@ $dql = "SELECT e FROM Entity e WHERE MATCHES_LQUERY(e.path, :pattern) = TRUE";
 
 ### Performance
 
-- Use GiST or GIN indexes on `ltree` columns
+- Use GiST indexes on `ltree` columns
 - `<@` and `@>` operators use those indexes automatically, as do the `~`, `?` and `@` match operators
 - `SUBPATH` with negative offsets is efficient for parent extraction
 - `LCA` is well-suited for finding shared ancestors in hierarchical queries

--- a/src/MartinGeorgiev/Doctrine/DBAL/Type.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Type.php
@@ -264,12 +264,32 @@ final class Type
     /**
      * @var string
      */
+    public const LQUERY = 'lquery';
+
+    /**
+     * @var string
+     */
+    public const LQUERY_ARRAY = 'lquery[]';
+
+    /**
+     * @var string
+     */
     public const LTREE = 'ltree';
 
     /**
      * @var string
      */
     public const LTREE_ARRAY = 'ltree[]';
+
+    /**
+     * @var string
+     */
+    public const LTXTQUERY = 'ltxtquery';
+
+    /**
+     * @var string
+     */
+    public const LTXTQUERY_ARRAY = 'ltxtquery[]';
 
     /**
      * @var string

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLqueryArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLqueryArrayItemForDatabaseException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidLqueryArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be lquery strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid lquery format in array: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLqueryArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLqueryArrayItemForPHPException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidLqueryArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be lquery strings, %s given', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLqueryForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLqueryForDatabaseException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidLqueryForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Value must be an lquery string, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid lquery format: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLqueryForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLqueryForPHPException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidLqueryForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Database value must be an lquery string, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLtxtqueryArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLtxtqueryArrayItemForDatabaseException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidLtxtqueryArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be ltxtquery strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid ltxtquery format in array: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLtxtqueryArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLtxtqueryArrayItemForPHPException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidLtxtqueryArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be ltxtquery strings, %s given', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLtxtqueryForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLtxtqueryForDatabaseException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidLtxtqueryForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Value must be an ltxtquery string, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid ltxtquery format: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLtxtqueryForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLtxtqueryForPHPException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidLtxtqueryForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Database value must be an ltxtquery string, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Lquery.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Lquery.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLqueryForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLqueryForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\LqueryValidationTrait;
+
+/**
+ * Implementation of PostgreSQL lquery data type.
+ *
+ * Path-matching pattern for ltree values, supporting `*` wildcards with `{n,m}` quantifiers,
+ * `|` alternatives, `!` negation and the `@`, `*` and `%` label modifiers.
+ * Requires the ltree extension.
+ *
+ * @see https://www.postgresql.org/docs/18/ltree.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class Lquery extends BaseType
+{
+    use LqueryValidationTrait;
+
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::LQUERY;
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidLqueryForDatabaseException::forInvalidType($value);
+        }
+
+        if (!$this->isValidLquery($value)) {
+            throw InvalidLqueryForDatabaseException::forInvalidFormat($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Format is deliberately not re-validated here. PostgreSQL already accepted and normalised
+     * the stored pattern, so a value coming back from the database is authoritative; applying the
+     * approximating pattern of the validation trait on read could make stored rows unreadable.
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidLqueryForPHPException::forInvalidType($value);
+        }
+
+        return $value;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/LqueryArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/LqueryArray.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLqueryArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLqueryArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\LqueryValidationTrait;
+
+/**
+ * Implementation of PostgreSQL lquery[] data type.
+ *
+ * @see https://www.postgresql.org/docs/18/ltree.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class LqueryArray extends BaseStringArray
+{
+    use LqueryValidationTrait;
+
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::LQUERY_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        if ($item === null) {
+            return true;
+        }
+
+        if (!\is_string($item)) {
+            return false;
+        }
+
+        return $this->isValidLquery($item);
+    }
+
+    protected function createInvalidTypeExceptionForPHP(mixed $item): InvalidLqueryArrayItemForPHPException
+    {
+        return InvalidLqueryArrayItemForPHPException::forInvalidType($item);
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidLqueryArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw \is_string($item)
+            ? InvalidLqueryArrayItemForDatabaseException::forInvalidFormat($item)
+            : InvalidLqueryArrayItemForDatabaseException::forInvalidType($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Ltxtquery.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Ltxtquery.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLtxtqueryForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLtxtqueryForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\LtxtqueryValidationTrait;
+
+/**
+ * Implementation of PostgreSQL ltxtquery data type.
+ *
+ * Full-text style query over the labels of an ltree value, combining words with `&`, `|`, `!`
+ * and parentheses, where each word may carry the `@`, `*` and `%` modifiers.
+ * Requires the ltree extension.
+ *
+ * @see https://www.postgresql.org/docs/18/ltree.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class Ltxtquery extends BaseType
+{
+    use LtxtqueryValidationTrait;
+
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::LTXTQUERY;
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidLtxtqueryForDatabaseException::forInvalidType($value);
+        }
+
+        if (!$this->isValidLtxtquery($value)) {
+            throw InvalidLtxtqueryForDatabaseException::forInvalidFormat($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Format is deliberately not re-validated here. PostgreSQL already accepted and normalised
+     * the stored query, so a value coming back from the database is authoritative; applying the
+     * approximating pattern of the validation trait on read could make stored rows unreadable.
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidLtxtqueryForPHPException::forInvalidType($value);
+        }
+
+        return $value;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryArray.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLtxtqueryArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLtxtqueryArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\LtxtqueryValidationTrait;
+
+/**
+ * Implementation of PostgreSQL ltxtquery[] data type.
+ *
+ * @see https://www.postgresql.org/docs/18/ltree.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class LtxtqueryArray extends BaseStringArray
+{
+    use LtxtqueryValidationTrait;
+
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::LTXTQUERY_ARRAY;
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        if ($item === null) {
+            return true;
+        }
+
+        if (!\is_string($item)) {
+            return false;
+        }
+
+        return $this->isValidLtxtquery($item);
+    }
+
+    protected function createInvalidTypeExceptionForPHP(mixed $item): InvalidLtxtqueryArrayItemForPHPException
+    {
+        return InvalidLtxtqueryArrayItemForPHPException::forInvalidType($item);
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidLtxtqueryArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw \is_string($item)
+            ? InvalidLtxtqueryArrayItemForDatabaseException::forInvalidFormat($item)
+            : InvalidLtxtqueryArrayItemForDatabaseException::forInvalidType($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LqueryValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LqueryValidationTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Traits;
+
+/**
+ * Common validation logic for lquery path-matching patterns.
+ *
+ * @since 4.8
+ */
+trait LqueryValidationTrait
+{
+    /**
+     * A single lquery item: either a star (optionally quantified) or a group of
+     * alternative labels with trailing modifiers, optionally negated and quantified.
+     *
+     * @var string
+     */
+    private const LQUERY_ITEM = '(?:\*|!?[\p{L}\p{N}_-]+[@*%]*(?:\|[\p{L}\p{N}_-]+[@*%]*)*)(?:\{(?:\d+|\d*,\d*)\})?';
+
+    /**
+     * @var string
+     */
+    private const LQUERY_PATTERN = '/^'.self::LQUERY_ITEM.'(?:\.'.self::LQUERY_ITEM.')*$/u';
+
+    /**
+     * Deliberately permissive: it accepts every pattern PostgreSQL accepts and rejects the
+     * structurally broken ones, but it does not enforce semantic constraints such as
+     * {n,m} requiring n <= m. PostgreSQL stays the authority on those.
+     */
+    protected function isValidLquery(string $value): bool
+    {
+        return \preg_match(self::LQUERY_PATTERN, $value) === 1;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LqueryValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LqueryValidationTrait.php
@@ -22,7 +22,8 @@ trait LqueryValidationTrait
     /**
      * @var string
      */
-    private const LQUERY_PATTERN = '/^'.self::LQUERY_ITEM.'(?:\.'.self::LQUERY_ITEM.')*$/u';
+    // Anchored with \z rather than $, which would also match before a trailing newline.
+    private const LQUERY_PATTERN = '/^'.self::LQUERY_ITEM.'(?:\.'.self::LQUERY_ITEM.')*\z/u';
 
     /**
      * Deliberately permissive: it accepts every pattern PostgreSQL accepts and rejects the

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LtxtqueryValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LtxtqueryValidationTrait.php
@@ -22,7 +22,7 @@ trait LtxtqueryValidationTrait
         .'(?<word>[\p{L}\p{N}_-]+[@*%]*)'
         .'(?<term>(?:! *)*(?:(?&word)|\( *(?&expr) *\)))'
         .'(?<expr>(?&term)(?: *[&|] *(?&term))*)'
-        .') *(?&expr) *$/u';
+        .') *(?&expr) *\z/u';
 
     protected function isValidLtxtquery(string $value): bool
     {

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LtxtqueryValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LtxtqueryValidationTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Traits;
+
+/**
+ * Common validation logic for ltxtquery full-text label queries.
+ *
+ * @since 4.8
+ */
+trait LtxtqueryValidationTrait
+{
+    /**
+     * Recursive grammar: a word with trailing modifiers, `!` negation, `&`/`|` operators
+     * and parenthesised sub-expressions. Only the space character separates tokens —
+     * PostgreSQL rejects tabs and newlines inside an ltxtquery.
+     *
+     * @var string
+     */
+    private const LTXTQUERY_PATTERN = '/^(?(DEFINE)'
+        .'(?<word>[\p{L}\p{N}_-]+[@*%]*)'
+        .'(?<term>(?:! *)*(?:(?&word)|\( *(?&expr) *\)))'
+        .'(?<expr>(?&term)(?: *[&|] *(?&term))*)'
+        .') *(?&expr) *$/u';
+
+    protected function isValidLtxtquery(string $value): bool
+    {
+        return \preg_match(self::LTXTQUERY_PATTERN, $value) === 1;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesAnyLquery.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesAnyLquery.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostgreSQL ltree ? operator.
+ *
+ * Checks whether an ltree path matches any lquery pattern in an array of patterns.
+ *
+ * @see https://www.postgresql.org/docs/18/ltree.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE MATCHES_ANY_LQUERY(e.path, ARR('Top.*', 'A.*')) = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" when used in WHERE clause in DQL.
+ */
+class MatchesAnyLquery extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        // ARRAY[...] of untyped literals resolves to text[], for which no ? operator against ltree
+        // exists. The cast target propagates into the constructor and coerces the elements to lquery.
+        // The doubled ? escapes the PDO placeholder parser.
+        $this->setFunctionPrototype('(%s ?? CAST(%s AS lquery[]))');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLquery.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLquery.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostgreSQL ltree ~ operator.
+ *
+ * Checks whether an ltree path matches an lquery path pattern.
+ *
+ * @see https://www.postgresql.org/docs/18/ltree.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE MATCHES_LQUERY(e.path, 'Top.*{0,2}.sport*@') = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" when used in WHERE clause in DQL.
+ */
+class MatchesLquery extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        // The second argument is cast explicitly so that plain DQL string literals and parameters
+        // resolve to lquery instead of text, which has its own, unrelated ~ regular-expression operator.
+        $this->setFunctionPrototype('(%s ~ CAST(%s AS lquery))');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLtxtquery.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLtxtquery.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseFunction;
+
+/**
+ * Implementation of PostgreSQL ltree @ operator.
+ *
+ * Checks whether an ltree path matches an ltxtquery full-text label query.
+ *
+ * @see https://www.postgresql.org/docs/18/ltree.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ *
+ * @example Using it in DQL with boolean comparison: "WHERE MATCHES_LTXTQUERY(e.path, 'Top & !Child2') = TRUE"
+ * Returns boolean, must be used with "= TRUE" or "= FALSE" when used in WHERE clause in DQL.
+ */
+class MatchesLtxtquery extends BaseFunction
+{
+    protected function customizeFunction(): void
+    {
+        // The second argument is cast explicitly so that plain DQL string literals and parameters
+        // resolve to ltxtquery instead of text, for which no @ operator against ltree exists.
+        $this->setFunctionPrototype('(%s @ CAST(%s AS ltxtquery))');
+        $this->addNodeMapping('StringPrimary');
+        $this->addNodeMapping('StringPrimary');
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LqueryArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LqueryArrayTypeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLqueryArrayItemForDatabaseException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class LqueryArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensurePostgresExtensionInSchema('ltree');
+    }
+
+    protected function getTypeName(): string
+    {
+        return 'lquery[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, string|null>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'single pattern' => [['Top.*']],
+            'multiple patterns' => [['Top.*', '!football|tennis', '*{1,2}']],
+            'pattern with a quantifier comma' => [['a.*{1,2}']],
+            'array with null item' => [['Top.*', null, '*']],
+        ];
+    }
+
+    #[DataProvider('provideInvalidItems')]
+    #[Test]
+    public function rejects_invalid_item(mixed $value): void
+    {
+        $this->expectException(InvalidLqueryArrayItemForDatabaseException::class);
+
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, [$value]);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidItems(): array
+    {
+        return [
+            'empty string' => [''],
+            'consecutive dots' => ['Top..Child'],
+            'integer value' => [123],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LqueryTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LqueryTypeTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLqueryForDatabaseException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class LqueryTypeTest extends ScalarTypeTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensurePostgresExtensionInSchema('ltree');
+    }
+
+    protected function getTypeName(): string
+    {
+        return 'lquery';
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function roundtrips_value(string $testValue): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $testValue);
+    }
+
+    /**
+     * Values are given in the form PostgreSQL stores them, so that the round-trip is stable.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'single label' => ['Top'],
+            'label followed by star' => ['Top.*'],
+            'star only' => ['*'],
+            'quantified star' => ['*{1,2}'],
+            'open-ended quantified star' => ['*{,2}'],
+            'quantified label' => ['tennis{1,}'],
+            'negated alternatives' => ['!football|tennis'],
+            'label modifiers' => ['foo%@*'],
+            'hyphenated and underscored labels' => ['a-b.c_d'],
+            'numeric labels' => ['1.2.3'],
+            'full featured pattern' => ['Top.*{1,2}.sport@*.!football|tennis'],
+        ];
+    }
+
+    #[Test]
+    public function normalizes_modifier_order(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTripExpectingDifferentRetrievedValue($typeName, $columnType, 'sport*@', 'sport@*');
+    }
+
+    #[DataProvider('provideInvalidValues')]
+    #[Test]
+    public function rejects_invalid_value(mixed $value): void
+    {
+        $this->expectException(InvalidLqueryForDatabaseException::class);
+
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $value);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidValues(): array
+    {
+        return [
+            'empty string' => [''],
+            'consecutive dots' => ['Top..Child'],
+            'negated star' => ['!*'],
+            'non-string value' => [42],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryArrayTypeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLtxtqueryArrayItemForDatabaseException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class LtxtqueryArrayTypeTest extends ArrayTypeTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensurePostgresExtensionInSchema('ltree');
+    }
+
+    protected function getTypeName(): string
+    {
+        return 'ltxtquery[]';
+    }
+
+    /**
+     * @return array<string, array{array<int, string|null>}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'single query' => [['Earth & Moon']],
+            'multiple queries' => [['Earth & Moon', '!Transportation', '( a | b ) & c']],
+            'array with null item' => [['Earth', null, '!Asia']],
+        ];
+    }
+
+    #[DataProvider('provideInvalidItems')]
+    #[Test]
+    public function rejects_invalid_item(mixed $value): void
+    {
+        $this->expectException(InvalidLtxtqueryArrayItemForDatabaseException::class);
+
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, [$value]);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidItems(): array
+    {
+        return [
+            'empty string' => [''],
+            'dotted path' => ['a.b'],
+            'integer value' => [123],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryTypeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLtxtqueryForDatabaseException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class LtxtqueryTypeTest extends ScalarTypeTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensurePostgresExtensionInSchema('ltree');
+    }
+
+    protected function getTypeName(): string
+    {
+        return 'ltxtquery';
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function roundtrips_value(string $testValue): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $testValue);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'single word' => ['Earth'],
+            'conjunction' => ['Earth & Moon'],
+            'disjunction' => ['Earth | Mars'],
+            'negation' => ['!Transportation'],
+            'parenthesised expression' => ['( a | b ) & c'],
+            'word modifiers' => ['Moon%@*'],
+            'full featured query' => ['Earth & Moon@* & !Transportation'],
+            'hyphenated and underscored words' => ['a-b & c_d'],
+        ];
+    }
+
+    #[Test]
+    public function normalizes_operator_spacing(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTripExpectingDifferentRetrievedValue($typeName, $columnType, 'Earth&Moon', 'Earth & Moon');
+    }
+
+    #[DataProvider('provideInvalidValues')]
+    #[Test]
+    public function rejects_invalid_value(mixed $value): void
+    {
+        $this->expectException(InvalidLtxtqueryForDatabaseException::class);
+
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $value);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidValues(): array
+    {
+        return [
+            'empty string' => [''],
+            'dotted path' => ['a.b'],
+            'unbalanced parenthesis' => ['(a'],
+            'non-string value' => [42],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesAnyLqueryTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesAnyLqueryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Arr;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesAnyLquery;
+use PHPUnit\Framework\Attributes\Test;
+
+final class MatchesAnyLqueryTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'MATCHES_ANY_LQUERY' => MatchesAnyLquery::class,
+            'ARR' => Arr::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_true_when_path_matches_one_of_the_patterns(): void
+    {
+        $dql = "SELECT l.id FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsLtrees l
+                WHERE MATCHES_ANY_LQUERY(l.ltree1, ARR('Root.*', 'Top.*')) = TRUE AND l.id = 1";
+        $result = $this->executeDqlQuery($dql);
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function returns_true_when_a_pattern_carries_a_quantifier(): void
+    {
+        $dql = "SELECT l.id FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsLtrees l
+                WHERE MATCHES_ANY_LQUERY(l.ltree1, ARR('*{1,2}.Child2')) = TRUE AND l.id = 1";
+        $result = $this->executeDqlQuery($dql);
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function returns_false_when_no_pattern_matches(): void
+    {
+        $dql = "SELECT l.id FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsLtrees l
+                WHERE MATCHES_ANY_LQUERY(l.ltree1, ARR('Root.*', 'A.*')) = TRUE AND l.id = 1";
+        $result = $this->executeDqlQuery($dql);
+        $this->assertCount(0, $result);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLqueryTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLqueryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLquery;
+use PHPUnit\Framework\Attributes\Test;
+
+final class MatchesLqueryTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'MATCHES_LQUERY' => MatchesLquery::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_true_when_path_matches_prefix_pattern(): void
+    {
+        $dql = "SELECT l.id FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsLtrees l
+                WHERE MATCHES_LQUERY(l.ltree1, 'Top.*') = TRUE AND l.id = 1";
+        $result = $this->executeDqlQuery($dql);
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function returns_true_when_path_matches_quantified_star_pattern(): void
+    {
+        $dql = "SELECT l.id FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsLtrees l
+                WHERE MATCHES_LQUERY(l.ltree1, '*{1,2}.Child2') = TRUE AND l.id = 1";
+        $result = $this->executeDqlQuery($dql);
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function returns_false_when_path_does_not_match_pattern(): void
+    {
+        $dql = "SELECT l.id FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsLtrees l
+                WHERE MATCHES_LQUERY(l.ltree1, 'Root.*') = TRUE AND l.id = 1";
+        $result = $this->executeDqlQuery($dql);
+        $this->assertCount(0, $result);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLtxtqueryTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLtxtqueryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLtxtquery;
+use PHPUnit\Framework\Attributes\Test;
+
+final class MatchesLtxtqueryTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'MATCHES_LTXTQUERY' => MatchesLtxtquery::class,
+        ];
+    }
+
+    #[Test]
+    public function returns_true_when_path_labels_satisfy_conjunction(): void
+    {
+        $dql = "SELECT l.id FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsLtrees l
+                WHERE MATCHES_LTXTQUERY(l.ltree1, 'Top & Child2') = TRUE AND l.id = 1";
+        $result = $this->executeDqlQuery($dql);
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function returns_true_when_path_labels_satisfy_prefix_modifier(): void
+    {
+        $dql = "SELECT l.id FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsLtrees l
+                WHERE MATCHES_LTXTQUERY(l.ltree1, 'Child*') = TRUE AND l.id = 1";
+        $result = $this->executeDqlQuery($dql);
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function returns_false_when_negated_label_is_present(): void
+    {
+        $dql = "SELECT l.id FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsLtrees l
+                WHERE MATCHES_LTXTQUERY(l.ltree1, 'Top & !Child2') = TRUE AND l.id = 1";
+        $result = $this->executeDqlQuery($dql);
+        $this->assertCount(0, $result);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/TestCase.php
@@ -62,10 +62,14 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Jsonb;
 use MartinGeorgiev\Doctrine\DBAL\Types\JsonbArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Line;
 use MartinGeorgiev\Doctrine\DBAL\Types\LineArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Lquery;
+use MartinGeorgiev\Doctrine\DBAL\Types\LqueryArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Lseg;
 use MartinGeorgiev\Doctrine\DBAL\Types\LsegArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Ltree;
 use MartinGeorgiev\Doctrine\DBAL\Types\LtreeArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Ltxtquery;
+use MartinGeorgiev\Doctrine\DBAL\Types\LtxtqueryArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Macaddr;
 use MartinGeorgiev\Doctrine\DBAL\Types\Macaddr8;
 use MartinGeorgiev\Doctrine\DBAL\Types\Macaddr8Array;
@@ -319,8 +323,12 @@ abstract class TestCase extends BaseTestCase
             'line[]' => LineArray::class,
             'lseg' => Lseg::class,
             'lseg[]' => LsegArray::class,
+            'lquery' => Lquery::class,
+            'lquery[]' => LqueryArray::class,
             'ltree' => Ltree::class,
             'ltree[]' => LtreeArray::class,
+            'ltxtquery' => Ltxtquery::class,
+            'ltxtquery[]' => LtxtqueryArray::class,
             'int4multirange' => Int4Multirange::class,
             'int4multirange[]' => Int4MultirangeArray::class,
             'int8multirange' => Int8Multirange::class,

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LqueryArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LqueryArrayTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLqueryArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLqueryArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\LqueryArray;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class LqueryArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&Stub
+     */
+    private Stub $platform;
+
+    private LqueryArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createStub(AbstractPlatform::class);
+        $this->fixture = new LqueryArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('lquery[]', $this->fixture->getName());
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single pattern' => [
+                'phpValue' => ['Top.*'],
+                'postgresValue' => '{"Top.*"}',
+            ],
+            'multiple patterns' => [
+                'phpValue' => ['Top.*', '!football|tennis'],
+                'postgresValue' => '{"Top.*","!football|tennis"}',
+            ],
+            'pattern with a quantifier comma' => [
+                'phpValue' => ['a.*{1,2}'],
+                'postgresValue' => '{"a.*{1,2}"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [null, 'Top.*'],
+                'postgresValue' => '{NULL,"Top.*"}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidLqueryArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'integer item' => [[123]],
+            'boolean item' => [[true]],
+            'object item' => [[new \stdClass()]],
+            'empty string item' => [['']],
+            'malformed pattern item' => [['Top..Child']],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidLqueryArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+        ];
+    }
+
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'single label' => ['Top'],
+            'star wildcard' => ['*'],
+            'quantified star' => ['*{1,2}'],
+            'negated alternatives' => ['!football|tennis'],
+            'null value' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'integer' => [123],
+            'float' => [3.14],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+            'empty string' => [''],
+            'consecutive dots' => ['Top..Child'],
+            'negated star' => ['!*'],
+        ];
+    }
+
+    #[Test]
+    public function converts_null_item_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidLqueryArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(123);
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LqueryTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LqueryTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLqueryForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLqueryForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Lquery;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class LqueryTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&Stub
+     */
+    private Stub $platform;
+
+    private Lquery $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createStub(AbstractPlatform::class);
+        $this->fixture = new Lquery();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('lquery', $this->fixture->getName());
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(?string $phpValue, ?string $databaseValue): void
+    {
+        $this->assertSame($databaseValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(?string $phpValue, ?string $databaseValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($databaseValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{phpValue: string|null, databaseValue: string|null}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'databaseValue' => null,
+            ],
+            'single label' => [
+                'phpValue' => 'Top',
+                'databaseValue' => 'Top',
+            ],
+            'star wildcard' => [
+                'phpValue' => '*',
+                'databaseValue' => '*',
+            ],
+            'label followed by star' => [
+                'phpValue' => 'Top.*',
+                'databaseValue' => 'Top.*',
+            ],
+            'quantified star' => [
+                'phpValue' => '*{1,2}',
+                'databaseValue' => '*{1,2}',
+            ],
+            'quantified label' => [
+                'phpValue' => 'tennis{1,}',
+                'databaseValue' => 'tennis{1,}',
+            ],
+            'negated alternatives' => [
+                'phpValue' => '!football|tennis',
+                'databaseValue' => '!football|tennis',
+            ],
+            'label modifiers' => [
+                'phpValue' => 'sport*@%',
+                'databaseValue' => 'sport*@%',
+            ],
+            'full featured pattern' => [
+                'phpValue' => 'Top.*{0,2}.sport*@.!football|tennis.Russ*|Spain',
+                'databaseValue' => 'Top.*{0,2}.sport*@.!football|tennis.Russ*|Spain',
+            ],
+            'hyphenated labels' => [
+                'phpValue' => 'a-b.c_d',
+                'databaseValue' => 'a-b.c_d',
+            ],
+            'numeric labels' => [
+                'phpValue' => '1.2.3',
+                'databaseValue' => '1.2.3',
+            ],
+            'unicode labels' => [
+                'phpValue' => 'äöü.日本',
+                'databaseValue' => 'äöü.日本',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $value): void
+    {
+        $this->expectException(InvalidLqueryForDatabaseException::class);
+
+        $this->fixture->convertToDatabaseValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'integer input' => [42],
+            'float input' => [3.14],
+            'array input' => [['not', 'a', 'string']],
+            'boolean input' => [true],
+            'object input' => [new \stdClass()],
+            'empty string' => [''],
+            'consecutive dots' => ['Top..Child'],
+            'leading dot' => ['.Top'],
+            'trailing dot' => ['Top.'],
+            'whitespace inside pattern' => ['a . b'],
+            'space inside label' => ['a b'],
+            'negated star' => ['!*'],
+            'star with modifier' => ['*@'],
+            'empty quantifier' => ['*{}'],
+            'non-numeric quantifier' => ['*{a}'],
+            'label characters after a modifier' => ['a@b'],
+            'dangling alternative separator' => ['a|'],
+            'negation inside alternatives' => ['a|!b'],
+            'unsupported character' => ['a$b'],
+            'quoted label' => ['"a b"'],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(mixed $value): void
+    {
+        $this->expectException(InvalidLqueryForPHPException::class);
+
+        $this->fixture->convertToPHPValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'integer input' => [42],
+            'float input' => [3.14],
+            'array input' => [['not', 'a', 'string']],
+            'boolean input' => [true],
+            'object input' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function preserves_database_value_unrecognised_by_write_side_validation(): void
+    {
+        $this->assertSame('{unrecognised by the write-side pattern}', $this->fixture->convertToPHPValue('{unrecognised by the write-side pattern}', $this->platform));
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LqueryTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LqueryTest.php
@@ -140,6 +140,7 @@ final class LqueryTest extends TestCase
             'negation inside alternatives' => ['a|!b'],
             'unsupported character' => ['a$b'],
             'quoted label' => ['"a b"'],
+            'trailing newline' => ["Top.Sports\n"],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryArrayTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLtxtqueryArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLtxtqueryArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\LtxtqueryArray;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class LtxtqueryArrayTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&Stub
+     */
+    private Stub $platform;
+
+    private LtxtqueryArray $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createStub(AbstractPlatform::class);
+        $this->fixture = new LtxtqueryArray();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('ltxtquery[]', $this->fixture->getName());
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{
+     *     phpValue: array|null,
+     *     postgresValue: string|null
+     * }>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single query' => [
+                'phpValue' => ['Earth & Moon'],
+                'postgresValue' => '{"Earth & Moon"}',
+            ],
+            'multiple queries' => [
+                'phpValue' => ['Earth & Moon', '!Transportation'],
+                'postgresValue' => '{"Earth & Moon","!Transportation"}',
+            ],
+            'array with null item' => [
+                'phpValue' => [null, 'Earth'],
+                'postgresValue' => '{NULL,"Earth"}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidLtxtqueryArrayItemForDatabaseException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'integer item' => [[123]],
+            'boolean item' => [[true]],
+            'object item' => [[new \stdClass()]],
+            'empty string item' => [['']],
+            'malformed query item' => [['a & & b']],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
+    {
+        $this->expectException(InvalidLtxtqueryArrayItemForPHPException::class);
+        $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+        ];
+    }
+
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_valid_array_item_for_database(mixed $value): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'single word' => ['Earth'],
+            'conjunction' => ['Earth & Moon'],
+            'negation' => ['!Transportation'],
+            'parenthesised expression' => ['(a | b) & c'],
+            'null value' => [null],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_invalid_array_item_for_database(mixed $value): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($value));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'integer' => [123],
+            'float' => [3.14],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+            'empty string' => [''],
+            'dotted path' => ['a.b'],
+            'unbalanced parenthesis' => ['(a'],
+        ];
+    }
+
+    #[Test]
+    public function converts_null_item_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidLtxtqueryArrayItemForPHPException::class);
+        $this->fixture->transformArrayItemForPHP(123);
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLtxtqueryForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidLtxtqueryForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Ltxtquery;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+final class LtxtqueryTest extends TestCase
+{
+    /**
+     * @var AbstractPlatform&Stub
+     */
+    private Stub $platform;
+
+    private Ltxtquery $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createStub(AbstractPlatform::class);
+        $this->fixture = new Ltxtquery();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('ltxtquery', $this->fixture->getName());
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(?string $phpValue, ?string $databaseValue): void
+    {
+        $this->assertSame($databaseValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(?string $phpValue, ?string $databaseValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($databaseValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{phpValue: string|null, databaseValue: string|null}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'databaseValue' => null,
+            ],
+            'single word' => [
+                'phpValue' => 'Earth',
+                'databaseValue' => 'Earth',
+            ],
+            'conjunction' => [
+                'phpValue' => 'Earth & Moon',
+                'databaseValue' => 'Earth & Moon',
+            ],
+            'conjunction without spaces' => [
+                'phpValue' => 'Earth&Moon',
+                'databaseValue' => 'Earth&Moon',
+            ],
+            'disjunction' => [
+                'phpValue' => 'Earth | Asia',
+                'databaseValue' => 'Earth | Asia',
+            ],
+            'negation' => [
+                'phpValue' => '!Transportation',
+                'databaseValue' => '!Transportation',
+            ],
+            'parenthesised expression' => [
+                'phpValue' => '(Earth | Asia) & Moon',
+                'databaseValue' => '(Earth | Asia) & Moon',
+            ],
+            'nested parentheses' => [
+                'phpValue' => '((a|b)&(c|d))',
+                'databaseValue' => '((a|b)&(c|d))',
+            ],
+            'word modifiers' => [
+                'phpValue' => 'Moon*@%',
+                'databaseValue' => 'Moon*@%',
+            ],
+            'full featured query' => [
+                'phpValue' => 'Earth & Moon*@ & !Transportation',
+                'databaseValue' => 'Earth & Moon*@ & !Transportation',
+            ],
+            'hyphenated and underscored words' => [
+                'phpValue' => 'a-b & c_d',
+                'databaseValue' => 'a-b & c_d',
+            ],
+            'unicode words' => [
+                'phpValue' => 'Ünïcödé & 日本',
+                'databaseValue' => 'Ünïcödé & 日本',
+            ],
+            'surrounding spaces' => [
+                'phpValue' => '  a  &  b  ',
+                'databaseValue' => '  a  &  b  ',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $value): void
+    {
+        $this->expectException(InvalidLtxtqueryForDatabaseException::class);
+
+        $this->fixture->convertToDatabaseValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'integer input' => [42],
+            'float input' => [3.14],
+            'array input' => [['not', 'a', 'string']],
+            'boolean input' => [true],
+            'object input' => [new \stdClass()],
+            'empty string' => [''],
+            'dotted path' => ['a.b'],
+            'words without an operator' => ['a b'],
+            'dangling operator' => ['a &'],
+            'leading operator' => ['& a'],
+            'unbalanced opening parenthesis' => ['(a'],
+            'unbalanced closing parenthesis' => ['a)'],
+            'empty parentheses' => ['()'],
+            'repeated operator' => ['a & & b'],
+            'star without a word' => ['*'],
+            'negation without a word' => ['!'],
+            'detached modifier' => ['a @'],
+            'trailing negation' => ['a!'],
+            'tab as separator' => ["a\t&\tb"],
+            'newline as separator' => ["a\n&\nb"],
+            'unsupported character' => ["a'b"],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(mixed $value): void
+    {
+        $this->expectException(InvalidLtxtqueryForPHPException::class);
+
+        $this->fixture->convertToPHPValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'integer input' => [42],
+            'float input' => [3.14],
+            'array input' => [['not', 'a', 'string']],
+            'boolean input' => [true],
+            'object input' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function preserves_database_value_unrecognised_by_write_side_validation(): void
+    {
+        $this->assertSame('{unrecognised by the write-side pattern}', $this->fixture->convertToPHPValue('{unrecognised by the write-side pattern}', $this->platform));
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LtxtqueryTest.php
@@ -138,6 +138,8 @@ final class LtxtqueryTest extends TestCase
             'unbalanced closing parenthesis' => ['a)'],
             'empty parentheses' => ['()'],
             'repeated operator' => ['a & & b'],
+            'trailing newline' => ["Earth & Moon\n"],
+            'tab separator' => ["Earth\t& Moon"],
             'star without a word' => ['*'],
             'negation without a word' => ['!'],
             'detached modifier' => ['a @'],

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesAnyLqueryTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesAnyLqueryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Arr;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesAnyLquery;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class MatchesAnyLqueryTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'MATCHES_ANY_LQUERY' => MatchesAnyLquery::class,
+            'ARR' => Arr::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'matches path against an array of lquery patterns' => "SELECT (c0_.text1 ?? CAST(ARRAY['Top.*', 'A.*'] AS lquery[])) AS sclr_0 FROM ContainsTexts c0_",
+            'matches path against a single-element array of lquery patterns' => "SELECT (c0_.text1 ?? CAST(ARRAY['Top.*'] AS lquery[])) AS sclr_0 FROM ContainsTexts c0_",
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'matches path against an array of lquery patterns' => \sprintf("SELECT MATCHES_ANY_LQUERY(e.text1, ARR('Top.*', 'A.*')) FROM %s e", ContainsTexts::class),
+            'matches path against a single-element array of lquery patterns' => \sprintf("SELECT MATCHES_ANY_LQUERY(e.text1, ARR('Top.*')) FROM %s e", ContainsTexts::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLqueryTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLqueryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLquery;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class MatchesLqueryTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'MATCHES_LQUERY' => MatchesLquery::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'matches path against an lquery literal' => "SELECT (c0_.text1 ~ CAST('Top.*' AS lquery)) AS sclr_0 FROM ContainsTexts c0_",
+            'matches path against an lquery column' => 'SELECT (c0_.text1 ~ CAST(c0_.text2 AS lquery)) AS sclr_0 FROM ContainsTexts c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'matches path against an lquery literal' => \sprintf("SELECT MATCHES_LQUERY(e.text1, 'Top.*') FROM %s e", ContainsTexts::class),
+            'matches path against an lquery column' => \sprintf('SELECT MATCHES_LQUERY(e.text1, e.text2) FROM %s e', ContainsTexts::class),
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLtxtqueryTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Ltree/MatchesLtxtqueryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ltree\MatchesLtxtquery;
+use Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\TestCase;
+
+final class MatchesLtxtqueryTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'MATCHES_LTXTQUERY' => MatchesLtxtquery::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'matches path against an ltxtquery literal' => "SELECT (c0_.text1 @ CAST('Top & !Child2' AS ltxtquery)) AS sclr_0 FROM ContainsTexts c0_",
+            'matches path against an ltxtquery column' => 'SELECT (c0_.text1 @ CAST(c0_.text2 AS ltxtquery)) AS sclr_0 FROM ContainsTexts c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'matches path against an ltxtquery literal' => \sprintf("SELECT MATCHES_LTXTQUERY(e.text1, 'Top & !Child2') FROM %s e", ContainsTexts::class),
+            'matches path against an ltxtquery column' => \sprintf('SELECT MATCHES_LTXTQUERY(e.text1, e.text2) FROM %s e', ContainsTexts::class),
+        ];
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL `lquery`, `lquery[]`, `ltxtquery`, and `ltxtquery[]` support, including validation and conversion.
  * Added DQL matching functions for `~`, `?`, and `@` ltree operators.
  * Added support for configuring these types and functions in Doctrine, Symfony, and Laravel integrations.

* **Documentation**
  * Expanded ltree guidance with query types, syntax, operators, examples, mappings, and performance notes.
  * Added the new types and functions to quick-reference documentation.

* **Tests**
  * Added unit and integration coverage for conversions, validation, arrays, and ltree matching queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->