### PR TITLE
test: cover reachable transformer and value-object gaps

### DIFF
--- a/.ai-tools/rules/test-naming-patterns.md
+++ b/.ai-tools/rules/test-naming-patterns.md
@@ -202,7 +202,7 @@ Array types whose items are value objects require these additional tests:
 | `throws_exception_when_invalid_{type}_format_provided` | — | `ForPHPException` | direct call: `transformArrayItemForPHP('(invalid,string)')` |
 | `throws_exception_for_malformed_{type}_strings_in_database` | — | `ForPHPException` | `convertToPHPValue` with a malformed embedded item |
 | `throws_exception_for_invalid_{type}_array_items` | `provideInvalid{Type}ArrayItems` | `ForDatabaseException` | arrays of invalid items passed to `convertToDatabaseValue` |
-| `returns_empty_array_for_malformed_input` | — | — | `convertToPHPValue('{}')`, `convertToPHPValue('{invalid}')`, `convertToPHPValue('{""}')` all return `[]` |
+| `returns_empty_array_for_malformed_input` | `provideMalformedInputs` | — | malformed postgres strings that yield `[]` rather than throwing (`'{}'`, `'{invalid}'`, `'{""}'`) |
 
 `{type}` is replaced by the type name (e.g., `line`, `point`).
 
@@ -240,7 +240,9 @@ The guard inside `transformArrayItemForPostgres` (see `dbal-types.md` § BaseArr
 - Type-name check: `has_name()`
 - One unique boundary condition: `converts_null_to_database_value()`, `roundtrips_null_value()`, `roundtrips_empty_array()`
 - Unique behavior that doesn't vary by input: `throws_exception_for_non_string_item_from_database()` (always `transformArrayItemForPHP(123)`)
-- Multiple assertions that test one cohesive scenario: `returns_empty_array_for_malformed_input()` (tests 3 bad strings, all expecting `[]`)
+- Multiple assertions about a **single** input: `returns_correct_coordinates_via_getters()` (one `Point`, asserts `getX()` and `getY()`)
+
+Several distinct inputs asserting the same outcome is a provider case, not a cohesive scenario — `returns_empty_array_for_malformed_input()` takes `provideMalformedInputs` for exactly this reason.
 
 **Exception — single-case provider is still correct** when the method belongs to a family of provider-driven methods for consistency. Example: `provideInvalidTypeInputs` always contains exactly one entry (`'string instead of array'`) but uses provider form because all sibling exception-test methods also use providers.
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CircleArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CircleArrayTest.php
@@ -150,16 +150,23 @@ final class CircleArrayTest extends TestCase
         $this->assertNull($this->fixture->transformArrayItemForPHP(null));
     }
 
+    #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(): void
+    public function returns_empty_array_for_malformed_input(string $postgresValue): void
     {
-        $result1 = $this->fixture->convertToPHPValue('{}', $this->platform);
-        $result2 = $this->fixture->convertToPHPValue('{invalid}', $this->platform);
-        $result3 = $this->fixture->convertToPHPValue('{""}', $this->platform);
+        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
 
-        $this->assertSame([], $result1);
-        $this->assertSame([], $result2);
-        $this->assertSame([], $result3);
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideMalformedInputs(): array
+    {
+        return [
+            'empty array literal' => ['{}'],
+            'unparsable item' => ['{invalid}'],
+            'quoted empty item' => ['{""}'],
+        ];
     }
 
     #[DataProvider('provideInvalidPHPValueTypes')]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/GeometryArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/GeometryArrayTest.php
@@ -425,10 +425,22 @@ final class GeometryArrayTest extends TestCase
         $this->type->transformArrayItemForPHP('SRID=4326POINT(1 2)');
     }
 
+    #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(): void
+    public function returns_empty_array_for_malformed_input(string $postgresValue): void
     {
-        $this->assertSame([], $this->type->convertToPHPValue('{""}', $this->platform));
-        $this->assertSame([], $this->type->convertToPHPValue('  ', $this->platform));
+        $this->assertSame([], $this->type->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideMalformedInputs(): array
+    {
+        return [
+            'quoted empty item' => ['{""}'],
+            'whitespace only' => ['  '],
+            'lone opening brace' => ['{'],
+        ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LineArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LineArrayTest.php
@@ -150,16 +150,23 @@ final class LineArrayTest extends TestCase
         $this->assertNull($this->fixture->transformArrayItemForPHP(null));
     }
 
+    #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(): void
+    public function returns_empty_array_for_malformed_input(string $postgresValue): void
     {
-        $result1 = $this->fixture->convertToPHPValue('{}', $this->platform);
-        $result2 = $this->fixture->convertToPHPValue('{invalid}', $this->platform);
-        $result3 = $this->fixture->convertToPHPValue('{""}', $this->platform);
+        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
 
-        $this->assertSame([], $result1);
-        $this->assertSame([], $result2);
-        $this->assertSame([], $result3);
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideMalformedInputs(): array
+    {
+        return [
+            'empty array literal' => ['{}'],
+            'unparsable item' => ['{invalid}'],
+            'quoted empty item' => ['{""}'],
+        ];
     }
 
     #[DataProvider('provideInvalidPHPValueTypes')]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LsegArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LsegArrayTest.php
@@ -150,16 +150,23 @@ final class LsegArrayTest extends TestCase
         $this->assertNull($this->fixture->transformArrayItemForPHP(null));
     }
 
+    #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(): void
+    public function returns_empty_array_for_malformed_input(string $postgresValue): void
     {
-        $result1 = $this->fixture->convertToPHPValue('{}', $this->platform);
-        $result2 = $this->fixture->convertToPHPValue('{invalid}', $this->platform);
-        $result3 = $this->fixture->convertToPHPValue('{""}', $this->platform);
+        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
 
-        $this->assertSame([], $result1);
-        $this->assertSame([], $result2);
-        $this->assertSame([], $result3);
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideMalformedInputs(): array
+    {
+        return [
+            'empty array literal' => ['{}'],
+            'unparsable item' => ['{invalid}'],
+            'quoted empty item' => ['{""}'],
+        ];
     }
 
     #[DataProvider('provideInvalidPHPValueTypes')]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PathArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PathArrayTest.php
@@ -150,16 +150,23 @@ final class PathArrayTest extends TestCase
         $this->assertNull($this->fixture->transformArrayItemForPHP(null));
     }
 
+    #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(): void
+    public function returns_empty_array_for_malformed_input(string $postgresValue): void
     {
-        $result1 = $this->fixture->convertToPHPValue('{}', $this->platform);
-        $result2 = $this->fixture->convertToPHPValue('{invalid}', $this->platform);
-        $result3 = $this->fixture->convertToPHPValue('{""}', $this->platform);
+        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
 
-        $this->assertSame([], $result1);
-        $this->assertSame([], $result2);
-        $this->assertSame([], $result3);
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideMalformedInputs(): array
+    {
+        return [
+            'empty array literal' => ['{}'],
+            'unparsable item' => ['{invalid}'],
+            'quoted empty item' => ['{""}'],
+        ];
     }
 
     #[DataProvider('provideInvalidPHPValueTypes')]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PointArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PointArrayTest.php
@@ -197,16 +197,23 @@ final class PointArrayTest extends TestCase
         $this->fixture->convertToPHPValue('{"(invalid,point)"}', $this->platform);
     }
 
+    #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(): void
+    public function returns_empty_array_for_malformed_input(string $postgresValue): void
     {
-        $result1 = $this->fixture->convertToPHPValue('{}', $this->platform);
-        $result2 = $this->fixture->convertToPHPValue('{invalid}', $this->platform);
-        $result3 = $this->fixture->convertToPHPValue('{""}', $this->platform);
+        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
 
-        $this->assertSame([], $result1);
-        $this->assertSame([], $result2);
-        $this->assertSame([], $result3);
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideMalformedInputs(): array
+    {
+        return [
+            'empty array literal' => ['{}'],
+            'unparsable item' => ['{invalid}'],
+            'quoted empty item' => ['{""}'],
+        ];
     }
 
     #[Test]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PolygonArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PolygonArrayTest.php
@@ -150,16 +150,23 @@ final class PolygonArrayTest extends TestCase
         $this->assertNull($this->fixture->transformArrayItemForPHP(null));
     }
 
+    #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(): void
+    public function returns_empty_array_for_malformed_input(string $postgresValue): void
     {
-        $result1 = $this->fixture->convertToPHPValue('{}', $this->platform);
-        $result2 = $this->fixture->convertToPHPValue('{invalid}', $this->platform);
-        $result3 = $this->fixture->convertToPHPValue('{""}', $this->platform);
+        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
 
-        $this->assertSame([], $result1);
-        $this->assertSame([], $result2);
-        $this->assertSame([], $result3);
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideMalformedInputs(): array
+    {
+        return [
+            'empty array literal' => ['{}'],
+            'unparsable item' => ['{invalid}'],
+            'quoted empty item' => ['{""}'],
+        ];
     }
 
     #[DataProvider('provideInvalidPHPValueTypes')]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/SparsevecTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/SparsevecTest.php
@@ -117,6 +117,10 @@ final class SparsevecTest extends TestCase
             'zero dimensions' => ['{1:1.5}/0'],
             'index below range' => ['{0:1.5}/3'],
             'index above range' => ['{4:1.5}/3'],
+            'pair missing colon' => ['{1}/3'],
+            'pair missing index' => ['{:5}/3'],
+            'pair missing value' => ['{1:}/3'],
+            'trailing comma leaves an empty pair' => ['{1:1.5,}/3'],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
@@ -291,6 +291,10 @@ final class PostgresArrayToPHPArrayTransformerTest extends TestCase
                 'expectedValue' => ['502.00', '505.00', '123.50'],
                 'postgresValue' => '{502.00,505.00,123.50}',
             ],
+            'unterminated array' => [
+                'expectedValue' => [],
+                'postgresValue' => '{',
+            ],
             'zero with decimals' => [
                 'expectedValue' => ['0.00', '0.0', '0.000'],
                 'postgresValue' => '{0.00,0.0,0.000}',


### PR DESCRIPTION
Convert returns_empty_array_for_malformed_input to a data provider across the geometric array types and align the rule that documented the standalone form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for malformed PostgreSQL array inputs, including unterminated, invalid, empty, and whitespace-only values.
  - Added validation for additional malformed sparse vector formats.
  - Standardized malformed-input coverage using data-driven test cases across array types.
- **Documentation**
  - Clarified guidance for choosing between standalone tests and provider-driven test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->