### PR TITLE
fix: preserve PostgreSQL's full float precision

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresFloatConversionTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresFloatConversionTrait.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace MartinGeorgiev\Doctrine\DBAL\Types\Traits;
 
 /**
- * Renders a single float in the textual form PostgreSQL accepts — a coordinate, but also a circle's radius and a
- * line's coefficients. Shared by the geometric value objects and by Cube, which does not extend their common base.
- *
  * @since 4.8
  *
  * @author Martin Georgiev <martin.georgiev@gmail.com>
@@ -15,9 +12,8 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types\Traits;
 trait PostgresFloatConversionTrait
 {
     /**
-     * Casting a float to string is bound by the `precision` ini setting (14 by default), which silently rewrites the
-     * value before it reaches PostgreSQL. Fall back to the 17-digit form, which always round-trips, whenever the short
-     * one does not.
+     * Casting a float to string is bound by the `precision` ini setting (14 by default). This rewrites the value before
+     * it reaches PostgreSQL. Fall back to the 17-digit form, which always round-trips, whenever the short one does not.
      */
     protected static function formatFloat(float $value): string
     {
@@ -34,7 +30,6 @@ trait PostgresFloatConversionTrait
             return $shortForm;
         }
 
-        // %H rather than %G because the latter honours LC_NUMERIC and would emit a comma PostgreSQL cannot parse.
         return \sprintf('%.17H', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresFloatConversionTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresFloatConversionTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Traits;
+
+/**
+ * Renders a single float in the textual form PostgreSQL accepts — a coordinate, but also a circle's radius and a
+ * line's coefficients. Shared by the geometric value objects and by Cube, which does not extend their common base.
+ *
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+trait PostgresFloatConversionTrait
+{
+    /**
+     * Casting a float to string is bound by the `precision` ini setting (14 by default), which silently rewrites the
+     * value before it reaches PostgreSQL. Fall back to the 17-digit form, which always round-trips, whenever the short
+     * one does not.
+     */
+    protected static function formatFloat(float $value): string
+    {
+        if (\is_nan($value)) {
+            return 'NaN';
+        }
+
+        if (\is_infinite($value)) {
+            return $value > 0 ? 'Infinity' : '-Infinity';
+        }
+
+        $shortForm = (string) $value;
+        if ((float) $shortForm === $value) {
+            return $shortForm;
+        }
+
+        // %H rather than %G because the latter honours LC_NUMERIC and would emit a comma PostgreSQL cannot parse.
+        return \sprintf('%.17H', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/BaseGeometricValue.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/BaseGeometricValue.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Doctrine\DBAL\Types\ValueObject;
 
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\PostgresFloatConversionTrait;
+
 /**
  * @since 4.5
  *
@@ -11,6 +13,8 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types\ValueObject;
  */
 abstract readonly class BaseGeometricValue implements \Stringable
 {
+    use PostgresFloatConversionTrait;
+
     /**
      * @var string
      */

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Box.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Box.php
@@ -32,10 +32,10 @@ final readonly class Box extends BaseGeometricValue
     {
         return \sprintf(
             '(%s,%s),(%s,%s)',
-            $this->upperRight->getX(),
-            $this->upperRight->getY(),
-            $this->lowerLeft->getX(),
-            $this->lowerLeft->getY()
+            self::formatFloat($this->upperRight->getX()),
+            self::formatFloat($this->upperRight->getY()),
+            self::formatFloat($this->lowerLeft->getX()),
+            self::formatFloat($this->lowerLeft->getY())
         );
     }
 

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Circle.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Circle.php
@@ -39,7 +39,12 @@ final readonly class Circle extends BaseGeometricValue
 
     public function __toString(): string
     {
-        return \sprintf('<(%s,%s),%s>', $this->center->getX(), $this->center->getY(), $this->radius);
+        return \sprintf(
+            '<(%s,%s),%s>',
+            self::formatFloat($this->center->getX()),
+            self::formatFloat($this->center->getY()),
+            self::formatFloat($this->radius)
+        );
     }
 
     public function getCenter(): Point

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Cube.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Cube.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Doctrine\DBAL\Types\ValueObject;
 
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\PostgresFloatConversionTrait;
 use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidCubeException;
 
 /**
@@ -23,6 +24,8 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidCubeExcepti
  */
 final readonly class Cube implements \Stringable
 {
+    use PostgresFloatConversionTrait;
+
     /**
      * PostgreSQL rejects anything above this with "A cube cannot have more than 100 dimensions".
      */
@@ -196,25 +199,6 @@ final readonly class Cube implements \Stringable
      */
     private function formatCorner(array $coordinates): string
     {
-        return '('.\implode(', ', \array_map($this->formatCoordinate(...), $coordinates)).')';
-    }
-
-    /**
-     * Casting a float to string uses the `precision` ini setting, which silently rewrites stored values in full float8
-     * precision. Fall back to the 17-digit form, which always round-trips, whenever the short one does not.
-     */
-    private function formatCoordinate(float $coordinate): string
-    {
-        if (\is_nan($coordinate)) {
-            return 'NaN';
-        }
-
-        if (\is_infinite($coordinate)) {
-            return $coordinate > 0 ? 'Infinity' : '-Infinity';
-        }
-
-        $shortForm = (string) $coordinate;
-
-        return (float) $shortForm === $coordinate ? $shortForm : \sprintf('%.17G', $coordinate);
+        return '('.\implode(', ', \array_map($this->formatFloat(...), $coordinates)).')';
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Line.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Line.php
@@ -35,7 +35,12 @@ final readonly class Line extends BaseGeometricValue
 
     public function __toString(): string
     {
-        return \sprintf('{%s,%s,%s}', (string) $this->a, (string) $this->b, (string) $this->c);
+        return \sprintf(
+            '{%s,%s,%s}',
+            self::formatFloat($this->a),
+            self::formatFloat($this->b),
+            self::formatFloat($this->c)
+        );
     }
 
     public function getA(): float

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Lseg.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Lseg.php
@@ -37,10 +37,10 @@ final readonly class Lseg extends BaseGeometricValue
     {
         return \sprintf(
             '[(%s,%s),(%s,%s)]',
-            $this->start->getX(),
-            $this->start->getY(),
-            $this->end->getX(),
-            $this->end->getY()
+            self::formatFloat($this->start->getX()),
+            self::formatFloat($this->start->getY()),
+            self::formatFloat($this->end->getX()),
+            self::formatFloat($this->end->getY())
         );
     }
 

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Path.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Path.php
@@ -43,7 +43,11 @@ final readonly class Path extends BaseGeometricValue
     public function __toString(): string
     {
         $pointStrings = \array_map(
-            static fn (Point $point): string => \sprintf('(%s,%s)', $point->getX(), $point->getY()),
+            static fn (Point $point): string => \sprintf(
+                '(%s,%s)',
+                self::formatFloat($point->getX()),
+                self::formatFloat($point->getY())
+            ),
             $this->points
         );
         $inner = \implode(',', $pointStrings);

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Point.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Point.php
@@ -33,7 +33,7 @@ final readonly class Point extends BaseGeometricValue
 
     public function __toString(): string
     {
-        return \sprintf('(%s,%s)', $this->x, $this->y);
+        return \sprintf('(%s,%s)', self::formatFloat($this->x), self::formatFloat($this->y));
     }
 
     public function getX(): float

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Polygon.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Polygon.php
@@ -39,7 +39,11 @@ final readonly class Polygon extends BaseGeometricValue
     public function __toString(): string
     {
         $vertexStrings = \array_map(
-            static fn (Point $point): string => \sprintf('(%s,%s)', $point->getX(), $point->getY()),
+            static fn (Point $point): string => \sprintf(
+                '(%s,%s)',
+                self::formatFloat($point->getX()),
+                self::formatFloat($point->getY())
+            ),
             $this->vertices
         );
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/BoxTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/BoxTest.php
@@ -70,4 +70,16 @@ final class BoxTest extends TestCase
         $box = new Box(new Point(1.0, 2.0), new Point(3.0, 4.0));
         $this->assertSame('(1,2),(3,4)', (string) $box);
     }
+
+    #[Test]
+    public function preserves_full_float_precision(): void
+    {
+        $coordinate = 0.12345678901234568;
+
+        $box = new Box(new Point($coordinate, 2.0), new Point(3.0, -$coordinate));
+
+        $this->assertSame('(0.12345678901234568,2),(3,-0.12345678901234568)', (string) $box);
+        $this->assertSame($coordinate, Box::fromString((string) $box)->getUpperRight()->getX());
+        $this->assertSame(-$coordinate, Box::fromString((string) $box)->getLowerLeft()->getY());
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/CircleTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/CircleTest.php
@@ -77,4 +77,15 @@ final class CircleTest extends TestCase
         $this->expectException(InvalidCircleException::class);
         new Circle(new Point(0.0, 0.0), -1.0);
     }
+
+    #[Test]
+    public function preserves_full_float_precision(): void
+    {
+        $coordinate = 0.12345678901234568;
+
+        $circle = new Circle(new Point($coordinate, -$coordinate), $coordinate);
+
+        $this->assertSame('<(0.12345678901234568,-0.12345678901234568),0.12345678901234568>', (string) $circle);
+        $this->assertSame($coordinate, Circle::fromString((string) $circle)->getRadius());
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/LineTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/LineTest.php
@@ -87,4 +87,16 @@ final class LineTest extends TestCase
         $line = new Line(1.1234567890123, 2.0, 3.0);
         $this->assertSame(1.1234567890123, $line->getA());
     }
+
+    #[Test]
+    public function preserves_full_float_precision(): void
+    {
+        $coefficient = 0.12345678901234568;
+
+        $line = new Line($coefficient, 2.0, -$coefficient);
+
+        $this->assertSame('{0.12345678901234568,2,-0.12345678901234568}', (string) $line);
+        $this->assertSame($coefficient, Line::fromString((string) $line)->getA());
+        $this->assertSame(-$coefficient, Line::fromString((string) $line)->getC());
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/LsegTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/LsegTest.php
@@ -83,4 +83,16 @@ final class LsegTest extends TestCase
         $lseg = Lseg::fromString('(1,2),(3,4)');
         $this->assertSame('[(1,2),(3,4)]', (string) $lseg);
     }
+
+    #[Test]
+    public function preserves_full_float_precision(): void
+    {
+        $coordinate = 0.12345678901234568;
+
+        $lseg = new Lseg(new Point($coordinate, 2.0), new Point(3.0, -$coordinate));
+
+        $this->assertSame('[(0.12345678901234568,2),(3,-0.12345678901234568)]', (string) $lseg);
+        $this->assertSame($coordinate, Lseg::fromString((string) $lseg)->getStart()->getX());
+        $this->assertSame(-$coordinate, Lseg::fromString((string) $lseg)->getEnd()->getY());
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PathTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PathTest.php
@@ -89,4 +89,16 @@ final class PathTest extends TestCase
         $this->assertSame('[(1,2),(3,4)]', (string) $path);
         $this->assertTrue($path->isOpen());
     }
+
+    #[Test]
+    public function preserves_full_float_precision(): void
+    {
+        $coordinate = 0.12345678901234568;
+
+        $path = new Path(true, new Point($coordinate, 2.0), new Point(3.0, -$coordinate));
+
+        $this->assertSame('[(0.12345678901234568,2),(3,-0.12345678901234568)]', (string) $path);
+        $this->assertSame($coordinate, Path::fromString((string) $path)->getPoints()[0]->getX());
+        $this->assertSame(-$coordinate, Path::fromString((string) $path)->getPoints()[1]->getY());
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PointTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PointTest.php
@@ -102,6 +102,38 @@ final class PointTest extends TestCase
     }
 
     #[Test]
+    public function preserves_full_float_precision(): void
+    {
+        $coordinate = 0.12345678901234568;
+
+        $point = new Point($coordinate, -$coordinate);
+
+        $this->assertSame('(0.12345678901234568,-0.12345678901234568)', (string) $point);
+        $this->assertSame($coordinate, Point::fromString((string) $point)->getX());
+        $this->assertSame(-$coordinate, Point::fromString((string) $point)->getY());
+    }
+
+    #[Test]
+    public function preserves_full_float_precision_under_a_comma_decimal_locale(): void
+    {
+        $originalLocale = \setlocale(\LC_NUMERIC, '0');
+        if (\setlocale(\LC_NUMERIC, 'de_DE.UTF-8', 'de_DE', 'German_Germany', 'nl_NL.UTF-8') === false) {
+            $this->markTestSkipped('No comma-decimal locale is installed on this machine');
+        }
+
+        // The full-precision fallback only runs when the short form does not round-trip, which needs a low precision.
+        $originalPrecision = \ini_get('precision');
+        \ini_set('precision', '3');
+
+        try {
+            $this->assertSame('(0.12345678901234568,1)', (string) new Point(0.12345678901234568, 1.0));
+        } finally {
+            \ini_set('precision', (string) $originalPrecision);
+            \setlocale(\LC_NUMERIC, (string) $originalLocale);
+        }
+    }
+
+    #[Test]
     public function accepts_high_precision_coordinates(): void
     {
         $point = new Point(45.123456789012, 179.987654321098);

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PolygonTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PolygonTest.php
@@ -75,6 +75,18 @@ final class PolygonTest extends TestCase
     }
 
     #[Test]
+    public function preserves_full_float_precision(): void
+    {
+        $coordinate = 0.12345678901234568;
+
+        $polygon = new Polygon(new Point($coordinate, 2.0), new Point(3.0, -$coordinate));
+
+        $this->assertSame('((0.12345678901234568,2),(3,-0.12345678901234568))', (string) $polygon);
+        $this->assertSame($coordinate, Polygon::fromString((string) $polygon)->getVertices()[0]->getX());
+        $this->assertSame(-$coordinate, Polygon::fromString((string) $polygon)->getVertices()[1]->getY());
+    }
+
+    #[Test]
     public function throws_exception_for_too_few_vertices(): void
     {
         $this->expectException(InvalidPolygonException::class);


### PR DESCRIPTION
Casting a float to string is bound by the `precision` ini setting (14 by default), so a coordinate such as 0.1234567890123**4568** reached PostgreSQL as 0.1234567890123**5**. Format coordinates through a shared helper that emits the short form only when it round-trips and falls back to the ini-independent 17-digit form otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved serialization of geometric values to preserve full floating-point precision.
  - Correctly retains special values such as `NaN` and positive or negative infinity.
  - Ensures serialized geometric values can be parsed back without losing coordinate, coefficient, or radius accuracy.

- **Tests**
  - Added coverage for precision-preserving serialization and round-trip parsing across supported geometric value types, including points, lines, paths, polygons, boxes, circles, and line segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->