### PR TITLE
refactor: align array item exception messages with the documented shape

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBoxArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBoxArrayItemForDatabaseException.php
@@ -20,6 +20,6 @@ class InvalidBoxArrayItemForDatabaseException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Cannot convert box array item to database value. Expected a Box value object, got %s.', $value);
+        return self::create('Array items must be Box value objects, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBoxArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidBoxArrayItemForPHPException.php
@@ -20,11 +20,11 @@ class InvalidBoxArrayItemForPHPException extends ConversionException
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Cannot convert box array item to PHP value. Value %s is not a valid box.', $value);
+        return self::create('Invalid box format in array: %s', $value);
     }
 
     public static function forInvalidArrayType(mixed $value): self
     {
-        return self::create('Cannot convert box array to PHP value. Expected a string or null, got %s.', $value);
+        return self::create('Value must be an array, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCircleArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCircleArrayItemForDatabaseException.php
@@ -20,6 +20,6 @@ class InvalidCircleArrayItemForDatabaseException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Cannot convert circle array item to database value. Expected a Circle value object, got %s.', $value);
+        return self::create('Array items must be Circle value objects, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCircleArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCircleArrayItemForPHPException.php
@@ -20,11 +20,11 @@ class InvalidCircleArrayItemForPHPException extends ConversionException
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Cannot convert circle array item to PHP value. Value %s is not a valid circle.', $value);
+        return self::create('Invalid circle format in array: %s', $value);
     }
 
     public static function forInvalidArrayType(mixed $value): self
     {
-        return self::create('Cannot convert circle array to PHP value. Expected a string or null, got %s.', $value);
+        return self::create('Value must be an array, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeArrayItemForDatabaseException.php
@@ -20,6 +20,6 @@ class InvalidCubeArrayItemForDatabaseException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Cannot convert cube array item to database value. Expected a Cube value object, got %s.', $value);
+        return self::create('Array items must be Cube value objects, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCubeArrayItemForPHPException.php
@@ -20,11 +20,11 @@ class InvalidCubeArrayItemForPHPException extends ConversionException
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Cannot convert cube array item to PHP value. Value %s is not a valid cube.', $value);
+        return self::create('Invalid cube format in array: %s', $value);
     }
 
     public static function forInvalidArrayType(mixed $value): self
     {
-        return self::create('Cannot convert cube array to PHP value. Expected a string or null, got %s.', $value);
+        return self::create('Value must be an array, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidIntervalArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidIntervalArrayItemForDatabaseException.php
@@ -20,6 +20,6 @@ class InvalidIntervalArrayItemForDatabaseException extends ConversionException
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Cannot convert interval array item to database value. Value %s is not a valid interval.', $value);
+        return self::create('Invalid interval format in array: %s', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidIntervalArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidIntervalArrayItemForPHPException.php
@@ -20,16 +20,16 @@ class InvalidIntervalArrayItemForPHPException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Cannot convert interval array item to PHP value. Expected a string or null, got %s.', $value);
+        return self::create('Array items must be strings, %s given', $value);
     }
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Cannot convert interval array item to PHP value. Value %s is not a valid interval.', $value);
+        return self::create('Invalid interval format in array: %s', $value);
     }
 
     public static function forInvalidArrayType(mixed $value): self
     {
-        return self::create('Cannot convert interval array to PHP value. Expected a string or null, got %s.', $value);
+        return self::create('Value must be an array, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLineArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLineArrayItemForDatabaseException.php
@@ -20,6 +20,6 @@ class InvalidLineArrayItemForDatabaseException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Cannot convert line array item to database value. Expected a Line value object, got %s.', $value);
+        return self::create('Array items must be Line value objects, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLineArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLineArrayItemForPHPException.php
@@ -20,11 +20,11 @@ class InvalidLineArrayItemForPHPException extends ConversionException
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Cannot convert line array item to PHP value. Value %s is not a valid line.', $value);
+        return self::create('Invalid line format in array: %s', $value);
     }
 
     public static function forInvalidArrayType(mixed $value): self
     {
-        return self::create('Cannot convert line array to PHP value. Expected a string or null, got %s.', $value);
+        return self::create('Value must be an array, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLsegArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLsegArrayItemForDatabaseException.php
@@ -20,6 +20,6 @@ class InvalidLsegArrayItemForDatabaseException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Cannot convert lseg array item to database value. Expected a Lseg value object, got %s.', $value);
+        return self::create('Array items must be Lseg value objects, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLsegArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidLsegArrayItemForPHPException.php
@@ -20,11 +20,11 @@ class InvalidLsegArrayItemForPHPException extends ConversionException
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Cannot convert lseg array item to PHP value. Value %s is not a valid lseg.', $value);
+        return self::create('Invalid lseg format in array: %s', $value);
     }
 
     public static function forInvalidArrayType(mixed $value): self
     {
-        return self::create('Cannot convert lseg array to PHP value. Expected a string or null, got %s.', $value);
+        return self::create('Value must be an array, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidPathArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidPathArrayItemForDatabaseException.php
@@ -20,6 +20,6 @@ class InvalidPathArrayItemForDatabaseException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Cannot convert path array item to database value. Expected a Path value object, got %s.', $value);
+        return self::create('Array items must be Path value objects, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidPathArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidPathArrayItemForPHPException.php
@@ -20,11 +20,11 @@ class InvalidPathArrayItemForPHPException extends ConversionException
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Cannot convert path array item to PHP value. Value %s is not a valid path.', $value);
+        return self::create('Invalid path format in array: %s', $value);
     }
 
     public static function forInvalidArrayType(mixed $value): self
     {
-        return self::create('Cannot convert path array to PHP value. Expected a string or null, got %s.', $value);
+        return self::create('Value must be an array, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidPolygonArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidPolygonArrayItemForDatabaseException.php
@@ -20,6 +20,6 @@ class InvalidPolygonArrayItemForDatabaseException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Cannot convert polygon array item to database value. Expected a Polygon value object, got %s.', $value);
+        return self::create('Array items must be Polygon value objects, %s given', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidPolygonArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidPolygonArrayItemForPHPException.php
@@ -20,11 +20,11 @@ class InvalidPolygonArrayItemForPHPException extends ConversionException
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Cannot convert polygon array item to PHP value. Value %s is not a valid polygon.', $value);
+        return self::create('Invalid polygon format in array: %s', $value);
     }
 
     public static function forInvalidArrayType(mixed $value): self
     {
-        return self::create('Cannot convert polygon array to PHP value. Expected a string or null, got %s.', $value);
+        return self::create('Value must be an array, %s given', $value);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified error messages for invalid array items across supported geometry and interval values.
  * Improved messages for invalid formats and non-array inputs.
  * Error messages now more directly identify the expected value type and received value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->