### PR TITLE
fix: require `\z` anchors in validation regexes for data types, for which PostgreSQL doesn't support a trailing newline

### DIFF
--- a/.ai-tools/rules/code-quality.md
+++ b/.ai-tools/rules/code-quality.md
@@ -31,7 +31,7 @@ type: always_apply
 \preg_match('/^[01]+\z/', $value)
 ```
 
-**Exception**: leave `$` in place when PostgreSQL itself accepts the trailing whitespace for that type (e.g. `macaddr`, `numeric`, the geometric types) — narrowing there is a behaviour change with no benefit.
+**Exception**: `$` is harmless only when the value is parsed into a typed or canonical form before it reaches the database, so the trailing newline is discarded on the way (the geometric value objects re-emit `(1,2)`; the integer and float array types cast). Anchor with `\z` everywhere else — including when PostgreSQL *accepts* the trailing whitespace, because a type that writes the item verbatim (`numeric[]`) then reads back a trimmed value, and a type that reformats it (`macaddr`) can build a malformed one.
 
 ## Assertions: Exact Values, Not Substring Matches
 **Required**: Assert the precise expected value.

--- a/.ai-tools/rules/code-quality.md
+++ b/.ai-tools/rules/code-quality.md
@@ -1,5 +1,5 @@
 ---
-description: "Code quality standards: avoid obvious comments, use strong assertions, never cast actual values in assertions"
+description: "Code quality standards: avoid obvious comments, anchor validation regexes with \\z, use strong assertions, never cast actual values in assertions"
 alwaysApply: true
 trigger: always_on
 applyTo: "**"
@@ -19,6 +19,19 @@ type: always_apply
 // ✓ Keep — explains non-obvious PostgreSQL behavior or architectural decision
 // PostgreSQL normalizes POINTZ → POINT Z on retrieval; normalize on write too
 ```
+
+## Validation Regexes: Anchor With `\z`, Not `$`
+**Required**: End validation patterns with `\z`. In PCRE, `$` also matches immediately before a trailing newline, so a `$`-anchored pattern accepts values PostgreSQL rejects.
+
+```php
+// ❌ Wrong — also matches "101\n", which PostgreSQL rejects for bit
+\preg_match('/^[01]+$/', $value)
+
+// ✓ Correct — matches only "101"
+\preg_match('/^[01]+\z/', $value)
+```
+
+**Exception**: leave `$` in place when PostgreSQL itself accepts the trailing whitespace for that type (e.g. `macaddr`, `numeric`, the geometric types) — narrowing there is a behaviour change with no benefit.
 
 ## Assertions: Exact Values, Not Substring Matches
 **Required**: Assert the precise expected value.

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
@@ -30,7 +30,9 @@ class NumericArray extends BaseStringArray
      *
      * @var string
      */
-    private const NUMERIC_REGEX = '/^-?\d+(\.\d+)?$/';
+    // Anchored with \z rather than $, which would also match before a trailing newline. Items are written to the array
+    // literal verbatim, so PostgreSQL would silently trim that newline and the value read back would differ.
+    private const NUMERIC_REGEX = '/^-?\d+(\.\d+)?\z/';
 
     /**
      * @var string

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
@@ -30,8 +30,6 @@ class NumericArray extends BaseStringArray
      *
      * @var string
      */
-    // Anchored with \z rather than $, which would also match before a trailing newline. Items are written to the array
-    // literal verbatim, so PostgreSQL would silently trim that newline and the value read back would differ.
     private const NUMERIC_REGEX = '/^-?\d+(\.\d+)?\z/';
 
     /**

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/BitValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/BitValidationTrait.php
@@ -13,6 +13,7 @@ trait BitValidationTrait
 {
     protected function isValidBitString(string $value): bool
     {
-        return \preg_match('/^[01]+$/', $value) === 1;
+        // Anchored with \z rather than $, which would also match before a trailing newline.
+        return \preg_match('/^[01]+\z/', $value) === 1;
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/BitValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/BitValidationTrait.php
@@ -13,7 +13,6 @@ trait BitValidationTrait
 {
     protected function isValidBitString(string $value): bool
     {
-        // Anchored with \z rather than $, which would also match before a trailing newline.
         return \preg_match('/^[01]+\z/', $value) === 1;
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LqueryValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/LqueryValidationTrait.php
@@ -22,7 +22,6 @@ trait LqueryValidationTrait
     /**
      * @var string
      */
-    // Anchored with \z rather than $, which would also match before a trailing newline.
     private const LQUERY_PATTERN = '/^'.self::LQUERY_ITEM.'(?:\.'.self::LQUERY_ITEM.')*\z/u';
 
     /**

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/Macaddr8ValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/Macaddr8ValidationTrait.php
@@ -34,8 +34,6 @@ trait Macaddr8ValidationTrait
             .'|[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}'
             .'|[0-9A-Fa-f]{8}:[0-9A-Fa-f]{8}'
             .'|[0-9A-Fa-f]{16}'
-            // Anchored with \z rather than $, which would also match before a trailing newline. Normalisation strips
-            // separators and re-splits in pairs, so a newline would produce a malformed extra group.
             .')\z/',
             $value
         );

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/Macaddr8ValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/Macaddr8ValidationTrait.php
@@ -34,7 +34,9 @@ trait Macaddr8ValidationTrait
             .'|[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}'
             .'|[0-9A-Fa-f]{8}:[0-9A-Fa-f]{8}'
             .'|[0-9A-Fa-f]{16}'
-            .')$/',
+            // Anchored with \z rather than $, which would also match before a trailing newline. Normalisation strips
+            // separators and re-splits in pairs, so a newline would produce a malformed extra group.
+            .')\z/',
             $value
         );
     }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/MacaddrValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/MacaddrValidationTrait.php
@@ -27,8 +27,6 @@ trait MacaddrValidationTrait
             .'|[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}'
             .'|[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}'
             .'|[0-9A-Fa-f]{12}'
-            // Anchored with \z rather than $, which would also match before a trailing newline. Normalisation strips
-            // separators and re-splits in pairs, so a newline would produce a malformed extra group.
             .')\z/',
             $value
         );

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/MacaddrValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/MacaddrValidationTrait.php
@@ -27,7 +27,9 @@ trait MacaddrValidationTrait
             .'|[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}'
             .'|[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}'
             .'|[0-9A-Fa-f]{12}'
-            .')$/',
+            // Anchored with \z rather than $, which would also match before a trailing newline. Normalisation strips
+            // separators and re-splits in pairs, so a newline would produce a malformed extra group.
+            .')\z/',
             $value
         );
     }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Ulid.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Ulid.php
@@ -23,10 +23,11 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidUlidForPHPException;
  */
 final class Ulid extends BaseType
 {
+    // Anchored with \z rather than $, which would also match before a trailing newline.
     /**
      * @var string
      */
-    private const ULID_REGEX = '/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/i';
+    private const ULID_REGEX = '/^[0-7][0-9A-HJKMNP-TV-Z]{25}\z/i';
 
     /**
      * @var string

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Ulid.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Ulid.php
@@ -23,7 +23,6 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidUlidForPHPException;
  */
 final class Ulid extends BaseType
 {
-    // Anchored with \z rather than $, which would also match before a trailing newline.
     /**
      * @var string
      */

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/UlidArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/UlidArray.php
@@ -22,7 +22,6 @@ use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
  */
 final class UlidArray extends BaseArray
 {
-    // Anchored with \z rather than $, which would also match before a trailing newline.
     /**
      * @var string
      */

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/UlidArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/UlidArray.php
@@ -22,10 +22,11 @@ use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
  */
 final class UlidArray extends BaseArray
 {
+    // Anchored with \z rather than $, which would also match before a trailing newline.
     /**
      * @var string
      */
-    private const ULID_REGEX = '/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/i';
+    private const ULID_REGEX = '/^[0-7][0-9A-HJKMNP-TV-Z]{25}\z/i';
 
     /**
      * @var string

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/UuidArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/UuidArray.php
@@ -19,10 +19,11 @@ use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
  */
 class UuidArray extends BaseArray
 {
+    // Anchored with \z rather than $, which would also match before a trailing newline.
     /**
      * @var string
      */
-    private const UUID_REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
+    private const UUID_REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i';
 
     /**
      * @var string

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/UuidArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/UuidArray.php
@@ -19,7 +19,6 @@ use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
  */
 class UuidArray extends BaseArray
 {
-    // Anchored with \z rather than $, which would also match before a trailing newline.
     /**
      * @var string
      */

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BitArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BitArrayTest.php
@@ -202,6 +202,7 @@ final class BitArrayTest extends TestCase
             'with space' => ['1 0'],
             'integer' => [123],
             'empty string' => [''],
+            'trailing newline' => ["101\n"],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BitTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BitTest.php
@@ -119,6 +119,7 @@ final class BitTest extends TestCase
             'digit two' => ['2'],
             'alphabetic' => ['abc'],
             'with space' => ['1 0'],
+            'trailing newline' => ["101\n"],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BitVaryingArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BitVaryingArrayTest.php
@@ -202,6 +202,7 @@ final class BitVaryingArrayTest extends TestCase
             'with space' => ['1 0'],
             'integer' => [123],
             'empty string' => [''],
+            'trailing newline' => ["101\n"],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BitVaryingTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BitVaryingTest.php
@@ -119,6 +119,7 @@ final class BitVaryingTest extends TestCase
             'digit two' => ['2'],
             'alphabetic' => ['abc'],
             'with space' => ['1 0'],
+            'trailing newline' => ["101\n"],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8Test.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8Test.php
@@ -111,6 +111,7 @@ final class Macaddr8Test extends TestCase
             'too long (9 octets)' => ['08:00:2b:ff:fe:01:02:03:04'],
             'invalid hex chars' => ['08:00:2b:zz:fe:01:02:03'],
             'mixed separators' => ['08:00-2b:ff:fe:01:02:03'],
+            'trailing newline' => ["08:00:2b:ff:fe:01:02:03\n"],
             'integer input' => [123],
             'array input' => [['not', 'string']],
             'boolean input' => [false],

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrTest.php
@@ -137,6 +137,7 @@ final class MacaddrTest extends TestCase
             'wrong format' => ['not-a-mac-address'],
             'mixed separators' => ['00:11-22:33-44:55'],
             'non-hex digits' => ['zz:zz:zz:zz:zz:zz'],
+            'trailing newline' => ["08:00:2b:01:02:03\n"],
             // Invalid types
             'integer input' => [123],
             'array input' => [['not', 'string']],

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/NumericArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/NumericArrayTest.php
@@ -181,6 +181,7 @@ final class NumericArrayTest extends TestCase
             'trailing dot' => ['5.'],
             'NaN' => ['NaN'],
             'comma as decimal separator' => ['1,5'],
+            'trailing newline' => ["1.50\n"],
             'integer' => [123],
             'float' => [3.14],
             'boolean' => [true],

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/UlidArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/UlidArrayTest.php
@@ -206,6 +206,7 @@ final class UlidArrayTest extends TestCase
             'boolean' => [true],
             'too short' => ['01ARZ3NDEKTSV4RRFFQ69G5FA'],
             'first character above 7' => ['81ARZ3NDEKTSV4RRFFQ69G5FAV'],
+            'trailing newline' => ["01ARZ3NDEKTSV4RRFFQ69G5FAV\n"],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/UlidTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/UlidTest.php
@@ -168,6 +168,7 @@ final class UlidTest extends TestCase
             'contains excluded letter U' => ['01ARZ3NDEKTSV4RRFFQ69G5FAU'],
             'UUID instead of ULID' => ['550e8400-e29b-41d4-a716-446655440000'],
             'whitespace only' => ['                          '],
+            'trailing newline' => ["01ARZ3NDEKTSV4RRFFQ69G5FAV\n"],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/UuidArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/UuidArrayTest.php
@@ -201,6 +201,7 @@ final class UuidArrayTest extends TestCase
             'boolean' => [true],
             'too short' => ['550e8400-e29b-41d4-a716'],
             'no hyphens' => ['550e8400e29b41d4a716446655440000'],
+            'trailing newline' => ["550e8400-e29b-41d4-a716-446655440000\n"],
         ];
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Validation now rejects bit strings, numeric values, MAC addresses, ULIDs, and UUIDs containing trailing newline characters.
  - Prevents invalid values from being accepted during conversion and causing database round-trip mismatches.
  - Validation now requires these values to end exactly at the end of the input.

- **Tests**
  - Added coverage confirming trailing-newline inputs are rejected across the affected types.

- **Documentation**
  - Documented the requirement for validation patterns to match the exact end of input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->