### PR TITLE
test: cover more xml declaration and malformed input cases

### DIFF
--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/XmlTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/XmlTypeTest.php
@@ -36,28 +36,76 @@ final class XmlTypeTest extends ScalarTypeTestCase
             'element with attributes' => ['<root id="1"><item key="value"/></root>'],
             'element with namespace' => ['<root xmlns="http://example.com"><child/></root>'],
             'element with CDATA section' => ['<root><![CDATA[some <raw> text]]></root>'],
+            // Unlike the version and encoding pseudo-attributes, standalone survives storage — see
+            // normalizes_xml_declaration_on_storage() for the ones PostgreSQL drops.
+            'declaration with standalone' => ['<?xml version="1.0" standalone="yes"?><root/>'],
         ];
     }
 
+    #[DataProvider('provideDroppedXmlDeclarations')]
     #[Test]
-    public function normalizes_xml_declaration_on_storage(): void
+    public function normalizes_xml_declaration_on_storage(string $storedValue, string $retrievedValue): void
     {
         $this->runDbalBindingRoundTripExpectingDifferentRetrievedValue(
             $this->getTypeName(),
             $this->getPostgresTypeName(),
-            '<?xml version="1.0"?><root/>',
-            '<root/>'
+            $storedValue,
+            $retrievedValue
         );
     }
 
+    /**
+     * PostgreSQL drops the version and encoding pseudo-attributes on storage, but keeps standalone, which is why the
+     * standalone form lives in provideValidTransformations() instead.
+     *
+     * @return array<string, array{storedValue: string, retrievedValue: string}>
+     */
+    public static function provideDroppedXmlDeclarations(): array
+    {
+        return [
+            'version only' => [
+                'storedValue' => '<?xml version="1.0"?><root/>',
+                'retrievedValue' => '<root/>',
+            ],
+            'version and encoding' => [
+                'storedValue' => '<?xml version="1.0" encoding="UTF-8"?><root/>',
+                'retrievedValue' => '<root/>',
+            ],
+            'declaration followed by a newline' => [
+                'storedValue' => "<?xml version=\"1.0\"?>\n<root/>",
+                'retrievedValue' => '<root/>',
+            ],
+            'declaration before nested elements' => [
+                'storedValue' => '<?xml version="1.0"?><root><a>1</a></root>',
+                'retrievedValue' => '<root><a>1</a></root>',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideMalformedXml')]
     #[Test]
-    public function rejects_malformed_xml_before_database_write(): void
+    public function rejects_malformed_xml_before_database_write(string $malformedXml): void
     {
         $this->expectException(InvalidXmlForDatabaseException::class);
 
         $typeName = $this->getTypeName();
         $columnType = $this->getPostgresTypeName();
 
-        $this->runDbalBindingRoundTrip($typeName, $columnType, '<unclosed>');
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $malformedXml);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideMalformedXml(): array
+    {
+        return [
+            'unclosed element' => ['<unclosed>'],
+            'mismatched closing tag' => ['<a></b>'],
+            'unclosed nested element' => ['<root><child></root>'],
+            'unquoted attribute value' => ['<root attr=unquoted/>'],
+            'empty tag name' => ['<>'],
+            'not markup at all' => ['not xml at all'],
+        ];
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/XmlTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/XmlTypeTest.php
@@ -36,8 +36,6 @@ final class XmlTypeTest extends ScalarTypeTestCase
             'element with attributes' => ['<root id="1"><item key="value"/></root>'],
             'element with namespace' => ['<root xmlns="http://example.com"><child/></root>'],
             'element with CDATA section' => ['<root><![CDATA[some <raw> text]]></root>'],
-            // Unlike the version and encoding pseudo-attributes, standalone survives storage — see
-            // normalizes_xml_declaration_on_storage() for the ones PostgreSQL drops.
             'declaration with standalone' => ['<?xml version="1.0" standalone="yes"?><root/>'],
         ];
     }
@@ -55,8 +53,9 @@ final class XmlTypeTest extends ScalarTypeTestCase
     }
 
     /**
-     * PostgreSQL drops the version and encoding pseudo-attributes on storage, but keeps standalone, which is why the
-     * standalone form lives in provideValidTransformations() instead.
+     * PostgreSQL drops certain pseudo-attributes:
+     * - encoding: because it is a direct conflict of interest with database storage architecture.
+     * - version: because it represents metadata about the document structure, rather than a property of the data content itself.
      *
      * @return array<string, array{storedValue: string, retrievedValue: string}>
      */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded XML storage coverage to verify handling of declarations containing version and encoding attributes.
  - Added parameterized scenarios for XML declarations that PostgreSQL normalizes or removes.
  - Broadened malformed XML validation coverage to include multiple invalid input formats before database writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->