### PR TITLE
feat: add `geometry_type` and `srid` column options to PostGIS spatial types

### DIFF
--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -93,9 +93,9 @@
 | polygon | polygon | `MartinGeorgiev\Doctrine\DBAL\Types\Polygon` |
 | polygon[] | _polygon | `MartinGeorgiev\Doctrine\DBAL\Types\PolygonArray` |
 |---|---|---|
-| geography | geography | `MartinGeorgiev\Doctrine\DBAL\Types\Geography` |
+| geography | geography | `MartinGeorgiev\Doctrine\DBAL\Types\Geography` (see [note](#postgis-spatial-types)) |
 | geography[] | _geography | `MartinGeorgiev\Doctrine\DBAL\Types\GeographyArray` |
-| geometry | geometry | `MartinGeorgiev\Doctrine\DBAL\Types\Geometry` |
+| geometry | geometry | `MartinGeorgiev\Doctrine\DBAL\Types\Geometry` (see [note](#postgis-spatial-types)) |
 | geometry[] | _geometry | `MartinGeorgiev\Doctrine\DBAL\Types\GeometryArray` |
 |---|---|---|
 | cube | cube | `MartinGeorgiev\Doctrine\DBAL\Types\Cube` (see [note](#cube-type)) |
@@ -122,6 +122,33 @@
 | vector | vector | `MartinGeorgiev\Doctrine\DBAL\Types\Vector` (see [note](#pgvector-types)) |
 |---|---|---|
 | *(user-defined enum)* | *(any)* | `MartinGeorgiev\Doctrine\DBAL\Types\Enum` (see [Enum Types](ENUM-TYPE.md)) |
+
+## PostGIS Spatial Types
+
+The `geometry` and `geography` types accept the `geometry_type` and `srid` column options, which emit a PostGIS type modifier so the subtype and spatial reference system are enforced by the database:
+
+```php
+use Doctrine\ORM\Mapping as ORM;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\WktSpatialData;
+
+#[ORM\Entity]
+class Place
+{
+    // GEOGRAPHY(POINT,4326) — only WGS 84 points are accepted
+    #[ORM\Column(type: 'geography', options: ['geometry_type' => 'Point', 'srid' => 4326])]
+    private WktSpatialData $location;
+
+    // GEOMETRY — unconstrained, accepts any geometry
+    #[ORM\Column(type: 'geometry')]
+    private WktSpatialData $shape;
+}
+```
+
+Omitting both options keeps the bare `GEOMETRY` / `GEOGRAPHY` declaration.
+
+> 📖 **See also**: [Spatial Types](SPATIAL-TYPES.md#column-options-for-ddl) for the full option reference
+
+---
 
 ## pgvector Types
 

--- a/docs/SPATIAL-TYPES.md
+++ b/docs/SPATIAL-TYPES.md
@@ -169,7 +169,7 @@ $polyhedralSurface = WktSpatialData::fromWkt('POLYHEDRALSURFACE(((0 0, 0 1, 1 1,
 
 ## Column options for DDL
 
-By default `geometry` and `geography` columns are declared as bare `GEOMETRY` / `GEOGRAPHY`, which accepts any subtype and any SRID. Two column options add a PostGIS type modifier so the constraint is enforced by PostgreSQL itself:
+By default `geometry` and `geography` columns are declared as bare `GEOMETRY` / `GEOGRAPHY`. A bare `GEOMETRY` column accepts any subtype and any SRID. A bare `GEOGRAPHY` column is narrower: it accepts only geography-compatible subtypes (PostGIS rejects e.g. `TIN`) and geodetic lon/lat SRIDs, and stores SRID-less input as SRID 4326. Two column options add a PostGIS type modifier so the constraint is enforced by PostgreSQL itself:
 
 | Option | Type | Meaning |
 |---|---|---|

--- a/docs/SPATIAL-TYPES.md
+++ b/docs/SPATIAL-TYPES.md
@@ -167,6 +167,54 @@ $tin = WktSpatialData::fromWkt('TIN(((0 0, 1 0, 0.5 1, 0 0)), ((1 0, 2 0, 1.5 1,
 $polyhedralSurface = WktSpatialData::fromWkt('POLYHEDRALSURFACE(((0 0, 0 1, 1 1, 1 0, 0 0)), ((0 0, 0 1, 0 0 1, 0 0)))');
 ```
 
+## Column options for DDL
+
+By default `geometry` and `geography` columns are declared as bare `GEOMETRY` / `GEOGRAPHY`, which accepts any subtype and any SRID. Two column options add a PostGIS type modifier so the constraint is enforced by PostgreSQL itself:
+
+| Option | Type | Meaning |
+|---|---|---|
+| `geometry_type` | string | The geometry subtype, e.g. `Point`, `LineString`, `MultiPolygon`. Case-insensitive. May carry a dimensional modifier suffix: `PointZ`, `PointM`, `PointZM`. Use `Geometry` for "any subtype". |
+| `srid` | int | The spatial reference system identifier, e.g. `4326`. Must be a non-negative integer. |
+
+```php
+use Doctrine\ORM\Mapping as ORM;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\WktSpatialData;
+
+#[ORM\Entity]
+class Place
+{
+    // GEOGRAPHY(POINT,4326)
+    #[ORM\Column(type: 'geography', options: ['geometry_type' => 'Point', 'srid' => 4326])]
+    private WktSpatialData $location;
+
+    // GEOMETRY(POLYGONZ) — 3D polygons, SRID unconstrained
+    #[ORM\Column(type: 'geometry', options: ['geometry_type' => 'PolygonZ'])]
+    private WktSpatialData $volume;
+
+    // GEOMETRY(GEOMETRY,3857) — any subtype, but SRID pinned to Web Mercator
+    #[ORM\Column(type: 'geometry', options: ['srid' => 3857])]
+    private WktSpatialData $tileShape;
+
+    // GEOMETRY — unconstrained
+    #[ORM\Column(type: 'geometry')]
+    private WktSpatialData $shape;
+}
+```
+
+Both options are optional and independent:
+
+- Neither option → bare `GEOMETRY` / `GEOGRAPHY`.
+- `geometry_type` only → `GEOMETRY(POINT)`.
+- `srid` only → `GEOMETRY(GEOMETRY,4326)`, since PostGIS requires a subtype whenever an SRID is given.
+
+### Caveats
+
+- The options only shape the DDL that Doctrine generates. They do not alter value conversion — a `WktSpatialData` carrying a different subtype is still handed to PostgreSQL, which rejects it at insert time.
+- `geography` only supports lon/lat reference systems; PostgreSQL rejects e.g. `GEOGRAPHY(POINT,3857)` at `CREATE TABLE` time.
+- A constrained column coerces values that carry no SRID: inserting `POINT(1 2)` into `GEOMETRY(POINT,4326)` stores `SRID=4326;POINT(1 2)`.
+- Doctrine's schema comparator does not understand PostGIS type modifiers, so `doctrine:schema:update` and diff-based migration generation may report spurious changes for these columns. Manage them with explicit migrations.
+- Spatial (GiST) indexes are not covered by these options. Declare them in a migration with raw SQL: `CREATE INDEX idx_place_location ON place USING GIST (location);`
+
 ## Geography vs Geometry specifics
 
 - Geometry accepts WKT and EWKT (`SRID=...;...`).

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseSpatialType.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseSpatialType.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\SpatialColumnOptionsSQLDeclarationTrait;
 
 /**
  * Base class for PostGIS spatial types (GEOMETRY, GEOGRAPHY).
  *
- * Provides common functionality for spatial types that need to convert
- * between binary (EWKB) and text (EWKT) formats.
+ * Provides common functionality for spatial types that need to convert between binary (EWKB) and text (EWKT) formats.
  *
  * @since 3.6
  *
@@ -18,6 +18,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 abstract class BaseSpatialType extends BaseType
 {
+    use SpatialColumnOptionsSQLDeclarationTrait;
+
     /**
      * Modifies the SQL expression to convert spatial data from binary to EWKT format.
      *

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidSpatialColumnDeclarationException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidSpatialColumnDeclarationException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidSpatialColumnDeclarationException extends \LogicException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidGeometryType(mixed $value): self
+    {
+        return self::create('Column option "geometry_type" must be a known PostGIS geometry type, optionally suffixed with Z, M or ZM, %s given', $value);
+    }
+
+    public static function forInvalidSrid(mixed $value): self
+    {
+        return self::create('Column option "srid" must be a non-negative integer, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/SpatialColumnOptionsSQLDeclarationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/SpatialColumnOptionsSQLDeclarationTrait.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Traits;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidSpatialColumnDeclarationException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DimensionalModifier;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\GeometryType;
+
+/**
+ * Adds option-aware SQL declaration for PostGIS types that support a type modifier.
+ * Generates `TYPE(subtype,srid)` from the `geometry_type` and `srid` column options, otherwise bare `TYPE`.
+ *
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+trait SpatialColumnOptionsSQLDeclarationTrait
+{
+    /**
+     * @var string
+     */
+    private const ANY_GEOMETRY_SUBTYPE = 'GEOMETRY';
+
+    /**
+     * @param array<string, mixed> $fieldDeclaration
+     *
+     * @throws InvalidSpatialColumnDeclarationException
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        $geometryType = $this->findGeometryTypeOption($fieldDeclaration);
+        $srid = $this->findSridOption($fieldDeclaration);
+        $typeName = \strtoupper(static::TYPE_NAME);
+
+        if ($geometryType === null && $srid === null) {
+            return $typeName;
+        }
+
+        $subtype = $geometryType ?? self::ANY_GEOMETRY_SUBTYPE;
+        if ($srid === null) {
+            return \sprintf('%s(%s)', $typeName, $subtype);
+        }
+
+        return \sprintf('%s(%s,%d)', $typeName, $subtype, $srid);
+    }
+
+    /**
+     * @param array<string, mixed> $fieldDeclaration
+     *
+     * @throws InvalidSpatialColumnDeclarationException
+     */
+    private function findGeometryTypeOption(array $fieldDeclaration): ?string
+    {
+        $geometryType = $fieldDeclaration['geometry_type'] ?? null;
+        if ($geometryType === null) {
+            return null;
+        }
+
+        if (!\is_string($geometryType)) {
+            throw InvalidSpatialColumnDeclarationException::forInvalidGeometryType($geometryType);
+        }
+
+        $normalised = \strtoupper(\trim($geometryType));
+        if (!$this->isSupportedSubtype($normalised)) {
+            throw InvalidSpatialColumnDeclarationException::forInvalidGeometryType($geometryType);
+        }
+
+        return $normalised;
+    }
+
+    private function isSupportedSubtype(string $subtype): bool
+    {
+        return $subtype === self::ANY_GEOMETRY_SUBTYPE
+            || GeometryType::tryFrom($subtype) !== null
+            || $this->isGeometryTypeWithDimensionalModifier($subtype);
+    }
+
+    /**
+     * PostGIS spells a dimensional variant by appending the modifier to the base type, so POINTZM is POINT plus ZM.
+     */
+    private function isGeometryTypeWithDimensionalModifier(string $subtype): bool
+    {
+        foreach ($this->getDimensionalModifiersSortedWithLongestFirst() as $modifier) {
+            if (\str_ends_with($subtype, $modifier)) {
+                return GeometryType::tryFrom(\substr($subtype, 0, -\strlen($modifier))) !== null;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string> ZM before M, so that POINTZM is split into POINT plus ZM rather than POINTZ plus M
+     */
+    private function getDimensionalModifiersSortedWithLongestFirst(): array
+    {
+        $modifiers = \array_map(
+            static fn (DimensionalModifier $dimensionalModifier): string => $dimensionalModifier->value,
+            DimensionalModifier::cases()
+        );
+        \usort($modifiers, static fn (string $a, string $b): int => \strlen($b) <=> \strlen($a));
+
+        return $modifiers;
+    }
+
+    /**
+     * @param array<string, mixed> $fieldDeclaration
+     *
+     * @throws InvalidSpatialColumnDeclarationException
+     */
+    private function findSridOption(array $fieldDeclaration): ?int
+    {
+        $srid = $fieldDeclaration['srid'] ?? null;
+        if ($srid === null) {
+            return null;
+        }
+
+        if (\is_string($srid) && \ctype_digit($srid)) {
+            return (int) $srid;
+        }
+
+        if (\is_int($srid) && $srid >= 0) {
+            return $srid;
+        }
+
+        throw InvalidSpatialColumnDeclarationException::forInvalidSrid($srid);
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ConstrainedGeographyColumnTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ConstrainedGeographyColumnTypeTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+final class ConstrainedGeographyColumnTypeTest extends ConstrainedSpatialColumnTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'geography';
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ConstrainedGeometryColumnTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ConstrainedGeometryColumnTypeTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+final class ConstrainedGeometryColumnTypeTest extends ConstrainedSpatialColumnTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return 'geometry';
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ConstrainedSpatialColumnTypeTestCase.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ConstrainedSpatialColumnTypeTestCase.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Exception\DriverException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\WktSpatialData;
+use PHPUnit\Framework\Attributes\Test;
+
+abstract class ConstrainedSpatialColumnTypeTestCase extends TestCase
+{
+    protected function getFieldDeclaration(): array
+    {
+        return [
+            'geometry_type' => 'POINT',
+            'srid' => 4326,
+        ];
+    }
+
+    protected function getSelectExpression(string $columnName): string
+    {
+        return \sprintf(
+            'CASE WHEN ST_SRID("%s") = 0 THEN ST_AsText("%s") ELSE '
+            ."'SRID=' || ST_SRID(\"%s\") || ';' || ST_AsText(\"%s\") END AS \"%s\"",
+            $columnName,
+            $columnName,
+            $columnName,
+            $columnName,
+            $columnName
+        );
+    }
+
+    #[Test]
+    public function declares_column_with_postgis_type_modifier(): void
+    {
+        $this->assertSame(
+            \sprintf('%s(POINT,4326)', \strtoupper($this->getTypeName())),
+            $this->getPostgresTypeName()
+        );
+    }
+
+    #[Test]
+    public function roundtrips_value_matching_the_declared_geometry_type(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, WktSpatialData::fromWkt('SRID=4326;POINT(-122.4194 37.7749)'));
+    }
+
+    #[Test]
+    public function rejects_value_of_another_geometry_type(): void
+    {
+        $this->expectException(DriverException::class);
+
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, WktSpatialData::fromWkt('SRID=4326;LINESTRING(0 0,1 1)'));
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ConstrainedSpatialColumnTypeTestCase.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/ConstrainedSpatialColumnTypeTestCase.php
@@ -50,6 +50,20 @@ abstract class ConstrainedSpatialColumnTypeTestCase extends TestCase
     }
 
     #[Test]
+    public function normalizes_sridless_value_to_the_declared_srid(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTripExpectingDifferentRetrievedValue(
+            $typeName,
+            $columnType,
+            WktSpatialData::fromWkt('POINT(-122.4194 37.7749)'),
+            WktSpatialData::fromWkt('SRID=4326;POINT(-122.4194 37.7749)')
+        );
+    }
+
+    #[Test]
     public function rejects_value_of_another_geometry_type(): void
     {
         $this->expectException(DriverException::class);

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TestCase.php
@@ -41,7 +41,7 @@ abstract class TestCase extends BaseTestCase
 
     protected function buildTableName(string $columnType): string
     {
-        return 'test_type_'.\strtolower(\str_replace([' ', '[]', '()', '(', ')'], ['_', '_array', '', '', ''], $columnType));
+        return 'test_type_'.\strtolower(\str_replace([' ', '[]', '()', '(', ')', ','], ['_', '_array', '', '', '', ''], $columnType));
     }
 
     /**

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseSpatialTypeTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseSpatialTypeTestCase.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use MartinGeorgiev\Doctrine\DBAL\Types\BaseSpatialType;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidSpatialColumnDeclarationException;
 use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\WktSpatialData;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -183,6 +184,150 @@ abstract class BaseSpatialTypeTestCase extends TestCase
                 'wktSpatialData' => WktSpatialData::fromWkt('SRID=4326;CIRCULARSTRING(0 0, 1 1, 2 0)'),
                 'postgresValue' => 'SRID=4326;CIRCULARSTRING(0 0, 1 1, 2 0)',
             ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $fieldDeclaration
+     */
+    #[DataProvider('provideColumnOptionsWithoutSpatialConstraints')]
+    #[Test]
+    public function returns_bare_type_for_column_options_without_spatial_constraints(array $fieldDeclaration): void
+    {
+        $this->assertSame(
+            \strtoupper($this->getExpectedTypeName()),
+            $this->fixture->getSQLDeclaration($fieldDeclaration, $this->platform)
+        );
+    }
+
+    /**
+     * @return array<string, array{array<string, mixed>}>
+     */
+    public static function provideColumnOptionsWithoutSpatialConstraints(): array
+    {
+        return [
+            'no options' => [[]],
+            'unrelated options only' => [['notnull' => true, 'length' => 255]],
+            'explicit nulls' => [['geometry_type' => null, 'srid' => null]],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $fieldDeclaration
+     */
+    #[DataProvider('provideSpatialColumnOptions')]
+    #[Test]
+    public function returns_constrained_type_when_column_options_declared(array $fieldDeclaration, string $expectedTypeModifier): void
+    {
+        $this->assertSame(
+            \strtoupper($this->getExpectedTypeName()).$expectedTypeModifier,
+            $this->fixture->getSQLDeclaration($fieldDeclaration, $this->platform)
+        );
+    }
+
+    /**
+     * @return array<string, array{fieldDeclaration: array<string, mixed>, expectedTypeModifier: string}>
+     */
+    public static function provideSpatialColumnOptions(): array
+    {
+        return [
+            'geometry type only' => [
+                'fieldDeclaration' => ['geometry_type' => 'POINT'],
+                'expectedTypeModifier' => '(POINT)',
+            ],
+            'geometry type and srid' => [
+                'fieldDeclaration' => ['geometry_type' => 'POINT', 'srid' => 4326],
+                'expectedTypeModifier' => '(POINT,4326)',
+            ],
+            'srid only falls back to the any-geometry subtype' => [
+                'fieldDeclaration' => ['srid' => 4326],
+                'expectedTypeModifier' => '(GEOMETRY,4326)',
+            ],
+            'srid zero' => [
+                'fieldDeclaration' => ['geometry_type' => 'POINT', 'srid' => 0],
+                'expectedTypeModifier' => '(POINT,0)',
+            ],
+            'srid as a digit string' => [
+                'fieldDeclaration' => ['geometry_type' => 'POINT', 'srid' => '4326'],
+                'expectedTypeModifier' => '(POINT,4326)',
+            ],
+            'lowercase geometry type' => [
+                'fieldDeclaration' => ['geometry_type' => 'point', 'srid' => 4326],
+                'expectedTypeModifier' => '(POINT,4326)',
+            ],
+            'padded geometry type' => [
+                'fieldDeclaration' => ['geometry_type' => '  MultiPolygon  '],
+                'expectedTypeModifier' => '(MULTIPOLYGON)',
+            ],
+            'geometry type with Z modifier' => [
+                'fieldDeclaration' => ['geometry_type' => 'PointZ', 'srid' => 4326],
+                'expectedTypeModifier' => '(POINTZ,4326)',
+            ],
+            'geometry type with M modifier' => [
+                'fieldDeclaration' => ['geometry_type' => 'LineStringM'],
+                'expectedTypeModifier' => '(LINESTRINGM)',
+            ],
+            'geometry type with ZM modifier' => [
+                'fieldDeclaration' => ['geometry_type' => 'PolygonZM'],
+                'expectedTypeModifier' => '(POLYGONZM)',
+            ],
+            'explicit any-geometry subtype' => [
+                'fieldDeclaration' => ['geometry_type' => 'Geometry', 'srid' => 4326],
+                'expectedTypeModifier' => '(GEOMETRY,4326)',
+            ],
+            'curved geometry type' => [
+                'fieldDeclaration' => ['geometry_type' => 'CircularString', 'srid' => 4326],
+                'expectedTypeModifier' => '(CIRCULARSTRING,4326)',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidGeometryTypeOptions')]
+    #[Test]
+    public function throws_exception_for_invalid_geometry_type_option(mixed $geometryType): void
+    {
+        $this->expectException(InvalidSpatialColumnDeclarationException::class);
+
+        $this->fixture->getSQLDeclaration(['geometry_type' => $geometryType], $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidGeometryTypeOptions(): array
+    {
+        return [
+            'unknown geometry type' => ['CUBE'],
+            'unknown dimensional modifier' => ['PointX'],
+            'empty string' => [''],
+            'sql injection attempt' => ['POINT,4326); DROP TABLE users; --'],
+            'integer' => [4326],
+            'array' => [['POINT']],
+            'boolean' => [true],
+        ];
+    }
+
+    #[DataProvider('provideInvalidSridOptions')]
+    #[Test]
+    public function throws_exception_for_invalid_srid_option(mixed $srid): void
+    {
+        $this->expectException(InvalidSpatialColumnDeclarationException::class);
+
+        $this->fixture->getSQLDeclaration(['geometry_type' => 'POINT', 'srid' => $srid], $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidSridOptions(): array
+    {
+        return [
+            'negative integer' => [-1],
+            'non-numeric string' => ['four thousand'],
+            'sql injection attempt' => ['4326); DROP TABLE users; --'],
+            'float' => [4326.5],
+            'array' => [[4326]],
+            'boolean' => [true],
         ];
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Spatial columns support optional `geometry_type` and `srid` settings for constrained PostGIS declarations.
  - Database-level constraints can enforce geometry subtypes, dimensional variants, and spatial reference systems.
  - Invalid geometry types and SRIDs are rejected with validation errors.
  - Constrained geometry and geography columns support compatible value round-tripping, normalize SRID-less values where applicable, and reject mismatched geometry types.

- **Documentation**
  - Added configuration examples, generated DDL details, limitations, and guidance for spatial column options, including geography-specific SRID requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->