### PR TITLE
feat: add support non-finite coordinates in geometric value objects

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresFloatConversionTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresFloatConversionTrait.php
@@ -12,6 +12,19 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types\Traits;
 trait PostgresFloatConversionTrait
 {
     /**
+     * A float without its sign, for the operands PostgreSQL never accepts a negative value for, such as a radius.
+     * The non-finite spellings (inf, infinity, nan) are part of the grammar; PostgreSQL emits them capitalised.
+     *
+     * @var string
+     */
+    protected const UNSIGNED_FLOAT_PATTERN = '(?:(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?|(?i:inf(?:inity)?|nan))';
+
+    /**
+     * @var string
+     */
+    protected const FLOAT_PATTERN = '[+-]?'.self::UNSIGNED_FLOAT_PATTERN;
+
+    /**
      * Casting a float to string is bound by the `precision` ini setting (14 by default). This rewrites the value before
      * it reaches PostgreSQL. Fall back to the 17-digit form, which always round-trips, whenever the short one does not.
      */
@@ -31,5 +44,18 @@ trait PostgresFloatConversionTrait
         }
 
         return \sprintf('%.17H', $value);
+    }
+
+    /**
+     * Casting a string to float yields 0.0 for every non-finite spelling PostgreSQL uses. Those are matched explicitly.
+     */
+    protected static function parseFloat(string $value): float
+    {
+        return match (\mb_strtolower(\ltrim($value, '+'))) {
+            'nan', '-nan' => \NAN,
+            'inf', 'infinity' => \INF,
+            '-inf', '-infinity' => -\INF,
+            default => (float) $value,
+        };
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/BaseGeometricValue.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/BaseGeometricValue.php
@@ -18,17 +18,12 @@ abstract readonly class BaseGeometricValue implements \Stringable
     /**
      * @var string
      */
-    protected const COORDINATE_PATTERN = '-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?';
+    protected const POINT_PATTERN = '\(\s*'.self::FLOAT_PATTERN.'\s*,\s*'.self::FLOAT_PATTERN.'\s*\)';
 
     /**
      * @var string
      */
-    protected const POINT_PATTERN = '\(\s*'.self::COORDINATE_PATTERN.'\s*,\s*'.self::COORDINATE_PATTERN.'\s*\)';
-
-    /**
-     * @var string
-     */
-    protected const POINT_CAPTURE_REGEX = '/\(\s*('.self::COORDINATE_PATTERN.')\s*,\s*('.self::COORDINATE_PATTERN.')\s*\)/';
+    protected const POINT_CAPTURE_REGEX = '/\(\s*('.self::FLOAT_PATTERN.')\s*,\s*('.self::FLOAT_PATTERN.')\s*\)/';
 
     /**
      * @return list<Point>
@@ -38,7 +33,7 @@ abstract readonly class BaseGeometricValue implements \Stringable
         \preg_match_all(self::POINT_CAPTURE_REGEX, $value, $matches, PREG_SET_ORDER);
 
         return \array_map(
-            static fn (array $match): Point => new Point((float) $match[1], (float) $match[2]),
+            static fn (array $match): Point => new Point(self::parseFloat($match[1]), self::parseFloat($match[2])),
             $matches
         );
     }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Circle.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Circle.php
@@ -19,14 +19,17 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidCircleExcep
 final readonly class Circle extends BaseGeometricValue
 {
     /**
+     * PostgreSQL accepts a NaN or Infinity radius but rejects every negative one, -Infinity included, so this pattern
+     * stays unsigned while allowing the non-finite spellings.
+     *
      * @var string
      */
-    private const RADIUS_PATTERN = '\d+(?:\.\d+)?(?:[eE][+-]?\d+)?';
+    private const RADIUS_PATTERN = self::UNSIGNED_FLOAT_PATTERN;
 
     /**
      * @var string
      */
-    private const CIRCLE_REGEX = '/^<\s*\(\s*('.self::COORDINATE_PATTERN.')\s*,\s*('.self::COORDINATE_PATTERN.')\s*\)\s*,\s*('.self::RADIUS_PATTERN.')\s*>$/';
+    private const CIRCLE_REGEX = '/^<\s*\(\s*('.self::FLOAT_PATTERN.')\s*,\s*('.self::FLOAT_PATTERN.')\s*\)\s*,\s*('.self::RADIUS_PATTERN.')\s*>$/';
 
     public function __construct(
         private Point $center,
@@ -63,6 +66,9 @@ final readonly class Circle extends BaseGeometricValue
             throw InvalidCircleException::forInvalidFormat($value, self::CIRCLE_REGEX);
         }
 
-        return new self(new Point((float) $matches[1], (float) $matches[2]), (float) $matches[3]);
+        return new self(
+            new Point(self::parseFloat($matches[1]), self::parseFloat($matches[2])),
+            self::parseFloat($matches[3])
+        );
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Cube.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Cube.php
@@ -32,17 +32,9 @@ final readonly class Cube implements \Stringable
     private const MAX_DIMENSIONS = 100;
 
     /**
-     * PostgreSQL accepts non-finite coordinates in several spellings (nan, inf, -inf, infinity).
-     * PostgreSQL always emits these as NaN, Infinity or -Infinity.
-     *
      * @var string
      */
-    private const COORDINATE_PATTERN = '(?:[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?|[+-]?(?i:inf(?:inity)?|nan))';
-
-    /**
-     * @var string
-     */
-    private const COORDINATE_LIST_PATTERN = self::COORDINATE_PATTERN.'(?:\s*,\s*'.self::COORDINATE_PATTERN.')*';
+    private const COORDINATE_LIST_PATTERN = self::FLOAT_PATTERN.'(?:\s*,\s*'.self::FLOAT_PATTERN.')*';
 
     /**
      * @var string
@@ -178,20 +170,7 @@ final readonly class Cube implements \Stringable
         $parts = \preg_split('/\s*,\s*/', \trim($coordinateList));
         \assert(\is_array($parts));
 
-        return \array_map(self::parseCoordinate(...), $parts);
-    }
-
-    /**
-     * Casting a string to float yields 0.0 for every non-finite spelling PostgreSQL uses. Those are matched explicitly.
-     */
-    private static function parseCoordinate(string $coordinate): float
-    {
-        return match (\mb_strtolower(\ltrim($coordinate, '+'))) {
-            'nan', '-nan' => \NAN,
-            'inf', 'infinity' => \INF,
-            '-inf', '-infinity' => -\INF,
-            default => (float) $coordinate,
-        };
+        return \array_map(self::parseFloat(...), $parts);
     }
 
     /**

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Exceptions/InvalidPointException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Exceptions/InvalidPointException.php
@@ -24,20 +24,4 @@ final class InvalidPointException extends \InvalidArgumentException
             \var_export($pointString, true)
         ));
     }
-
-    public static function forNonFiniteCoordinate(float $value): self
-    {
-        if (\is_nan($value)) {
-            $representation = 'NAN';
-        } elseif ($value > 0) {
-            $representation = 'INF';
-        } else {
-            $representation = '-INF';
-        }
-
-        return new self(\sprintf(
-            'Point coordinates must be finite numbers, got: %s',
-            $representation
-        ));
-    }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Line.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Line.php
@@ -21,7 +21,7 @@ final readonly class Line extends BaseGeometricValue
     /**
      * @var string
      */
-    private const LINE_REGEX = '/^\{\s*('.self::COORDINATE_PATTERN.'),\s*('.self::COORDINATE_PATTERN.'),\s*('.self::COORDINATE_PATTERN.')\s*\}$/';
+    private const LINE_REGEX = '/^\{\s*('.self::FLOAT_PATTERN.'),\s*('.self::FLOAT_PATTERN.'),\s*('.self::FLOAT_PATTERN.')\s*\}$/';
 
     public function __construct(
         private float $a,
@@ -64,6 +64,10 @@ final readonly class Line extends BaseGeometricValue
             throw InvalidLineException::forInvalidFormat($value, self::LINE_REGEX);
         }
 
-        return new self((float) $matches[1], (float) $matches[2], (float) $matches[3]);
+        return new self(
+            self::parseFloat($matches[1]),
+            self::parseFloat($matches[2]),
+            self::parseFloat($matches[3])
+        );
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Point.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Point.php
@@ -16,20 +16,12 @@ final readonly class Point extends BaseGeometricValue
     /**
      * @var string
      */
-    private const POINT_REGEX = '/^\(\s*('.self::COORDINATE_PATTERN.')\s*,\s*('.self::COORDINATE_PATTERN.')\s*\)$/';
+    private const POINT_REGEX = '/^\(\s*('.self::FLOAT_PATTERN.')\s*,\s*('.self::FLOAT_PATTERN.')\s*\)$/';
 
     public function __construct(
         private float $x,
         private float $y,
-    ) {
-        if (!\is_finite($x)) {
-            throw InvalidPointException::forNonFiniteCoordinate($x);
-        }
-
-        if (!\is_finite($y)) {
-            throw InvalidPointException::forNonFiniteCoordinate($y);
-        }
-    }
+    ) {}
 
     public function __toString(): string
     {
@@ -52,6 +44,6 @@ final readonly class Point extends BaseGeometricValue
             throw InvalidPointException::forInvalidPointFormat($pointString, self::POINT_REGEX);
         }
 
-        return new self((float) $matches[1], (float) $matches[2]);
+        return new self(self::parseFloat($matches[1]), self::parseFloat($matches[2]));
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/BoxTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/BoxTypeTest.php
@@ -53,7 +53,22 @@ final class BoxTypeTest extends TestCase
                 BoxValueObject::fromString('(-3,-4),(-1,-2)'),
                 BoxValueObject::fromString('(-1,-2),(-3,-4)'),
             ],
+            'box with infinite coordinates' => [
+                BoxValueObject::fromString('(-Infinity,-2),(Infinity,2)'),
+                BoxValueObject::fromString('(Infinity,2),(-Infinity,-2)'),
+            ],
         ];
+    }
+
+    #[Test]
+    public function roundtrips_nan_coordinate(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $box = BoxValueObject::fromString('(NaN,2),(Infinity,-Infinity)');
+
+        $this->runDbalBindingRoundTripAssertingRepresentation($typeName, $columnType, $box);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CircleTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CircleTypeTest.php
@@ -44,7 +44,20 @@ final class CircleTypeTest extends TestCase
             'unit circle at origin' => [CircleValueObject::fromString('<(0,0),1>')],
             'circle with floats' => [CircleValueObject::fromString('<(1.5,2.5),3.5>')],
             'circle with negative center' => [CircleValueObject::fromString('<(-10,-20),5>')],
+            'circle with infinite center' => [CircleValueObject::fromString('<(Infinity,-Infinity),1>')],
+            'circle with infinite radius' => [CircleValueObject::fromString('<(1,2),Infinity>')],
         ];
+    }
+
+    #[Test]
+    public function roundtrips_nan_coordinate(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $circle = CircleValueObject::fromString('<(NaN,2),Infinity>');
+
+        $this->runDbalBindingRoundTripAssertingRepresentation($typeName, $columnType, $circle);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CubeTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CubeTypeTest.php
@@ -50,30 +50,29 @@ final class CubeTypeTest extends ScalarTypeTestCase
         ];
     }
 
+    #[DataProvider('provideNanCoordinates')]
     #[Test]
-    public function roundtrips_nan_coordinate(): void
+    public function roundtrips_nan_coordinate(CubeValueObject $cubeValueObject): void
     {
-        // NaN never equals itself, so the round-trip is asserted on the emitted representation.
         $typeName = $this->getTypeName();
         $columnType = $this->getPostgresTypeName();
 
-        [$tableName, $columnName] = $this->prepareTestTable($columnType);
+        $this->runDbalBindingRoundTripAssertingRepresentation($typeName, $columnType, $cubeValueObject);
+    }
 
-        try {
-            $this->connection->createQueryBuilder()
-                ->insert(self::DATABASE_SCHEMA.'.'.$tableName)
-                ->values([$columnName => ':value'])
-                ->setParameter('value', new CubeValueObject([\NAN, 1.0]), $typeName)
-                ->executeStatement();
-
-            $retrieved = $this->fetchConvertedValue($typeName, $tableName, $columnName);
-
-            $this->assertInstanceOf(CubeValueObject::class, $retrieved);
-            $this->assertSame('(NaN, 1)', (string) $retrieved);
-            $this->assertNan($retrieved->getFirstCorner()[0]);
-        } finally {
-            $this->dropTestTableIfItExists($tableName);
-        }
+    /**
+     * NaN never equals itself, so these cannot live in provideValidTransformations() — the round-trip there compares
+     * value objects, while these are asserted on the emitted representation.
+     *
+     * @return array<string, array{CubeValueObject}>
+     */
+    public static function provideNanCoordinates(): array
+    {
+        return [
+            'nan in a point' => [new CubeValueObject([\NAN, 1.0])],
+            'nan in both corners' => [new CubeValueObject([\NAN, 1.0], [\NAN, 2.0])],
+            'nan mixed with infinity' => [new CubeValueObject([\NAN, -\INF])],
+        ];
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LineTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LineTypeTest.php
@@ -44,7 +44,17 @@ final class LineTypeTest extends TestCase
             'simple line' => [LineValueObject::fromString('{1,0,0}')],
             'line with floats' => [LineValueObject::fromString('{1.5,2.5,3.5}')],
             'line with negative coefficients' => [LineValueObject::fromString('{-1,-2,-3}')],
+            'line with infinite coefficient' => [LineValueObject::fromString('{1,0,-Infinity}')],
         ];
+    }
+
+    #[Test]
+    public function roundtrips_nan_coefficient(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTripAssertingRepresentation($typeName, $columnType, new LineValueObject(\NAN, 1.0, -\INF));
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LsegTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LsegTypeTest.php
@@ -44,7 +44,19 @@ final class LsegTypeTest extends TestCase
             'simple segment' => [LsegValueObject::fromString('[(0,0),(1,1)]')],
             'segment with floats' => [LsegValueObject::fromString('[(1.5,2.5),(3.5,4.5)]')],
             'segment with negative coordinates' => [LsegValueObject::fromString('[(-1,-2),(-3,-4)]')],
+            'segment with infinite coordinates' => [LsegValueObject::fromString('[(Infinity,2),(-Infinity,-2)]')],
         ];
+    }
+
+    #[Test]
+    public function roundtrips_nan_coordinate(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $lseg = LsegValueObject::fromString('[(NaN,2),(Infinity,-Infinity)]');
+
+        $this->runDbalBindingRoundTripAssertingRepresentation($typeName, $columnType, $lseg);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PathTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PathTypeTest.php
@@ -45,7 +45,19 @@ final class PathTypeTest extends TestCase
             'closed path' => [PathValueObject::fromString('((0,0),(1,1),(2,0))')],
             'path with floats' => [PathValueObject::fromString('[(1.5,2.5),(3.5,4.5)]')],
             'path with negative coordinates' => [PathValueObject::fromString('[(-1,-2),(-3,-4)]')],
+            'path with infinite coordinates' => [PathValueObject::fromString('[(Infinity,2),(-Infinity,-2)]')],
         ];
+    }
+
+    #[Test]
+    public function roundtrips_nan_coordinate(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $path = PathValueObject::fromString('[(NaN,2),(Infinity,-Infinity)]');
+
+        $this->runDbalBindingRoundTripAssertingRepresentation($typeName, $columnType, $path);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PointTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PointTypeTest.php
@@ -60,6 +60,33 @@ final class PointTypeTest extends TestCase
             'negative coordinates' => [new PointValueObject(-10.5, -20.75)],
             'high precision' => [new PointValueObject(123.456789, -987.654321)],
             'integer coordinates' => [new PointValueObject(100, 200)],
+            'infinite coordinates' => [new PointValueObject(\INF, -\INF)],
+        ];
+    }
+
+    #[DataProvider('provideNanCoordinates')]
+    #[Test]
+    public function roundtrips_nan_coordinate(PointValueObject $pointValueObject): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTripAssertingRepresentation($typeName, $columnType, $pointValueObject);
+    }
+
+    /**
+     * NaN never equals itself, so these cannot live in provideValidTransformations() — the round-trip there compares
+     * value objects, while these are asserted on the emitted representation.
+     *
+     * @return array<string, array{PointValueObject}>
+     */
+    public static function provideNanCoordinates(): array
+    {
+        return [
+            'nan x' => [new PointValueObject(\NAN, 1.0)],
+            'nan y' => [new PointValueObject(1.0, \NAN)],
+            'both nan' => [new PointValueObject(\NAN, \NAN)],
+            'nan with infinity' => [new PointValueObject(\NAN, \INF)],
         ];
     }
 

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PolygonTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PolygonTypeTest.php
@@ -45,7 +45,19 @@ final class PolygonTypeTest extends TestCase
             'square' => [PolygonValueObject::fromString('((0,0),(0,1),(1,1),(1,0))')],
             'polygon with floats' => [PolygonValueObject::fromString('((1.5,2.5),(3.5,4.5),(5.5,6.5))')],
             'polygon with negative coordinates' => [PolygonValueObject::fromString('((-1,-2),(-3,-4),(-5,-6))')],
+            'polygon with infinite coordinates' => [PolygonValueObject::fromString('((Infinity,2),(-Infinity,-2),(5,6))')],
         ];
+    }
+
+    #[Test]
+    public function roundtrips_nan_coordinate(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $polygon = PolygonValueObject::fromString('((NaN,2),(Infinity,-Infinity),(5,6))');
+
+        $this->runDbalBindingRoundTripAssertingRepresentation($typeName, $columnType, $polygon);
     }
 
     #[Test]

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TestCase.php
@@ -132,6 +132,30 @@ abstract class TestCase extends BaseTestCase
         }
     }
 
+    /**
+     * Perform a round-trip asserting on the emitted representation rather than on value equality.
+     * Needed for values carrying NaN, which never equals itself and so can never satisfy an equality-based assertion.
+     */
+    protected function runDbalBindingRoundTripAssertingRepresentation(string $typeName, string $columnType, \Stringable $stringable): void
+    {
+        [$tableName, $columnName] = $this->prepareTestTable($columnType);
+
+        try {
+            $this->connection->createQueryBuilder()
+                ->insert(self::DATABASE_SCHEMA.'.'.$tableName)
+                ->values([$columnName => ':value'])
+                ->setParameter('value', $stringable, $typeName)
+                ->executeStatement();
+
+            $retrieved = $this->fetchConvertedValue($typeName, $tableName, $columnName);
+
+            $this->assertInstanceOf($stringable::class, $retrieved);
+            $this->assertSame((string) $stringable, (string) $retrieved);
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
+    }
+
     protected function createTestTableForDataType(string $tableName, string $columnName, string $columnType): void
     {
         $this->dropTestTableIfItExists($tableName);

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/BoxTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/BoxTest.php
@@ -31,6 +31,8 @@ final class BoxTest extends TestCase
         yield 'negative coordinates' => ['(-1,-2),(-3,-4)', '(-1,-2),(-3,-4)'];
         yield 'zero coordinates' => ['(0,0),(1,1)', '(0,0),(1,1)'];
         yield 'mixed positive and negative' => ['(-1,2),(3,-4)', '(-1,2),(3,-4)'];
+        yield 'non-finite coordinates' => ['(NaN,2),(Infinity,-Infinity)', '(NaN,2),(Infinity,-Infinity)'];
+        yield 'short non-finite spellings' => ['(nan,2),(inf,-inf)', '(NaN,2),(Infinity,-Infinity)'];
     }
 
     #[DataProvider('provideInvalidBoxStrings')]
@@ -69,6 +71,19 @@ final class BoxTest extends TestCase
     {
         $box = new Box(new Point(1.0, 2.0), new Point(3.0, 4.0));
         $this->assertSame('(1,2),(3,4)', (string) $box);
+    }
+
+    #[Test]
+    public function accepts_non_finite_coordinates(): void
+    {
+        $box = new Box(new Point(\NAN, 2.0), new Point(\INF, -\INF));
+
+        $this->assertSame('(NaN,2),(Infinity,-Infinity)', (string) $box);
+
+        $parsed = Box::fromString((string) $box);
+        $this->assertNan($parsed->getUpperRight()->getX());
+        $this->assertSame(\INF, $parsed->getLowerLeft()->getX());
+        $this->assertSame(-\INF, $parsed->getLowerLeft()->getY());
     }
 
     #[Test]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/CircleTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/CircleTest.php
@@ -31,6 +31,9 @@ final class CircleTest extends TestCase
         yield 'circle with negative center' => ['<(-1,-2),5>', '<(-1,-2),5>'];
         yield 'circle at origin' => ['<(0,0),1>', '<(0,0),1>'];
         yield 'circle with float radius' => ['<(0,0),1.5>', '<(0,0),1.5>'];
+        yield 'non-finite center' => ['<(NaN,-Infinity),3>', '<(NaN,-Infinity),3>'];
+        yield 'non-finite radius' => ['<(1,2),Infinity>', '<(1,2),Infinity>'];
+        yield 'short non-finite spellings' => ['<(nan,inf),nan>', '<(NaN,Infinity),NaN>'];
     }
 
     #[DataProvider('provideInvalidCircleStrings')]
@@ -53,6 +56,7 @@ final class CircleTest extends TestCase
         yield 'line format' => ['{1,2,3}'];
         yield 'only center, no radius' => ['<(1,2)>'];
         yield 'negative radius' => ['<(0,0),-1>'];
+        yield 'negative infinite radius' => ['<(0,0),-Infinity>'];
     }
 
     #[Test]
@@ -76,6 +80,29 @@ final class CircleTest extends TestCase
     {
         $this->expectException(InvalidCircleException::class);
         new Circle(new Point(0.0, 0.0), -1.0);
+    }
+
+    #[Test]
+    public function accepts_non_finite_center_and_radius(): void
+    {
+        $circle = new Circle(new Point(\NAN, -\INF), \INF);
+
+        $this->assertSame('<(NaN,-Infinity),Infinity>', (string) $circle);
+
+        $parsed = Circle::fromString((string) $circle);
+        $this->assertNan($parsed->getCenter()->getX());
+        $this->assertSame(-\INF, $parsed->getCenter()->getY());
+        $this->assertSame(\INF, $parsed->getRadius());
+    }
+
+    /**
+     * PostgreSQL rejects every negative radius, -Infinity included, so the existing guard already matches it.
+     */
+    #[Test]
+    public function throws_exception_for_negative_infinite_radius(): void
+    {
+        $this->expectException(InvalidCircleException::class);
+        new Circle(new Point(0.0, 0.0), -\INF);
     }
 
     #[Test]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Int4RangeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Int4RangeTest.php
@@ -120,6 +120,27 @@ final class Int4RangeTest extends BaseRangeTestCase
         yield 'empty' => ['empty', Int4Range::empty()];
     }
 
+    #[DataProvider('provideNonIntegerBounds')]
+    #[Test]
+    public function throws_for_non_integer_bound_from_string(string $input): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not a valid integer');
+
+        Int4Range::fromString($input);
+    }
+
+    /**
+     * @return \Generator<string, array{string}>
+     */
+    public static function provideNonIntegerBounds(): \Generator
+    {
+        yield 'non-numeric lower bound' => ['[abc,10)'];
+        yield 'non-numeric upper bound' => ['[1,abc)'];
+        yield 'decimal lower bound' => ['[1.5,10)'];
+        yield 'trailing characters' => ['[10abc,20)'];
+    }
+
     #[Test]
     public function validates_int4_bounds_for_lower(): void
     {

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/LineTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/LineTest.php
@@ -30,6 +30,8 @@ final class LineTest extends TestCase
         yield 'line with negative coefficients' => ['{-1,-2,-3}', '{-1,-2,-3}'];
         yield 'line through origin' => ['{1,2,0}', '{1,2,0}'];
         yield 'line with zero A' => ['{0,1,-2}', '{0,1,-2}'];
+        yield 'non-finite coefficients' => ['{NaN,1,-Infinity}', '{NaN,1,-Infinity}'];
+        yield 'short non-finite spellings' => ['{nan,1,inf}', '{NaN,1,Infinity}'];
     }
 
     #[Test]
@@ -86,6 +88,18 @@ final class LineTest extends TestCase
     {
         $line = new Line(1.1234567890123, 2.0, 3.0);
         $this->assertSame(1.1234567890123, $line->getA());
+    }
+
+    #[Test]
+    public function accepts_non_finite_coefficients(): void
+    {
+        $line = new Line(\NAN, 1.0, -\INF);
+
+        $this->assertSame('{NaN,1,-Infinity}', (string) $line);
+
+        $parsed = Line::fromString((string) $line);
+        $this->assertNan($parsed->getA());
+        $this->assertSame(-\INF, $parsed->getC());
     }
 
     #[Test]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/LsegTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/LsegTest.php
@@ -36,6 +36,8 @@ final class LsegTest extends TestCase
         yield 'with whitespace before closing bracket' => ['[(1,2),(3,4) ]', '[(1,2),(3,4)]'];
         yield 'with whitespace around comma between points' => ['[(1,2) , (3,4)]', '[(1,2),(3,4)]'];
         yield 'with mixed whitespace variations' => ['[ ( 1 , 2 ) , ( 3 , 4 ) ]', '[(1,2),(3,4)]'];
+        yield 'with non-finite coordinates' => ['[(NaN,2),(Infinity,-Infinity)]', '[(NaN,2),(Infinity,-Infinity)]'];
+        yield 'with short non-finite spellings' => ['[(nan,2),(inf,-inf)]', '[(NaN,2),(Infinity,-Infinity)]'];
     }
 
     #[Test]
@@ -82,6 +84,19 @@ final class LsegTest extends TestCase
     {
         $lseg = Lseg::fromString('(1,2),(3,4)');
         $this->assertSame('[(1,2),(3,4)]', (string) $lseg);
+    }
+
+    #[Test]
+    public function accepts_non_finite_coordinates(): void
+    {
+        $lseg = new Lseg(new Point(\NAN, 2.0), new Point(\INF, -\INF));
+
+        $this->assertSame('[(NaN,2),(Infinity,-Infinity)]', (string) $lseg);
+
+        $parsed = Lseg::fromString((string) $lseg);
+        $this->assertNan($parsed->getStart()->getX());
+        $this->assertSame(\INF, $parsed->getEnd()->getX());
+        $this->assertSame(-\INF, $parsed->getEnd()->getY());
     }
 
     #[Test]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PathTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PathTest.php
@@ -33,6 +33,8 @@ final class PathTest extends TestCase
         yield 'path with floats' => ['[(1.5,2.5),(3.5,4.5)]', '[(1.5,2.5),(3.5,4.5)]'];
         yield 'path with negative coordinates' => ['[(-1,-2),(-3,-4)]', '[(-1,-2),(-3,-4)]'];
         yield 'path with spaces' => ['[(1, 2), (3, 4)]', '[(1,2),(3,4)]'];
+        yield 'path with non-finite coordinates' => ['[(NaN,2),(Infinity,-Infinity)]', '[(NaN,2),(Infinity,-Infinity)]'];
+        yield 'closed path with non-finite coordinates' => ['((nan,2),(inf,-inf))', '((NaN,2),(Infinity,-Infinity))'];
     }
 
     #[DataProvider('provideInvalidPathStrings')]
@@ -88,6 +90,19 @@ final class PathTest extends TestCase
         $path = new Path(true, new Point(1.0, 2.0), new Point(3.0, 4.0));
         $this->assertSame('[(1,2),(3,4)]', (string) $path);
         $this->assertTrue($path->isOpen());
+    }
+
+    #[Test]
+    public function accepts_non_finite_coordinates(): void
+    {
+        $path = new Path(true, new Point(\NAN, 2.0), new Point(\INF, -\INF));
+
+        $this->assertSame('[(NaN,2),(Infinity,-Infinity)]', (string) $path);
+
+        $parsed = Path::fromString((string) $path);
+        $this->assertNan($parsed->getPoints()[0]->getX());
+        $this->assertSame(\INF, $parsed->getPoints()[1]->getX());
+        $this->assertSame(-\INF, $parsed->getPoints()[1]->getY());
     }
 
     #[Test]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PointTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PointTest.php
@@ -31,6 +31,11 @@ final class PointTest extends TestCase
         yield 'origin' => ['(0,0)', '(0,0)'];
         yield 'point with spaces' => ['( 1 , 2 )', '(1,2)'];
         yield 'high precision' => ['(45.123456789,179.987654321)', '(45.123456789,179.987654321)'];
+        yield 'not a number' => ['(NaN,NaN)', '(NaN,NaN)'];
+        yield 'positive and negative infinity' => ['(Infinity,-Infinity)', '(Infinity,-Infinity)'];
+        yield 'short non-finite spellings' => ['(inf,-inf)', '(Infinity,-Infinity)'];
+        yield 'lowercase non-finite spellings' => ['(nan,infinity)', '(NaN,Infinity)'];
+        yield 'signed infinity' => ['(+inf,2)', '(Infinity,2)'];
     }
 
     #[Test]
@@ -74,24 +79,14 @@ final class PointTest extends TestCase
     }
 
     #[Test]
-    public function throws_exception_for_nan_coordinate(): void
+    public function accepts_non_finite_coordinates(): void
     {
-        $this->expectException(InvalidPointException::class);
-        new Point(\NAN, 1.0);
-    }
+        $this->assertSame('(NaN,1)', (string) new Point(\NAN, 1.0));
+        $this->assertSame('(Infinity,-Infinity)', (string) new Point(\INF, -\INF));
 
-    #[Test]
-    public function throws_exception_for_infinite_coordinate(): void
-    {
-        $this->expectException(InvalidPointException::class);
-        new Point(1.0, \INF);
-    }
-
-    #[Test]
-    public function throws_exception_for_negative_infinite_coordinate(): void
-    {
-        $this->expectException(InvalidPointException::class);
-        new Point(-\INF, 1.0);
+        $point = Point::fromString('(NaN,-Infinity)');
+        $this->assertNan($point->getX());
+        $this->assertSame(-\INF, $point->getY());
     }
 
     #[Test]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PolygonTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/PolygonTest.php
@@ -32,6 +32,8 @@ final class PolygonTest extends TestCase
         yield 'polygon with floats' => ['((1.5,2.5),(3.5,4.5),(5.5,6.5))', '((1.5,2.5),(3.5,4.5),(5.5,6.5))'];
         yield 'polygon with negative coordinates' => ['((-1,-2),(-3,-4),(-5,-6))', '((-1,-2),(-3,-4),(-5,-6))'];
         yield 'polygon with spaces' => ['((0, 0), (1, 0), (0, 1))', '((0,0),(1,0),(0,1))'];
+        yield 'polygon with non-finite coordinates' => ['((NaN,2),(Infinity,-Infinity),(5,6))', '((NaN,2),(Infinity,-Infinity),(5,6))'];
+        yield 'polygon with short non-finite spellings' => ['((nan,2),(inf,-inf),(5,6))', '((NaN,2),(Infinity,-Infinity),(5,6))'];
     }
 
     #[DataProvider('provideInvalidPolygonStrings')]
@@ -72,6 +74,19 @@ final class PolygonTest extends TestCase
     {
         $polygon = new Polygon(new Point(0.0, 0.0), new Point(1.0, 0.0), new Point(0.0, 1.0));
         $this->assertSame('((0,0),(1,0),(0,1))', (string) $polygon);
+    }
+
+    #[Test]
+    public function accepts_non_finite_coordinates(): void
+    {
+        $polygon = new Polygon(new Point(\NAN, 2.0), new Point(\INF, -\INF));
+
+        $this->assertSame('((NaN,2),(Infinity,-Infinity))', (string) $polygon);
+
+        $parsed = Polygon::fromString((string) $polygon);
+        $this->assertNan($parsed->getVertices()[0]->getX());
+        $this->assertSame(\INF, $parsed->getVertices()[1]->getX());
+        $this->assertSame(-\INF, $parsed->getVertices()[1]->getY());
     }
 
     #[Test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Geometric value objects now support `NaN`, positive infinity, and negative infinity in coordinates, radii, and line coefficients.
  - Common decimal formats such as `.5` and `5.` are accepted.
  - Short and case-insensitive non-finite spellings are normalized consistently.
  - Non-finite values are preserved across strings, value objects, and database representations.

- **Bug Fixes**
  - Invalid non-integer bounds are now correctly rejected for integer ranges.

- **Tests**
  - Expanded coverage for parsing, formatting, validation, and database round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->