### PR TITLE
feat(#538): add support for user-defined composite types

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ $query = $em->createQuery('
 - **Enum Types**
   - User-defined PostgreSQL enum types [via `Enum` base class](docs/ENUM-TYPE.md)
 - **Composite Types**
+  - User-defined PostgreSQL composite (row) types [via `Composite` base class](docs/COMPOSITE-TYPE.md)
   - Access fields from [user-defined composite types](https://www.postgresql.org/docs/17/rowtypes.html) via `COMPOSITE_FIELD()` function
 
 ### PostgreSQL Operators

--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -123,6 +123,8 @@
 |---|---|---|
 | *(user-defined enum)* | *(any)* | `MartinGeorgiev\Doctrine\DBAL\Types\Enum` (see [Enum Types](ENUM-TYPE.md)) |
 | *(user-defined enum)[]* | *(any)* | `MartinGeorgiev\Doctrine\DBAL\Types\EnumArray` (see [Enum Types](ENUM-TYPE.md)) |
+| *(user-defined composite)* | *(any)* | `MartinGeorgiev\Doctrine\DBAL\Types\Composite` (see [Composite Types](COMPOSITE-TYPE.md)) |
+| *(user-defined composite)[]* | *(any)* | `MartinGeorgiev\Doctrine\DBAL\Types\CompositeArray` (see [Composite Types](COMPOSITE-TYPE.md)) |
 
 ## PostGIS Spatial Types
 

--- a/docs/COMPOSITE-TYPE.md
+++ b/docs/COMPOSITE-TYPE.md
@@ -1,0 +1,201 @@
+# PostgreSQL Composite Types
+
+PostgreSQL [composite (row) types](https://www.postgresql.org/docs/18/rowtypes.html) bundle several named fields into a single column type. Like enums, they are user-defined - there is no pre-registered constant, so each PostgreSQL composite type maps to its own subclass of `Composite`.
+
+> 📖 **See also**: [Available Types](AVAILABLE-TYPES.md), [Enum Types](ENUM-TYPE.md)
+
+## How it works
+
+[`Composite`](../src/MartinGeorgiev/Doctrine/DBAL/Types/Composite.php) is an abstract base class. You create one concrete subclass per PostgreSQL composite type. The subclass declares `TYPE_NAME` (matching the PostgreSQL type name exactly) and implements `getFieldTypes()`, which maps each field name to the Doctrine type used to convert it.
+
+A composite column becomes a PHP `array` keyed by those field names, with each field already converted by its Doctrine type - so an `integer` field arrives as an `int`, a `date` field as a `DateTime`, a `json` field as an `array`.
+
+> ⚠️ **Field order is the contract.** PostgreSQL record literals are positional; the field *names* exist only on the PHP side. If `getFieldTypes()` lists the fields in a different order from `CREATE TYPE`, values are silently written into the wrong columns. Keep the two in step.
+
+## Setup
+
+### 1. Create the PostgreSQL composite type
+
+```sql
+CREATE TYPE inventory_item AS (name text, supplier_id integer, price numeric);
+```
+
+### 2. Create the DBAL type subclass
+
+```php
+use Doctrine\DBAL\Types\Types;
+use MartinGeorgiev\Doctrine\DBAL\Types\Composite;
+
+final class InventoryItemType extends Composite
+{
+    protected const TYPE_NAME = 'inventory_item';
+
+    protected function getFieldTypes(): array
+    {
+        return [
+            'name' => Types::TEXT,
+            'supplier_id' => Types::INTEGER,
+            'price' => Types::DECIMAL,
+        ];
+    }
+}
+```
+
+### 3. Register the type
+
+```php
+use Doctrine\DBAL\Types\Type;
+
+Type::addType('inventory_item', InventoryItemType::class);
+$platform->registerDoctrineTypeMapping('inventory_item', 'inventory_item');
+```
+
+### 4. Use in an entity
+
+```php
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Product
+{
+    /**
+     * @var array{name: string|null, supplier_id: int|null, price: string|null}|null
+     */
+    #[ORM\Column(type: 'inventory_item', nullable: true)]
+    private ?array $item = null;
+}
+```
+
+```php
+$product->item = ['name' => 'widget', 'supplier_id' => 42, 'price' => '9.99'];
+```
+
+### 5. Query individual fields
+
+Use the [`COMPOSITE_FIELD()`](AVAILABLE-FUNCTIONS-AND-OPERATORS.md) DQL function to reach a single field inside a query:
+
+```php
+$dql = "SELECT p FROM Product p WHERE COMPOSITE_FIELD(p.item, 'price') > 9.99";
+```
+
+## NULL handling
+
+PostgreSQL distinguishes a NULL column from a row whose fields are all NULL, and so does this type:
+
+| PHP value | Stored as |
+|---|---|
+| `null` | SQL `NULL` |
+| `['name' => null, 'supplier_id' => null, 'price' => null]` | `(,,)` |
+| `['name' => '', 'supplier_id' => null, 'price' => null]` | `("",,)` |
+
+Note that an unquoted empty field means NULL, while `""` means the empty string. The unquoted word `NULL` is *not* a null - it is the four-character string `"NULL"`.
+
+## Field types
+
+Every field is converted by a registered Doctrine type, so anything Doctrine can convert works - including this library's own types, provided they are registered.
+
+A field type whose `convertToDatabaseValue()` returns something other than a string, int, float, bool or null is rejected with `InvalidCompositeForDatabaseException` - the record literal has no way to carry it.
+
+That includes another composite type: name it in `getFieldTypes()`, and the nested record is decomposed too. For example, a `person` whose `home` field is an `address` type will arrive as `['name' => 'bob', 'home' => ['street' => '1 Main St', 'city' => 'Sofia']]`. Declare the `home` field as `Types::TEXT` instead to receive the raw inner literal `("1 Main St",Sofia)` and parse it yourself.
+
+## Arrays of composites
+
+A `composite[]` column maps to a PHP array of field-keyed arrays. Extend `CompositeArray`, declare `TYPE_NAME` with the `[]` suffix and point `getCompositeClass()` at the scalar type's class:
+
+```php
+use MartinGeorgiev\Doctrine\DBAL\Types\CompositeArray;
+
+final class InventoryItemArrayType extends CompositeArray
+{
+    protected const TYPE_NAME = 'inventory_item[]';
+
+    protected function getCompositeClass(): string
+    {
+        return InventoryItemType::class;
+    }
+}
+```
+
+Register both types, as you would for any other pair of scalar and array types. PostgreSQL escapes at both levels - a field holding a comma arrives as `{"(\"a,b\",1)"}` - which the type handles for you.
+
+## Value stability
+
+What this type writes is byte-identical to what PostgreSQL emits for the same value, so a value does not drift across repeated save-load cycles. Three field types are re-rendered by PostgreSQL itself rather than echoed back verbatim; the PHP value still round-trips, but the stored literal differs from the one that was written:
+
+- `timestamptz` is rendered in the session time zone (`2024-01-15 10:30:00+00` under UTC, `2024-01-15 12:30:00+02` under `Europe/Sofia`). The same instant comes back either way.
+- `jsonb` normalizes whitespace and key order. Use `json` if you need to preserve the document verbatim.
+- `numeric` keeps the scale you supply (`9.90` stays `9.90`) but canonicalizes exponent notation (`1e10` becomes `10000000000`).
+
+## Mapping to an object
+
+The base class deliberately maps to an array rather than to a class of your own - there is no single right way to hydrate an arbitrary object.
+If you need to narrow that to your own class, hydrate at the entity boundary instead:
+
+```php
+#[ORM\Entity]
+class Product
+{
+    /**
+     * @var array{name: string|null, supplier_id: int|null, price: string|null}|null
+     */
+    #[ORM\Column(type: 'inventory_item', nullable: true)]
+    private ?array $item = null;
+
+    public function getItem(): ?InventoryItem
+    {
+        return $this->item === null ? null : InventoryItem::fromArray($this->item);
+    }
+
+    public function setItem(?InventoryItem $item): void
+    {
+        $this->item = $item?->toArray();
+    }
+}
+```
+
+The write direction *can* be overridden, because the parameter is untyped, if you would rather accept your object anywhere the type is bound:
+
+```php
+final class InventoryItemType extends Composite
+{
+    protected const TYPE_NAME = 'inventory_item';
+
+    protected function getFieldTypes(): array
+    {
+        return ['name' => Types::TEXT, 'supplier_id' => Types::INTEGER, 'price' => Types::DECIMAL];
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value instanceof InventoryItem) {
+            $value = $value->toArray();
+        }
+
+        return parent::convertToDatabaseValue($value, $platform);
+    }
+}
+```
+
+## Limitations
+
+- **No schema introspection.** The library never reads `pg_type` to discover your fields. `getFieldTypes()` is the single source of truth, which keeps the type usable offline and in unit tests but means you must keep it aligned with your migrations by hand.
+- **No schema generation or diffing.** As with enums, `CREATE TYPE` and `ALTER TYPE` statements are yours to write.
+
+## Migrations
+
+```sql
+CREATE TYPE inventory_item AS (name text, supplier_id integer, price numeric);
+ALTER TABLE products ADD COLUMN item inventory_item;
+```
+
+Unlike enums, composite types can be altered freely:
+
+```sql
+ALTER TYPE inventory_item ADD ATTRIBUTE weight numeric CASCADE;
+ALTER TYPE inventory_item DROP ATTRIBUTE weight CASCADE;
+ALTER TYPE inventory_item RENAME ATTRIBUTE name TO title CASCADE;
+```
+
+`CASCADE` is required when tables already use the type. Update `getFieldTypes()` after any of them.
+
+Adding or dropping an attribute changes the field count, which is reported as `InvalidCompositeForPHPException` on the next read rather than silently mis-assigning values. A rename isn't caught: the count still matches, so reads keep succeeding and simply return the old key names.

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -734,6 +734,59 @@ $platform->registerDoctrineTypeMapping('status[]', 'status[]');
 $platform->registerDoctrineTypeMapping('_status', 'status[]');
 ```
 
+### Mapping User-Defined PostgreSQL Composite Types
+
+For each PostgreSQL composite (row) type, create a concrete class extending `MartinGeorgiev\Doctrine\DBAL\Types\Composite` and register it like the examples above. See [COMPOSITE-TYPE.md](COMPOSITE-TYPE.md) for a full example.
+
+```php
+<?php
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use MartinGeorgiev\Doctrine\DBAL\Types\Composite;
+
+// CREATE TYPE inventory_item AS (name text, supplier_id integer, price numeric);
+
+final class InventoryItemType extends Composite
+{
+    protected const TYPE_NAME = 'inventory_item'; // must match PostgreSQL composite type name exactly
+
+    protected function getFieldTypes(): array
+    {
+        // Field order must match the CREATE TYPE declaration - record literals are positional
+        return [
+            'name' => Types::TEXT,
+            'supplier_id' => Types::INTEGER,
+            'price' => Types::DECIMAL,
+        ];
+    }
+}
+
+// Register like any other type
+Type::addType('inventory_item', InventoryItemType::class);
+$platform->registerDoctrineTypeMapping('inventory_item', 'inventory_item');
+```
+
+For a `composite[]` column, extend `CompositeArray` and point it at the scalar type's class:
+
+```php
+use MartinGeorgiev\Doctrine\DBAL\Types\CompositeArray;
+
+final class InventoryItemArrayType extends CompositeArray
+{
+    protected const TYPE_NAME = 'inventory_item[]';
+
+    protected function getCompositeClass(): string
+    {
+        return InventoryItemType::class;
+    }
+}
+
+Type::addType('inventory_item[]', InventoryItemArrayType::class);
+$platform->registerDoctrineTypeMapping('inventory_item[]', 'inventory_item[]');
+$platform->registerDoctrineTypeMapping('_inventory_item', 'inventory_item[]');
+```
+
 ### Usage in Entities
 
 Once types are registered, you can use them in your Doctrine entities:

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -393,6 +393,18 @@ return [
 >
 > See [ENUM-TYPE.md](ENUM-TYPE.md) for a full example.
 
+> **User-defined composite types**: For each PostgreSQL composite (row) type, create a concrete class extending `MartinGeorgiev\Doctrine\DBAL\Types\Composite` and register it like the examples above.
+> Columns holding an array of that composite get a second concrete class extending `MartinGeorgiev\Doctrine\DBAL\Types\CompositeArray`, registered alongside the scalar one:
+>
+> ```php
+> 'types' => [
+>     'inventory_item' => App\Doctrine\Type\InventoryItemType::class,
+>     'inventory_item[]' => App\Doctrine\Type\InventoryItemArrayType::class,
+> ],
+> ```
+>
+> See [COMPOSITE-TYPE.md](COMPOSITE-TYPE.md) for a full example.
+
 
 ### Register DQL Functions
 

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -165,6 +165,19 @@ doctrine:
 >
 > See [ENUM-TYPE.md](ENUM-TYPE.md) for a full example.
 
+> **User-defined composite types**: For each PostgreSQL composite (row) type, create a concrete class extending `MartinGeorgiev\Doctrine\DBAL\Types\Composite` and register it like the examples above.
+> Columns holding an array of that composite get a second concrete class extending `MartinGeorgiev\Doctrine\DBAL\Types\CompositeArray`, registered alongside the scalar one:
+>
+> ```yaml
+> doctrine:
+>     dbal:
+>         types:
+>             inventory_item: App\Doctrine\Type\InventoryItemType
+>             inventory_item[]: App\Doctrine\Type\InventoryItemArrayType
+> ```
+>
+> See [COMPOSITE-TYPE.md](COMPOSITE-TYPE.md) for a full example.
+
 
 ### Configure Type Mappings
 

--- a/fixtures/MartinGeorgiev/Doctrine/ConcreteInventoryItemArrayType.php
+++ b/fixtures/MartinGeorgiev/Doctrine/ConcreteInventoryItemArrayType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\MartinGeorgiev\Doctrine;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\CompositeArray;
+
+final class ConcreteInventoryItemArrayType extends CompositeArray
+{
+    protected const TYPE_NAME = 'test_inventory_item[]';
+
+    protected function getCompositeClass(): string
+    {
+        return ConcreteInventoryItemType::class;
+    }
+}

--- a/fixtures/MartinGeorgiev/Doctrine/ConcreteInventoryItemType.php
+++ b/fixtures/MartinGeorgiev/Doctrine/ConcreteInventoryItemType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\MartinGeorgiev\Doctrine;
+
+use Doctrine\DBAL\Types\Types;
+use MartinGeorgiev\Doctrine\DBAL\Types\Composite;
+
+final class ConcreteInventoryItemType extends Composite
+{
+    protected const TYPE_NAME = 'test_inventory_item';
+
+    protected function getFieldTypes(): array
+    {
+        return [
+            'name' => Types::TEXT,
+            'supplier_id' => Types::INTEGER,
+            'price' => Types::DECIMAL,
+        ];
+    }
+}

--- a/fixtures/MartinGeorgiev/Doctrine/ConcreteShipmentType.php
+++ b/fixtures/MartinGeorgiev/Doctrine/ConcreteShipmentType.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\MartinGeorgiev\Doctrine;
+
+use Doctrine\DBAL\Types\Types;
+use MartinGeorgiev\Doctrine\DBAL\Types\Composite;
+
+final class ConcreteShipmentType extends Composite
+{
+    protected const TYPE_NAME = 'test_shipment';
+
+    protected function getFieldTypes(): array
+    {
+        return [
+            'label' => Types::TEXT,
+            'item' => 'test_inventory_item',
+            'packed_at' => Types::DATETIME_IMMUTABLE,
+            'delivered_at' => Types::DATETIMETZ_IMMUTABLE,
+            'dispatched_on' => Types::DATE_IMMUTABLE,
+            'is_express' => Types::BOOLEAN,
+            'tracking_id' => Types::GUID,
+            'weight' => Types::FLOAT,
+            'metadata' => Types::JSON,
+        ];
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Composite.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Composite.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type as DoctrineType;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCompositeForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCompositeForPHPException;
+use MartinGeorgiev\Utils\Exception\InvalidRecordFormatException;
+use MartinGeorgiev\Utils\PHPArrayToPostgresRecordTransformer;
+use MartinGeorgiev\Utils\PostgresRecordToPHPArrayTransformer;
+
+/**
+ * Abstract base for mapping PostgreSQL composite (row) types to PHP arrays keyed by field name.
+ *
+ * Extend this class, define TYPE_NAME matching your PostgreSQL composite type name exactly,
+ * and implement getFieldTypes() returning the field names mapped to Doctrine type names,
+ * in the exact order the fields were declared in CREATE TYPE.
+ *
+ * Composite record literals are positional - the field names exist only on the PHP side, so a
+ * getFieldTypes() ordering that disagrees with the PostgreSQL declaration silently mixes up columns.
+ *
+ * Example:
+ *   CREATE TYPE inventory_item AS (name text, supplier_id integer, price numeric)
+ *
+ *   final class InventoryItemType extends Composite {
+ *       protected const TYPE_NAME = 'inventory_item';
+ *       protected function getFieldTypes(): array {
+ *           return ['name' => Types::TEXT, 'supplier_id' => Types::INTEGER, 'price' => Types::DECIMAL];
+ *       }
+ *   }
+ *
+ * @see https://www.postgresql.org/docs/18/rowtypes.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+abstract class Composite extends BaseType
+{
+    /**
+     * Field name mapped to the Doctrine type used to convert it, in PostgreSQL declaration order.
+     *
+     * @return array<string, string>
+     */
+    abstract protected function getFieldTypes(): array;
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $this->getName();
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @throws InvalidCompositeForDatabaseException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_array($value)) {
+            throw InvalidCompositeForDatabaseException::forInvalidType($value);
+        }
+
+        $fieldTypes = $this->getFieldTypes();
+        $this->assertFieldNamesMatchDeclaration($value, $fieldTypes);
+
+        $fields = [];
+        foreach ($fieldTypes as $fieldName => $fieldType) {
+            $fields[] = $this->convertFieldForDatabase($value[$fieldName], $fieldType, $fieldName, $platform);
+        }
+
+        return PHPArrayToPostgresRecordTransformer::transformPHPArrayToPostgresRecord($fields);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return array<string, mixed>|null
+     *
+     * @throws InvalidCompositeForPHPException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?array
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidCompositeForPHPException::forInvalidType($value);
+        }
+
+        $fieldTypes = $this->getFieldTypes();
+
+        try {
+            $rawFields = PostgresRecordToPHPArrayTransformer::transformPostgresRecordToPHPArray($value);
+        } catch (InvalidRecordFormatException) {
+            throw InvalidCompositeForPHPException::forInvalidFormat($value);
+        }
+
+        if (\count($rawFields) !== \count($fieldTypes)) {
+            throw InvalidCompositeForPHPException::forUnexpectedFieldCount(\count($fieldTypes), \count($rawFields), $value);
+        }
+
+        $result = [];
+        $position = 0;
+        foreach ($fieldTypes as $fieldName => $fieldType) {
+            $result[$fieldName] = DoctrineType::getType($fieldType)->convertToPHPValue($rawFields[$position], $platform);
+            $position++;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     * @param array<string, string> $fieldTypes
+     *
+     * @throws InvalidCompositeForDatabaseException
+     */
+    private function assertFieldNamesMatchDeclaration(array $value, array $fieldTypes): void
+    {
+        $missing = \array_diff(\array_keys($fieldTypes), \array_keys($value));
+        if ($missing !== []) {
+            throw InvalidCompositeForDatabaseException::forMissingFields(\implode(', ', $missing));
+        }
+
+        $unknown = \array_diff(\array_keys($value), \array_keys($fieldTypes));
+        if ($unknown !== []) {
+            throw InvalidCompositeForDatabaseException::forUnknownFields(\implode(', ', \array_map(\strval(...), $unknown)));
+        }
+    }
+
+    /**
+     * @throws InvalidCompositeForDatabaseException
+     */
+    private function convertFieldForDatabase(mixed $fieldValue, string $fieldType, string $fieldName, AbstractPlatform $platform): ?string
+    {
+        $converted = DoctrineType::getType($fieldType)->convertToDatabaseValue($fieldValue, $platform);
+
+        return match (true) {
+            $converted === null => null,
+            \is_string($converted) => $converted,
+            // PostgreSQL accepts 1/0 for boolean, which is what its platform returns for a bool field
+            \is_bool($converted) => $converted ? '1' : '0',
+            \is_int($converted), \is_float($converted) => (string) $converted,
+            default => throw InvalidCompositeForDatabaseException::forUnsupportedFieldValue($fieldName, $converted),
+        };
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/CompositeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/CompositeArray.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCompositeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCompositeArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCompositeForPHPException;
+use MartinGeorgiev\Utils\Exception\InvalidArrayFormatException;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
+
+/**
+ * Abstract base for mapping arrays of PostgreSQL composite (row) types to PHP arrays of field-keyed arrays.
+ *
+ * Extend this class, define TYPE_NAME as the PostgreSQL composite type name followed by [], and implement
+ * getCompositeClass() returning the Composite subclass each item maps to.
+ *
+ * Example:
+ *   CREATE TYPE inventory_item AS (name text, supplier_id integer, price numeric);
+ *   CREATE TABLE orders (id serial PRIMARY KEY, items inventory_item[]);
+ *
+ *   final class InventoryItemType extends Composite {
+ *       protected const TYPE_NAME = 'inventory_item';
+ *       protected function getFieldTypes(): array {
+ *           return ['name' => Types::TEXT, 'supplier_id' => Types::INTEGER, 'price' => Types::FLOAT];
+ *       }
+ *   }
+ *
+ *   final class InventoryItemArrayType extends CompositeArray {
+ *       protected const TYPE_NAME = 'inventory_item[]';
+ *       protected function getCompositeClass(): string { return InventoryItemType::class; }
+ *   }
+ *
+ *   Type::addType('inventory_item', InventoryItemType::class);
+ *   Type::addType('inventory_item[]', InventoryItemArrayType::class);
+ *
+ * @see https://www.postgresql.org/docs/18/rowtypes.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+abstract class CompositeArray extends BaseArray
+{
+    /**
+     * BaseArray's per-item hooks are not given the platform, but converting an item means handing it to the scalar
+     * composite type, which needs one. It is captured on entry and read only within that same call.
+     */
+    private ?AbstractPlatform $conversionPlatform = null;
+
+    private ?Composite $compositeType = null;
+
+    /**
+     * The scalar composite type each item is converted by.
+     *
+     * @return class-string<Composite>
+     */
+    abstract protected function getCompositeClass(): string;
+
+    /**
+     * The name is user-defined, so it has no platform mapping to look up the way built-in types do.
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $this->getName();
+    }
+
+    /**
+     * @param array|null $phpArray
+     */
+    public function convertToDatabaseValue($phpArray, AbstractPlatform $platform): ?string
+    {
+        $this->conversionPlatform = $platform;
+
+        return parent::convertToDatabaseValue($phpArray, $platform);
+    }
+
+    /**
+     * @param string|null $postgresArray
+     */
+    public function convertToPHPValue($postgresArray, AbstractPlatform $platform): ?array
+    {
+        $this->conversionPlatform = $platform;
+
+        return parent::convertToPHPValue($postgresArray, $platform);
+    }
+
+    public function isValidArrayItemForDatabase(mixed $item): bool
+    {
+        return $item === null || \is_array($item);
+    }
+
+    protected function transformArrayItemForPostgres(mixed $item): string
+    {
+        if ($item === null) {
+            return 'NULL';
+        }
+
+        if (!\is_array($item)) {
+            $this->throwInvalidItemException($item);
+        }
+
+        $literal = $this->getCompositeType()->convertToDatabaseValue($item, $this->getPlatform());
+
+        return $this->quoteAndEscapeArrayItem((string) $literal);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function transformArrayItemForPHP(mixed $item): ?array
+    {
+        if ($item === null) {
+            return null;
+        }
+
+        if (!\is_string($item)) {
+            throw InvalidCompositeArrayItemForPHPException::forInvalidFormat($item);
+        }
+
+        try {
+            return $this->getCompositeType()->convertToPHPValue($item, $this->getPlatform());
+        } catch (InvalidCompositeForPHPException) {
+            throw InvalidCompositeArrayItemForPHPException::forInvalidFormat($item);
+        }
+    }
+
+    /**
+     * A bare NULL element must become PHP null rather than the string "NULL", so string types are not preserved.
+     * Record literals arrive quoted and survive either way.
+     */
+    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
+    {
+        try {
+            return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray);
+        } catch (InvalidArrayFormatException) {
+            throw InvalidCompositeArrayItemForPHPException::forInvalidFormat($postgresArray);
+        }
+    }
+
+    protected function throwInvalidTypeException(mixed $value): never
+    {
+        throw InvalidCompositeArrayItemForPHPException::forInvalidArrayType($value);
+    }
+
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        throw InvalidCompositeArrayItemForDatabaseException::forInvalidType($item);
+    }
+
+    private function getCompositeType(): Composite
+    {
+        $compositeClass = $this->getCompositeClass();
+
+        return $this->compositeType ??= new $compositeClass();
+    }
+
+    private function getPlatform(): AbstractPlatform
+    {
+        \assert($this->conversionPlatform instanceof AbstractPlatform);
+
+        return $this->conversionPlatform;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCompositeArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCompositeArrayItemForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidCompositeArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be arrays keyed by field name, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCompositeArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCompositeArrayItemForPHPException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class InvalidCompositeArrayItemForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid composite record format in array: %s', $value);
+    }
+
+    public static function forInvalidArrayType(mixed $value): self
+    {
+        return self::create('Value must be an array, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCompositeForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCompositeForDatabaseException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCompositeForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Database value must be an array keyed by field name, %s given', $value);
+    }
+
+    public static function forMissingFields(string $missingFieldNames): self
+    {
+        return new self('Composite value must define every declared field, missing: '.$missingFieldNames);
+    }
+
+    public static function forUnknownFields(string $unknownFieldNames): self
+    {
+        return new self('Composite value must not contain undeclared fields, unknown: '.$unknownFieldNames);
+    }
+
+    public static function forUnsupportedFieldValue(string $fieldName, mixed $value): self
+    {
+        return self::create('Field '.$fieldName.' must convert to a scalar, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCompositeForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCompositeForPHPException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCompositeForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('PHP value must be a string, %s given', $value);
+    }
+
+    public static function forInvalidFormat(string $value): self
+    {
+        return self::create('Invalid composite record format: %s', $value);
+    }
+
+    public static function forUnexpectedFieldCount(int $expected, int $actual, string $value): self
+    {
+        return self::create('Composite record must hold '.$expected.' fields, '.$actual.' found in: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Utils/Exception/InvalidRecordFormatException.php
+++ b/src/MartinGeorgiev/Utils/Exception/InvalidRecordFormatException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Utils\Exception;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidRecordFormatException extends \InvalidArgumentException
+{
+    public static function invalidFormat(string $details = ''): self
+    {
+        $message = 'Invalid record format';
+        if ($details !== '') {
+            $message .= ': '.$details;
+        }
+
+        return new self($message);
+    }
+}

--- a/src/MartinGeorgiev/Utils/PHPArrayToPostgresRecordTransformer.php
+++ b/src/MartinGeorgiev/Utils/PHPArrayToPostgresRecordTransformer.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Utils;
+
+/**
+ * Handles transformation from already-converted field strings to a PostgreSQL record literal.
+ *
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class PHPArrayToPostgresRecordTransformer
+{
+    /**
+     * PostgreSQL quotes a record field only when leaving it bare would be ambiguous: when it is empty,
+     * or when it holds a delimiter, a quote, a backslash or whitespace. Matching that rule exactly keeps
+     * what this writes byte-identical to what PostgreSQL hands back for the same value.
+     *
+     * @var string
+     */
+    private const FIELD_NEEDS_QUOTING_PATTERN = '/[(),"\\\\\s]/';
+
+    /**
+     * @param array<int, string|null> $fields null marks a NULL field, which PostgreSQL writes as nothing at all
+     */
+    public static function transformPHPArrayToPostgresRecord(array $fields): string
+    {
+        $encoded = \array_map(
+            static function (?string $field): string {
+                if ($field === null) {
+                    return '';
+                }
+
+                if ($field !== '' && \preg_match(self::FIELD_NEEDS_QUOTING_PATTERN, $field) !== 1) {
+                    return $field;
+                }
+
+                return '"'.\str_replace(['\\', '"'], ['\\\\', '""'], $field).'"';
+            },
+            $fields
+        );
+
+        return '('.\implode(',', $encoded).')';
+    }
+}

--- a/src/MartinGeorgiev/Utils/PostgresRecordToPHPArrayTransformer.php
+++ b/src/MartinGeorgiev/Utils/PostgresRecordToPHPArrayTransformer.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Utils;
+
+use MartinGeorgiev\Utils\Exception\InvalidRecordFormatException;
+
+/**
+ * Handles transformation from a PostgreSQL record literal to its raw field strings.
+ *
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class PostgresRecordToPHPArrayTransformer
+{
+    /**
+     * Splits a PostgreSQL record literal into its raw field strings, where null marks an unquoted empty field.
+     *
+     * @return array<int, string|null>
+     *
+     * @throws InvalidRecordFormatException
+     */
+    public static function transformPostgresRecordToPHPArray(string $literal): array
+    {
+        $trimmed = \trim($literal);
+        if (!\str_starts_with($trimmed, '(') || !\str_ends_with($trimmed, ')')) {
+            throw InvalidRecordFormatException::invalidFormat('a record literal must be wrapped in parentheses');
+        }
+
+        $body = \substr($trimmed, 1, -1);
+        $fields = [];
+        $current = '';
+        $wasQuoted = false;
+        $inQuotes = false;
+        $length = \strlen($body);
+
+        for ($index = 0; $index < $length; $index++) {
+            $character = $body[$index];
+
+            if ($character === '\\') {
+                if ($index + 1 >= $length) {
+                    throw InvalidRecordFormatException::invalidFormat('the literal ends with a dangling escape character');
+                }
+
+                $current .= $body[++$index];
+
+                continue;
+            }
+
+            if ($character === '"') {
+                // A doubled quote inside a quoted section is a literal quote, not the end of the section
+                if ($inQuotes && $index + 1 < $length && $body[$index + 1] === '"') {
+                    $current .= '"';
+                    $index++;
+
+                    continue;
+                }
+
+                $inQuotes = !$inQuotes;
+                $wasQuoted = true;
+
+                continue;
+            }
+
+            if ($character === ',' && !$inQuotes) {
+                $fields[] = $wasQuoted || $current !== '' ? $current : null;
+                $current = '';
+                $wasQuoted = false;
+
+                continue;
+            }
+
+            // The outer parenthesis was already stripped, so a bare one here means the record ended early and the
+            // rest is junk. PostgreSQL rejects those too, while accepting a bare opening parenthesis inside a field.
+            if ($character === ')' && !$inQuotes) {
+                throw InvalidRecordFormatException::invalidFormat('a closing parenthesis appears outside a quoted field');
+            }
+
+            $current .= $character;
+        }
+
+        if ($inQuotes) {
+            throw InvalidRecordFormatException::invalidFormat('a quoted field is left unterminated');
+        }
+
+        $fields[] = $wasQuoted || $current !== '' ? $current : null;
+
+        return $fields;
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CompositeArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CompositeArrayTypeTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Types\Type;
+use Fixtures\MartinGeorgiev\Doctrine\ConcreteInventoryItemArrayType;
+use Fixtures\MartinGeorgiev\Doctrine\ConcreteInventoryItemType;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class CompositeArrayTypeTest extends TestCase
+{
+    private const ITEM_TYPE_NAME = 'test_inventory_item';
+
+    private const DBAL_TYPE_NAME = self::ITEM_TYPE_NAME.'[]';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection->executeStatement(\sprintf(
+            'CREATE TYPE %s.%s AS (name text, supplier_id integer, price numeric)',
+            self::DATABASE_SCHEMA,
+            self::ITEM_TYPE_NAME
+        ));
+
+        $this->registerCompositeType(self::ITEM_TYPE_NAME, ConcreteInventoryItemType::class);
+        $this->registerCompositeType(self::DBAL_TYPE_NAME, ConcreteInventoryItemArrayType::class);
+    }
+
+    /**
+     * @param class-string<Type> $typeClass
+     */
+    private function registerCompositeType(string $typeName, string $typeClass): void
+    {
+        if (Type::hasType($typeName)) {
+            Type::overrideType($typeName, $typeClass);
+        } else {
+            Type::addType($typeName, $typeClass);
+        }
+
+        $this->connection->getDatabasePlatform()->registerDoctrineTypeMapping($typeName, $typeName);
+    }
+
+    protected function getTypeName(): string
+    {
+        return self::DBAL_TYPE_NAME;
+    }
+
+    #[Test]
+    public function type_will_be_registered(): void
+    {
+        $typeName = $this->getTypeName();
+        $this->assertTrue(Type::hasType($typeName));
+
+        $type = Type::getType($typeName);
+        $platform = $this->connection->getDatabasePlatform();
+
+        $this->assertSame($typeName, $type->getSQLDeclaration([], $platform));
+
+        if (\method_exists($type, 'requiresSQLCommentHint')) {
+            $this->assertFalse($type->requiresSQLCommentHint($platform)); // @phpstan-ignore-line
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>|null> $phpValue
+     */
+    #[DataProvider('provideValidArrayTransformations')]
+    #[Test]
+    public function roundtrips_array_of_composites(array $phpValue, string $postgresValue): void
+    {
+        $typeName = $this->getTypeName();
+
+        [$tableName, $columnName] = $this->prepareTestTable(self::DBAL_TYPE_NAME);
+
+        try {
+            $this->connection->createQueryBuilder()
+                ->insert(self::DATABASE_SCHEMA.'.'.$tableName)
+                ->values([$columnName => ':value'])
+                ->setParameter('value', $phpValue, $typeName)
+                ->executeStatement();
+
+            $storedLiteral = $this->connection->fetchOne(\sprintf(
+                'SELECT "%s"::text FROM %s.%s WHERE id = 1',
+                $columnName,
+                self::DATABASE_SCHEMA,
+                $tableName
+            ));
+            $this->assertSame($postgresValue, $storedLiteral);
+
+            $this->assertSame($phpValue, $this->fetchConvertedValue($typeName, $tableName, $columnName));
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
+    }
+
+    /**
+     * @return array<string, array{phpValue: array<int, array<string, mixed>|null>, postgresValue: string}>
+     */
+    public static function provideValidArrayTransformations(): array
+    {
+        return [
+            'several items' => [
+                'phpValue' => [
+                    ['name' => 'widget', 'supplier_id' => 1, 'price' => '9.99'],
+                    ['name' => 'bolt', 'supplier_id' => 2, 'price' => '0.10'],
+                ],
+                'postgresValue' => '{"(widget,1,9.99)","(bolt,2,0.10)"}',
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'item with a delimiter needs escaping at both levels' => [
+                'phpValue' => [['name' => 'a,b', 'supplier_id' => 1, 'price' => '1']],
+                'postgresValue' => '{"(\\"a,b\\",1,1)"}',
+            ],
+            'item with quotes needs escaping at both levels' => [
+                'phpValue' => [['name' => 'say "hi"', 'supplier_id' => 1, 'price' => '1']],
+                'postgresValue' => '{"(\\"say \\"\\"hi\\"\\"\\",1,1)"}',
+            ],
+            'item with a null field' => [
+                'phpValue' => [['name' => null, 'supplier_id' => 1, 'price' => '1']],
+                'postgresValue' => '{"(,1,1)"}',
+            ],
+            'null element beside a value' => [
+                'phpValue' => [['name' => 'x', 'supplier_id' => 1, 'price' => '1'], null],
+                'postgresValue' => '{"(x,1,1)",NULL}',
+            ],
+        ];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CompositeNestedTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CompositeNestedTypeTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Types\Type;
+use Fixtures\MartinGeorgiev\Doctrine\ConcreteInventoryItemType;
+use Fixtures\MartinGeorgiev\Doctrine\ConcreteShipmentType;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class CompositeNestedTypeTest extends TestCase
+{
+    private const ITEM_TYPE_NAME = 'test_inventory_item';
+
+    private const DBAL_TYPE_NAME = 'test_shipment';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection->executeStatement(\sprintf(
+            'CREATE TYPE %s.%s AS (name text, supplier_id integer, price numeric)',
+            self::DATABASE_SCHEMA,
+            self::ITEM_TYPE_NAME
+        ));
+        $this->connection->executeStatement(\sprintf(
+            'CREATE TYPE %s.%s AS (label text, item %s.%s, packed_at timestamp, delivered_at timestamptz, dispatched_on date, is_express boolean, tracking_id uuid, weight double precision, metadata json)',
+            self::DATABASE_SCHEMA,
+            self::DBAL_TYPE_NAME,
+            self::DATABASE_SCHEMA,
+            self::ITEM_TYPE_NAME
+        ));
+
+        $this->registerCompositeType(self::ITEM_TYPE_NAME, ConcreteInventoryItemType::class);
+        $this->registerCompositeType(self::DBAL_TYPE_NAME, ConcreteShipmentType::class);
+    }
+
+    /**
+     * @param class-string<Type> $typeClass
+     */
+    private function registerCompositeType(string $typeName, string $typeClass): void
+    {
+        if (Type::hasType($typeName)) {
+            Type::overrideType($typeName, $typeClass);
+        } else {
+            Type::addType($typeName, $typeClass);
+        }
+
+        $this->connection->getDatabasePlatform()->registerDoctrineTypeMapping($typeName, $typeName);
+    }
+
+    protected function getTypeName(): string
+    {
+        return self::DBAL_TYPE_NAME;
+    }
+
+    #[Test]
+    public function type_will_be_registered(): void
+    {
+        $typeName = $this->getTypeName();
+        $this->assertTrue(Type::hasType($typeName));
+
+        $type = Type::getType($typeName);
+        $platform = $this->connection->getDatabasePlatform();
+
+        $this->assertSame($typeName, $type->getSQLDeclaration([], $platform));
+
+        if (\method_exists($type, 'requiresSQLCommentHint')) {
+            $this->assertFalse($type->requiresSQLCommentHint($platform)); // @phpstan-ignore-line
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $phpValue
+     */
+    #[DataProvider('provideValidWideFieldTransformations')]
+    #[Test]
+    public function roundtrips_value_with_non_string_field_types(array $phpValue): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = Type::getType($typeName)->getSQLDeclaration([], $this->connection->getDatabasePlatform());
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $phpValue);
+    }
+
+    /**
+     * @return array<string, array{array<string, mixed>}>
+     */
+    public static function provideValidWideFieldTransformations(): array
+    {
+        $item = ['name' => 'widget', 'supplier_id' => 42, 'price' => '9.99'];
+
+        return [
+            'populated' => [[
+                'label' => 'bulk',
+                'item' => $item,
+                'packed_at' => new \DateTimeImmutable('2024-01-15 10:30:00'),
+                'delivered_at' => new \DateTimeImmutable('2024-01-15 10:30:00', new \DateTimeZone('UTC')),
+                'dispatched_on' => new \DateTimeImmutable('2024-01-15 00:00:00'),
+                'is_express' => true,
+                'tracking_id' => '550e8400-e29b-41d4-a716-446655440000',
+                'weight' => 1.5,
+                'metadata' => ['carrier' => 'acme', 'note' => 'a, b "c" d'],
+            ]],
+            'false boolean is not confused with null' => [[
+                'label' => 'bulk',
+                'item' => $item,
+                'packed_at' => new \DateTimeImmutable('2024-01-15 10:30:00'),
+                'delivered_at' => new \DateTimeImmutable('2024-01-15 10:30:00', new \DateTimeZone('UTC')),
+                'dispatched_on' => new \DateTimeImmutable('2024-01-15 00:00:00'),
+                'is_express' => false,
+                'tracking_id' => '550e8400-e29b-41d4-a716-446655440000',
+                'weight' => 0.0,
+                'metadata' => [],
+            ]],
+            'all fields null' => [[
+                'label' => null,
+                'item' => null,
+                'packed_at' => null,
+                'delivered_at' => null,
+                'dispatched_on' => null,
+                'is_express' => null,
+                'tracking_id' => null,
+                'weight' => null,
+                'metadata' => null,
+            ]],
+        ];
+    }
+
+    #[Test]
+    public function decomposes_a_nested_composite_field(): void
+    {
+        [$tableName, $columnName] = $this->prepareTestTable($this->getTypeName());
+
+        try {
+            $this->connection->executeStatement(\sprintf(
+                'INSERT INTO %s.%s ("%s") VALUES (ROW(\'bulk\', ROW(\'widget\', 42, 9.99)::%s.%s, NULL, NULL, NULL, NULL, NULL, NULL, NULL))',
+                self::DATABASE_SCHEMA,
+                $tableName,
+                $columnName,
+                self::DATABASE_SCHEMA,
+                self::ITEM_TYPE_NAME
+            ));
+
+            $retrieved = $this->fetchConvertedValue($this->getTypeName(), $tableName, $columnName);
+
+            $this->assertSame(
+                [
+                    'label' => 'bulk',
+                    'item' => ['name' => 'widget', 'supplier_id' => 42, 'price' => '9.99'],
+                    'packed_at' => null,
+                    'delivered_at' => null,
+                    'dispatched_on' => null,
+                    'is_express' => null,
+                    'tracking_id' => null,
+                    'weight' => null,
+                    'metadata' => null,
+                ],
+                $retrieved
+            );
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CompositeTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CompositeTypeTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Types\Type;
+use Fixtures\MartinGeorgiev\Doctrine\ConcreteInventoryItemType;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCompositeForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCompositeForPHPException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class CompositeTypeTest extends TestCase
+{
+    private const INVENTORY_ITEM_TYPE_NAME = 'test_inventory_item';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection->executeStatement(\sprintf(
+            'CREATE TYPE %s.%s AS (name text, supplier_id integer, price numeric)',
+            self::DATABASE_SCHEMA,
+            self::INVENTORY_ITEM_TYPE_NAME
+        ));
+        $this->registerCompositeType(self::INVENTORY_ITEM_TYPE_NAME, ConcreteInventoryItemType::class);
+    }
+
+    /**
+     * @param class-string<Type> $typeClass
+     */
+    private function registerCompositeType(string $typeName, string $typeClass): void
+    {
+        if (Type::hasType($typeName)) {
+            Type::overrideType($typeName, $typeClass);
+        } else {
+            Type::addType($typeName, $typeClass);
+        }
+
+        $this->connection->getDatabasePlatform()->registerDoctrineTypeMapping($typeName, $typeName);
+    }
+
+    protected function getTypeName(): string
+    {
+        return self::INVENTORY_ITEM_TYPE_NAME;
+    }
+
+    #[Test]
+    public function type_will_be_registered(): void
+    {
+        $typeName = $this->getTypeName();
+        $this->assertTrue(Type::hasType($typeName));
+
+        $type = Type::getType($typeName);
+        $platform = $this->connection->getDatabasePlatform();
+
+        $this->assertSame($typeName, $type->getSQLDeclaration([], $platform));
+
+        if (\method_exists($type, 'requiresSQLCommentHint')) {
+            $this->assertFalse($type->requiresSQLCommentHint($platform)); // @phpstan-ignore-line
+        }
+    }
+
+    #[Test]
+    public function roundtrips_null_value(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+        $this->runDbalBindingRoundTrip($typeName, $columnType, null);
+    }
+
+    /**
+     * @param array<string, mixed> $phpValue
+     */
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function roundtrips_value(array $phpValue, string $postgresValue): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+        [$tableName, $columnName] = $this->prepareTestTable($columnType);
+
+        try {
+            $this->connection->createQueryBuilder()
+                ->insert(self::DATABASE_SCHEMA.'.'.$tableName)
+                ->values([$columnName => ':value'])
+                ->setParameter('value', $phpValue, $typeName)
+                ->executeStatement();
+
+            $storedLiteral = $this->connection->fetchOne(\sprintf(
+                'SELECT "%s"::text FROM %s.%s WHERE id = 1',
+                $columnName,
+                self::DATABASE_SCHEMA,
+                $tableName
+            ));
+            $this->assertSame($postgresValue, $storedLiteral);
+
+            $retrieved = $this->fetchConvertedValue($typeName, $tableName, $columnName);
+            $this->assertRoundTrip($typeName, $phpValue, $retrieved);
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
+    }
+
+    /**
+     * @return array<string, array{phpValue: array<string, mixed>, postgresValue: string}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'plain values' => [
+                'phpValue' => ['name' => 'widget', 'supplier_id' => 42, 'price' => '9.99'],
+                'postgresValue' => '(widget,42,9.99)',
+            ],
+            'all fields null' => [
+                'phpValue' => ['name' => null, 'supplier_id' => null, 'price' => null],
+                'postgresValue' => '(,,)',
+            ],
+            'empty string then nulls' => [
+                'phpValue' => ['name' => '', 'supplier_id' => null, 'price' => null],
+                'postgresValue' => '("",,)',
+            ],
+            'value containing a comma' => [
+                'phpValue' => ['name' => 'a,b', 'supplier_id' => 1, 'price' => '1'],
+                'postgresValue' => '("a,b",1,1)',
+            ],
+            'value containing double quotes' => [
+                'phpValue' => ['name' => 'say "hi"', 'supplier_id' => 1, 'price' => '1'],
+                'postgresValue' => '("say ""hi""",1,1)',
+            ],
+            'value containing a backslash' => [
+                'phpValue' => ['name' => 'back\\slash', 'supplier_id' => 1, 'price' => '1'],
+                'postgresValue' => '("back\\\\slash",1,1)',
+            ],
+            'value containing parentheses' => [
+                'phpValue' => ['name' => '(paren)', 'supplier_id' => 1, 'price' => '1'],
+                'postgresValue' => '("(paren)",1,1)',
+            ],
+            'value with leading and trailing spaces' => [
+                'phpValue' => ['name' => '  padded  ', 'supplier_id' => 1, 'price' => '1'],
+                'postgresValue' => '("  padded  ",1,1)',
+            ],
+            'value containing a newline and a tab' => [
+                'phpValue' => ['name' => "line1\nline2\tend", 'supplier_id' => 1, 'price' => '1'],
+                'postgresValue' => "(\"line1\nline2\tend\",1,1)",
+            ],
+            'literal NULL text is not a null field' => [
+                'phpValue' => ['name' => 'NULL', 'supplier_id' => 1, 'price' => '1'],
+                'postgresValue' => '(NULL,1,1)',
+            ],
+            'every special character at once' => [
+                'phpValue' => ['name' => "a,b \"q\" c\\d (e) \n f", 'supplier_id' => 1, 'price' => '1'],
+                'postgresValue' => "(\"a,b \"\"q\"\" c\\\\d (e) \n f\",1,1)",
+            ],
+            'braces and quotes need no quoting' => [
+                'phpValue' => ['name' => "a{b}c'd;e:f|g", 'supplier_id' => 1, 'price' => '1'],
+                'postgresValue' => "(a{b}c'd;e:f|g,1,1)",
+            ],
+            'numeric scale is preserved' => [
+                'phpValue' => ['name' => 'x', 'supplier_id' => 1, 'price' => '9.90'],
+                'postgresValue' => '(x,1,9.90)',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidValues')]
+    #[Test]
+    public function rejects_invalid_value(mixed $value): void
+    {
+        $this->expectException(InvalidCompositeForDatabaseException::class);
+
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $value);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidValues(): array
+    {
+        return [
+            'raw record literal instead of array' => ['(widget,42,9.99)'],
+            'missing a declared field' => [['name' => 'widget', 'supplier_id' => 42]],
+            'carrying an undeclared field' => [['name' => 'widget', 'supplier_id' => 42, 'price' => '1', 'color' => 'red']],
+        ];
+    }
+
+    #[Test]
+    public function rejects_record_with_a_field_count_the_php_side_does_not_declare(): void
+    {
+        // Simulates DB/PHP model drift: a migration added a field that getFieldTypes() does not know about
+        $columnType = $this->getPostgresTypeName();
+        [$tableName, $columnName] = $this->prepareTestTable($columnType);
+
+        try {
+            $this->connection->executeStatement(\sprintf(
+                'ALTER TYPE %s.%s ADD ATTRIBUTE weight numeric CASCADE',
+                self::DATABASE_SCHEMA,
+                self::INVENTORY_ITEM_TYPE_NAME
+            ));
+            $this->connection->executeStatement(\sprintf(
+                'INSERT INTO %s.%s ("%s") VALUES (?)',
+                self::DATABASE_SCHEMA,
+                $tableName,
+                $columnName
+            ), ['(widget,42,9.99,1.25)']);
+
+            $this->expectException(InvalidCompositeForPHPException::class);
+            $this->fetchConvertedValue(self::INVENTORY_ITEM_TYPE_NAME, $tableName, $columnName);
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CompositeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CompositeArrayTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Fixtures\MartinGeorgiev\Doctrine\ConcreteInventoryItemArrayType;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCompositeArrayItemForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCompositeArrayItemForPHPException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CompositeArrayTest extends TestCase
+{
+    private PostgreSQLPlatform $platform;
+
+    private ConcreteInventoryItemArrayType $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = new PostgreSQLPlatform();
+        $this->fixture = new ConcreteInventoryItemArrayType();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('test_inventory_item[]', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function returns_sql_declaration_as_type_name(): void
+    {
+        $this->assertSame('test_inventory_item[]', $this->fixture->getSQLDeclaration([], $this->platform));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>|null>|null $phpValue
+     */
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>|null>|null $phpValue
+     */
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(?array $phpValue, ?string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{phpValue: array<int, array<string, mixed>|null>|null, postgresValue: string|null}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'null' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty array' => [
+                'phpValue' => [],
+                'postgresValue' => '{}',
+            ],
+            'single item' => [
+                'phpValue' => [['name' => 'widget', 'supplier_id' => 1, 'price' => '9.99']],
+                'postgresValue' => '{"(widget,1,9.99)"}',
+            ],
+            'multiple items' => [
+                'phpValue' => [
+                    ['name' => 'widget', 'supplier_id' => 1, 'price' => '9.99'],
+                    ['name' => 'bolt', 'supplier_id' => 2, 'price' => '0.50'],
+                ],
+                'postgresValue' => '{"(widget,1,9.99)","(bolt,2,0.50)"}',
+            ],
+            'null element' => [
+                'phpValue' => [null, ['name' => 'bolt', 'supplier_id' => 2, 'price' => '0.50']],
+                'postgresValue' => '{NULL,"(bolt,2,0.50)"}',
+            ],
+            'field holding a delimiter escapes at both levels' => [
+                'phpValue' => [['name' => 'a,b', 'supplier_id' => 1, 'price' => '1.00']],
+                'postgresValue' => '{"(\\"a,b\\",1,1.00)"}',
+            ],
+            // The composite layer doubles the quotes, the array layer then backslash-escapes each one
+            'field holding a quote' => [
+                'phpValue' => [['name' => 'say "hi"', 'supplier_id' => 1, 'price' => '1.00']],
+                'postgresValue' => '{"(\\"say \\"\\"hi\\"\\"\\",1,1.00)"}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidTypeInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_type_inputs(mixed $value): void
+    {
+        $this->expectException(InvalidCompositeArrayItemForPHPException::class);
+
+        $this->fixture->convertToDatabaseValue($value, $this->platform); // @phpstan-ignore-line
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidTypeInputs(): array
+    {
+        return [
+            'string instead of array' => ['not-an-array'],
+        ];
+    }
+
+    /**
+     * @param array<int, mixed> $value
+     */
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(array $value): void
+    {
+        $this->expectException(InvalidCompositeArrayItemForDatabaseException::class);
+
+        $this->fixture->convertToDatabaseValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{array<int, mixed>}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'string item' => [['not-a-composite']],
+            'integer item' => [[123]],
+            'boolean item' => [[true]],
+            'object item' => [[new \stdClass()]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(string $postgresValue): void
+    {
+        $this->expectException(InvalidCompositeArrayItemForPHPException::class);
+
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'not an array literal' => ['not-an-array-literal'],
+            'item missing its closing parenthesis' => ['{"(widget,1"}'],
+            'item that is not a record literal' => ['{"widget"}'],
+            'multi-dimensional array literal' => ['{{"(a,1,1.00)"},{"(b,2,2.00)"}}'],
+            'unclosed quotes in the array literal' => ['{"(widget,1,9.99)}'],
+        ];
+    }
+
+    #[DataProvider('provideValidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_valid_array_item_for_database(mixed $item): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($item));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideValidArrayItemsForDatabase(): array
+    {
+        return [
+            'null' => [null],
+            'field-keyed array' => [['name' => 'widget', 'supplier_id' => 1, 'price' => '9.99']],
+            'empty array' => [[]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidArrayItemsForDatabase')]
+    #[Test]
+    public function validates_invalid_array_item_for_database(mixed $item): void
+    {
+        $this->assertFalse($this->fixture->isValidArrayItemForDatabase($item));
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidArrayItemsForDatabase(): array
+    {
+        return [
+            'string' => ['(widget,1,9.99)'],
+            'integer' => [123],
+            'float' => [1.5],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    public function converts_null_item_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
+    #[Test]
+    public function throws_exception_for_non_string_item_from_database(): void
+    {
+        $this->expectException(InvalidCompositeArrayItemForPHPException::class);
+
+        $this->fixture->transformArrayItemForPHP(123);
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CompositeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CompositeTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Fixtures\MartinGeorgiev\Doctrine\ConcreteInventoryItemType;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCompositeForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCompositeForPHPException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CompositeTest extends TestCase
+{
+    private PostgreSQLPlatform $platform;
+
+    private ConcreteInventoryItemType $fixture;
+
+    protected function setUp(): void
+    {
+        $this->platform = new PostgreSQLPlatform();
+        $this->fixture = new ConcreteInventoryItemType();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame('test_inventory_item', $this->fixture->getName());
+    }
+
+    #[Test]
+    public function returns_sql_declaration_as_type_name(): void
+    {
+        $this->assertSame('test_inventory_item', $this->fixture->getSQLDeclaration([], $this->platform));
+    }
+
+    #[Test]
+    public function converts_null_to_database_value(): void
+    {
+        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+    }
+
+    #[Test]
+    public function converts_null_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+    }
+
+    #[Test]
+    public function converts_empty_string_from_database_to_null(): void
+    {
+        $this->assertNull($this->fixture->convertToPHPValue('', $this->platform));
+    }
+
+    /**
+     * @param array<string, mixed> $phpValue
+     */
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(array $phpValue, string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    /**
+     * @param array<string, mixed> $phpValue
+     */
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(array $phpValue, string $postgresValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{phpValue: array<string, mixed>, postgresValue: string}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'plain values' => [
+                'phpValue' => ['name' => 'widget', 'supplier_id' => 42, 'price' => '9.99'],
+                'postgresValue' => '(widget,42,9.99)',
+            ],
+            'all fields null' => [
+                'phpValue' => ['name' => null, 'supplier_id' => null, 'price' => null],
+                'postgresValue' => '(,,)',
+            ],
+            'empty string then nulls' => [
+                'phpValue' => ['name' => '', 'supplier_id' => null, 'price' => null],
+                'postgresValue' => '("",,)',
+            ],
+            'value containing a comma' => [
+                'phpValue' => ['name' => 'a,b', 'supplier_id' => 1, 'price' => '1'],
+                'postgresValue' => '("a,b",1,1)',
+            ],
+            'numeric scale is preserved' => [
+                'phpValue' => ['name' => 'x', 'supplier_id' => 1, 'price' => '9.90'],
+                'postgresValue' => '(x,1,9.90)',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideAlternativeDatabaseEncodings')]
+    #[Test]
+    public function parses_alternative_database_encodings(string $postgresValue, string $expectedName): void
+    {
+        $converted = $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+
+        $this->assertIsArray($converted);
+        $this->assertSame($expectedName, $converted['name']);
+    }
+
+    /**
+     * @return array<string, array{postgresValue: string, expectedName: string}>
+     */
+    public static function provideAlternativeDatabaseEncodings(): array
+    {
+        return [
+            'backslash escape inside quotes' => ['postgresValue' => '("a\\,b",1,1)', 'expectedName' => 'a,b'],
+            'backslash escape outside quotes' => ['postgresValue' => '(a\\,b,1,1)', 'expectedName' => 'a,b'],
+            'backslash escaped quote inside quotes' => ['postgresValue' => '("a\\"b",1,1)', 'expectedName' => 'a"b'],
+            'whitespace around the parentheses' => ['postgresValue' => '  (widget,1,1)  ', 'expectedName' => 'widget'],
+            'unquoted whitespace stays significant' => ['postgresValue' => '(  ,1,1)', 'expectedName' => '  '],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $value): void
+    {
+        $this->expectException(InvalidCompositeForDatabaseException::class);
+
+        $this->fixture->convertToDatabaseValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'string instead of array' => ['(widget,42,9.99)'],
+            'integer' => [42],
+            'boolean' => [true],
+            'object' => [new \stdClass()],
+            'missing a declared field' => [['name' => 'widget', 'supplier_id' => 42]],
+            'carrying an undeclared field' => [['name' => 'widget', 'supplier_id' => 42, 'price' => '1', 'color' => 'red']],
+            'empty array' => [[]],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(mixed $value): void
+    {
+        $this->expectException(InvalidCompositeForPHPException::class);
+
+        $this->fixture->convertToPHPValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'integer' => [42],
+            'array' => [['widget', 42, '9.99']],
+            'object' => [new \stdClass()],
+            'boolean' => [true],
+            'missing the opening parenthesis' => ['widget,42,9.99)'],
+            'missing the closing parenthesis' => ['(widget,42,9.99'],
+            'unterminated quoted field' => ['("widget,42,9.99)'],
+            'trailing backslash' => ['(widget,42,9.99\\'],
+            'too few fields' => ['(widget,42)'],
+            'too many fields' => ['(widget,42,9.99,extra)'],
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_field_value_that_cannot_be_stringified(): void
+    {
+        $this->expectException(InvalidCompositeForDatabaseException::class);
+
+        $this->fixture->convertToDatabaseValue(
+            ['name' => 'widget', 'supplier_id' => 42, 'price' => ['not', 'a', 'scalar']],
+            $this->platform
+        );
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Utils/PHPArrayToPostgresRecordTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PHPArrayToPostgresRecordTransformerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MartinGeorgiev\Utils;
+
+use MartinGeorgiev\Utils\PHPArrayToPostgresRecordTransformer;
+use MartinGeorgiev\Utils\PostgresRecordToPHPArrayTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PHPArrayToPostgresRecordTransformerTest extends TestCase
+{
+    /**
+     * @param array<int, string|null> $phpValue
+     */
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_postgres_value(array $phpValue, string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, PHPArrayToPostgresRecordTransformer::transformPHPArrayToPostgresRecord($phpValue));
+    }
+
+    /**
+     * Quoting only where PostgreSQL itself would quote is what keeps a stored value from drifting, so the
+     * written literal must survive being read back unchanged.
+     *
+     * @param array<int, string|null> $phpValue
+     */
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function roundtrips_through_the_reading_transformer(array $phpValue, string $postgresValue): void
+    {
+        $this->assertSame($phpValue, PostgresRecordToPHPArrayTransformer::transformPostgresRecordToPHPArray($postgresValue));
+    }
+
+    /**
+     * @return array<string, array{phpValue: array<int, string|null>, postgresValue: string}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'plain fields need no quoting' => [
+                'phpValue' => ['widget', '42', '9.99'],
+                'postgresValue' => '(widget,42,9.99)',
+            ],
+            'null becomes an empty field' => [
+                'phpValue' => [null, null],
+                'postgresValue' => '(,)',
+            ],
+            'empty string is quoted' => [
+                'phpValue' => ['', null],
+                'postgresValue' => '("",)',
+            ],
+            'delimiter forces quoting' => [
+                'phpValue' => ['a,b', '1'],
+                'postgresValue' => '("a,b",1)',
+            ],
+            'parenthesis forces quoting' => [
+                'phpValue' => ['(paren)', '1'],
+                'postgresValue' => '("(paren)",1)',
+            ],
+            'whitespace forces quoting' => [
+                'phpValue' => ['  padded  ', '1'],
+                'postgresValue' => '("  padded  ",1)',
+            ],
+            'quote is doubled' => [
+                'phpValue' => ['say "hi"', '1'],
+                'postgresValue' => '("say ""hi""",1)',
+            ],
+            'backslash is escaped' => [
+                'phpValue' => ['back\\slash', '1'],
+                'postgresValue' => '("back\\\\slash",1)',
+            ],
+            'braces and quotes need no quoting' => [
+                'phpValue' => ["a{b}c'd;e:f|g", '1'],
+                'postgresValue' => "(a{b}c'd;e:f|g,1)",
+            ],
+            'value containing a newline and a tab' => [
+                'phpValue' => ["line1\nline2\tend", '1'],
+                'postgresValue' => "(\"line1\nline2\tend\",1)",
+            ],
+            'every special character at once' => [
+                'phpValue' => ["a,b \"q\" c\\d (e) \n f", '1'],
+                'postgresValue' => "(\"a,b \"\"q\"\" c\\\\d (e) \n f\",1)",
+            ],
+            'the literal word NULL is not quoted' => [
+                'phpValue' => ['NULL', '1'],
+                'postgresValue' => '(NULL,1)',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Utils/PostgresRecordToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresRecordToPHPArrayTransformerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MartinGeorgiev\Utils;
+
+use MartinGeorgiev\Utils\Exception\InvalidRecordFormatException;
+use MartinGeorgiev\Utils\PostgresRecordToPHPArrayTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PostgresRecordToPHPArrayTransformerTest extends TestCase
+{
+    /**
+     * @param array<int, string|null> $phpValue
+     */
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(array $phpValue, string $postgresValue): void
+    {
+        $this->assertSame($phpValue, PostgresRecordToPHPArrayTransformer::transformPostgresRecordToPHPArray($postgresValue));
+    }
+
+    /**
+     * @return array<string, array{phpValue: array<int, string|null>, postgresValue: string}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'plain fields' => [
+                'phpValue' => ['widget', '42', '9.99'],
+                'postgresValue' => '(widget,42,9.99)',
+            ],
+            'unquoted empty fields are null' => [
+                'phpValue' => [null, null, null],
+                'postgresValue' => '(,,)',
+            ],
+            'quoted empty field is an empty string' => [
+                'phpValue' => ['', null, null],
+                'postgresValue' => '("",,)',
+            ],
+            'unquoted NULL is the four-character string' => [
+                'phpValue' => ['NULL', '1'],
+                'postgresValue' => '(NULL,1)',
+            ],
+            'quoted field holding a delimiter' => [
+                'phpValue' => ['a,b', '1'],
+                'postgresValue' => '("a,b",1)',
+            ],
+            'doubled quote is a literal quote' => [
+                'phpValue' => ['say "hi"', '1'],
+                'postgresValue' => '("say ""hi""",1)',
+            ],
+            'backslash escape inside quotes' => [
+                'phpValue' => ['back\\slash', '1'],
+                'postgresValue' => '("back\\\\slash",1)',
+            ],
+            'backslash escape outside quotes' => [
+                'phpValue' => ['a,b', '1'],
+                'postgresValue' => '(a\\,b,1)',
+            ],
+            'surrounding whitespace is trimmed' => [
+                'phpValue' => ['a', 'b'],
+                'postgresValue' => '  (a,b)  ',
+            ],
+            'single field' => [
+                'phpValue' => ['only'],
+                'postgresValue' => '(only)',
+            ],
+            'nested record arrives as one raw field' => [
+                'phpValue' => ['bob', '("1 Main St",Sofia)'],
+                'postgresValue' => '(bob,"(""1 Main St"",Sofia)")',
+            ],
+            'bare opening parenthesis is an ordinary character' => [
+                'phpValue' => ['a(b', '1'],
+                'postgresValue' => '(a(b,1)',
+            ],
+            'escaped closing parenthesis outside quotes' => [
+                'phpValue' => ['a)b', '1'],
+                'postgresValue' => '(a\\)b,1)',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidRecordLiterals')]
+    #[Test]
+    public function throws_exception_for_invalid_record_literal(string $postgresValue): void
+    {
+        $this->expectException(InvalidRecordFormatException::class);
+
+        PostgresRecordToPHPArrayTransformer::transformPostgresRecordToPHPArray($postgresValue);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidRecordLiterals(): array
+    {
+        return [
+            'empty string' => [''],
+            'missing both parentheses' => ['a,b'],
+            'missing opening parenthesis' => ['a,b)'],
+            'missing closing parenthesis' => ['(a,b'],
+            'unterminated quoted field' => ['("a,b)'],
+            'trailing backslash' => ['(a\\'],
+            'escape consuming the closing parenthesis' => ['(a\\)'],
+            'bare closing parenthesis ends the record early' => ['(a)b,1)'],
+            'nested parentheses left unquoted' => ['((a),1)'],
+        ];
+    }
+}


### PR DESCRIPTION
Maps a PostgreSQL composite (row) column to a PHP array keyed by field name, with each field converted by its own Doctrine type.

Follows the `Enum` precedent: the library cannot know a user's fields, so `Composite` is an abstract base with a single configuration method, `getFieldTypes()`, alongside `TYPE_NAME`.

The record-literal codec mirrors PostgreSQL's own rules: a field is quoted only when empty or when it holds a delimiter, quote, backslash or whitespace; `"` doubles and `\` escapes on write, both forms are accepted on read; an unquoted empty field is NULL while `""` is the empty string and a bare `NULL` is the four-character string. What the type writes is therefore byte-identical to what PostgreSQL emits for the same value.

Nested composites and arrays of composites are not decomposed, and no schema introspection is performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for mapping PostgreSQL composite (row) types to PHP arrays through Doctrine DBAL.
  - Added support for arrays of composite types.
  - Composite values support field-level conversion, null handling, escaping, nested types, and round-trip persistence.
  - Invalid composite values produce clear conversion errors.

- **Documentation**
  - Added comprehensive guidance for configuring, registering, querying, and using composite types.
  - Updated available-type references and Doctrine, Laravel, and Symfony integration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->