### PR TITLE
fix: stop rejecting float array values PostgreSQL itself produces

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseFloatArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseFloatArray.php
@@ -52,14 +52,8 @@ abstract class BaseFloatArray extends BaseArray
 
         $floatValue = (float) $stringValue;
 
-        // For scientific notation, convert to standard decimal form before checking precision
-        if (\str_contains($stringValue, 'e') || \str_contains($stringValue, 'E')) {
-            $standardForm = \sprintf('%.'.($this->getMaxPrecision() + 1).'f', $floatValue);
-            $parts = \explode('.', $standardForm);
-            if (isset($parts[1]) && \strlen($parts[1]) > $this->getMaxPrecision()) {
-                throw InvalidFloatArrayItemForDatabaseException::isAScientificNotationWithExcessPrecision($item);
-            }
-        } elseif (\str_contains($stringValue, '.')) {
+        $isScientificNotation = \str_contains($stringValue, 'e') || \str_contains($stringValue, 'E');
+        if (!$isScientificNotation && \str_contains($stringValue, '.')) {
             $parts = \explode('.', $stringValue);
             if (\strlen($parts[1]) > $this->getMaxPrecision()) {
                 throw InvalidFloatArrayItemForDatabaseException::isANormalNumberWithExcessPrecision($item);
@@ -102,28 +96,8 @@ abstract class BaseFloatArray extends BaseArray
 
         $floatValue = (float) $stringValue;
 
-        // Check if value is too close to zero
-        $absValue = \abs($floatValue);
-        if ($absValue > 0 && $absValue < (float) $this->getMinAbsoluteValue()) {
-            throw InvalidFloatArrayItemForPHPException::forValueThatIsTooCloseToZero($item, static::TYPE_NAME);
-        }
-
         if ($floatValue < (float) $this->getMinValue() || $floatValue > (float) $this->getMaxValue()) {
             throw InvalidFloatArrayItemForPHPException::forValueThatIsNotAValidPHPFloat($item, static::TYPE_NAME);
-        }
-
-        // Scientific notation is valid for input as long as the resulting number
-        // when converted to decimal doesn't exceed precision limits
-        if (\str_contains($stringValue, 'e') || \str_contains($stringValue, 'E')) {
-            return $floatValue;
-        }
-
-        // For regular decimal notation, check precision
-        if (\str_contains($stringValue, '.')) {
-            $parts = \explode('.', $stringValue);
-            if (\strlen($parts[1]) > $this->getMaxPrecision()) {
-                throw InvalidFloatArrayItemForPHPException::forValueThatExceedsMaximumPrecision($item, static::TYPE_NAME);
-            }
         }
 
         return $floatValue;

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/DoublePrecisionArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/DoublePrecisionArrayTypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
-final class DoublePrecisionArrayTypeTest extends ArrayTypeTestCase
+final class DoublePrecisionArrayTypeTest extends FloatArrayTypeTestCase
 {
     protected function getTypeName(): string
     {
@@ -28,6 +28,24 @@ final class DoublePrecisionArrayTypeTest extends ArrayTypeTestCase
             'double precision array with zero' => [[0.0, 1.5, -1.5]],
             'empty double precision array' => [[]],
             'double precision array with large numbers' => [[1234567.123456, -9876543.987654]],
+        ];
+    }
+
+    public static function providePostgresWrittenValues(): array
+    {
+        return [
+            'shortest round-trip form needing more digits than the type guarantees' => [
+                'literal' => '{0.12345678901234566}',
+                'expected' => [0.12345678901234566],
+            ],
+            'subnormal' => [
+                'literal' => '{5e-324}',
+                'expected' => [5.0E-324],
+            ],
+            'scientific notation at the upper bound' => [
+                'literal' => '{1.7976931348623157e+308,-1.7976931348623157e+308}',
+                'expected' => [1.7976931348623157E+308, -1.7976931348623157E+308],
+            ],
         ];
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/FloatArrayTypeTestCase.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/FloatArrayTypeTestCase.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+abstract class FloatArrayTypeTestCase extends ArrayTypeTestCase
+{
+    /**
+     * @param array<int, float> $expected
+     */
+    #[DataProvider('providePostgresWrittenValues')]
+    #[Test]
+    public function converts_postgres_written_value_to_php_value(string $literal, array $expected): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+        [$tableName, $columnName] = $this->prepareTestTable($columnType);
+
+        try {
+            $sql = \sprintf(
+                'INSERT INTO %s.%s ("%s") VALUES (?::%s)',
+                self::DATABASE_SCHEMA,
+                $tableName,
+                $columnName,
+                $columnType
+            );
+            $this->connection->executeStatement($sql, [$literal]);
+
+            $retrieved = $this->fetchConvertedValue($typeName, $tableName, $columnName);
+            $this->assertTypeValueEquals($expected, $retrieved, $typeName);
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
+    }
+
+    /**
+     * @return array<string, array{literal: string, expected: array<int, float>}>
+     */
+    abstract public static function providePostgresWrittenValues(): array;
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/RealArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/RealArrayTypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
-final class RealArrayTypeTest extends ArrayTypeTestCase
+final class RealArrayTypeTest extends FloatArrayTypeTestCase
 {
     protected function getTypeName(): string
     {
@@ -28,6 +28,24 @@ final class RealArrayTypeTest extends ArrayTypeTestCase
             'real array with zero' => [[0.0, 1.5, -1.5]],
             'empty real array' => [[]],
             'real array with large numbers' => [[3.402823e+6, -3.402823e+6]],
+        ];
+    }
+
+    public static function providePostgresWrittenValues(): array
+    {
+        return [
+            'shortest round-trip form needing more digits than the type guarantees' => [
+                'literal' => '{1.1234567,0.12345679}',
+                'expected' => [1.1234567, 0.12345679],
+            ],
+            'subnormal' => [
+                'literal' => '{1e-45}',
+                'expected' => [1.0E-45],
+            ],
+            'scientific notation at the upper bound' => [
+                'literal' => '{3.4028235e+38,-3.4028235e+38}',
+                'expected' => [3.4028235E+38, -3.4028235E+38],
+            ],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseFloatArrayTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseFloatArrayTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidFloatArrayItemForPHPException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 abstract class BaseFloatArrayTestCase extends BaseNumericArrayTestCase
@@ -46,4 +47,28 @@ abstract class BaseFloatArrayTestCase extends BaseNumericArrayTestCase
 
         $this->fixture->transformArrayItemForPHP('1.e234');
     }
+
+    #[DataProvider('providePostgresOutputValues')]
+    #[Test]
+    public function converts_postgres_output_to_php_value(string $postgresValue, float $phpValue): void
+    {
+        $this->assertSame($phpValue, $this->fixture->transformArrayItemForPHP($postgresValue));
+    }
+
+    /**
+     * @return array<string, array{postgresValue: string, phpValue: float}>
+     */
+    abstract public static function providePostgresOutputValues(): array;
+
+    #[DataProvider('provideValidScientificNotationStrings')]
+    #[Test]
+    public function validates_scientific_notation_string_for_database(string $item): void
+    {
+        $this->assertTrue($this->fixture->isValidArrayItemForDatabase($item));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    abstract public static function provideValidScientificNotationStrings(): array;
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DoublePrecisionArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DoublePrecisionArrayTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
 use MartinGeorgiev\Doctrine\DBAL\Types\DoublePrecisionArray;
-use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidFloatArrayItemForPHPException;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 final class DoublePrecisionArrayTest extends BaseFloatArrayTestCase
@@ -29,6 +27,10 @@ final class DoublePrecisionArrayTest extends BaseFloatArrayTestCase
             'too large' => ['1.7976931348623157E+309'],
             'too small' => ['-1.7976931348623157E+309'],
             'too many decimal places' => ['1.123456789012345678'],
+            'sixteen decimals' => ['1.1234567890123456789'],
+            'many trailing zeros' => ['1.123456789012345000000'],
+            'large number with excess precision' => ['123456.1234567890123456789'],
+            'negative with excess precision' => ['-1.1234567890123456789'],
             'too close to zero' => ['2.2250738585072014E-309'],
             'too close to zero (negative)' => ['-2.2250738585072014E-309'],
         ]);
@@ -52,44 +54,29 @@ final class DoublePrecisionArrayTest extends BaseFloatArrayTestCase
         ];
     }
 
-    #[Test]
-    public function throws_exception_for_value_too_close_to_zero(): void
-    {
-        $this->expectException(InvalidFloatArrayItemForPHPException::class);
-        $this->expectExceptionMessage('is too close to zero for PostgreSQL double precision[] type');
-
-        $this->fixture->transformArrayItemForPHP('1.18E-308');
-    }
-
-    #[Test]
-    public function throws_exception_for_value_exceeding_precision_limit(): void
-    {
-        $this->expectException(InvalidFloatArrayItemForPHPException::class);
-        $this->expectExceptionMessage('exceeds maximum precision for PostgreSQL double precision[] type');
-
-        $this->fixture->transformArrayItemForPHP('1.123456789012345678');
-    }
-
-    #[DataProvider('providePrecisionExceedingValues')]
-    #[Test]
-    public function throws_exception_for_various_precision_violations(string $value): void
-    {
-        $this->expectException(InvalidFloatArrayItemForPHPException::class);
-        $this->expectExceptionMessage('exceeds maximum precision for PostgreSQL double precision[] type');
-
-        $this->fixture->transformArrayItemForPHP($value);
-    }
-
-    /**
-     * @return array<string, array{string}>
-     */
-    public static function providePrecisionExceedingValues(): array
+    public static function providePostgresOutputValues(): array
     {
         return [
-            'sixteen decimals' => ['1.1234567890123456789'],
-            'many trailing zeros' => ['1.123456789012345000000'],
-            'large number with excess precision' => ['123456.1234567890123456789'],
-            'negative with excess precision' => ['-1.1234567890123456789'],
+            'seventeen significant digits' => ['postgresValue' => '0.12345678901234566', 'phpValue' => 0.12345678901234566],
+            'trailing zeros beyond the precision limit' => ['postgresValue' => '1.123456789012345000000', 'phpValue' => 1.123456789012345],
+            'sixteen decimals' => ['postgresValue' => '1.1234567890123456789', 'phpValue' => 1.1234567890123457],
+            'eighteen decimals' => ['postgresValue' => '1.123456789012345678', 'phpValue' => 1.1234567890123457],
+            'large number with excess precision' => ['postgresValue' => '123456.1234567890123456789', 'phpValue' => 123456.123456789],
+            'negative with excess precision' => ['postgresValue' => '-1.1234567890123456789', 'phpValue' => -1.1234567890123457],
+            'below the minimum normal magnitude' => ['postgresValue' => '1.18E-308', 'phpValue' => 1.18E-308],
+            'scientific notation with a negative exponent' => ['postgresValue' => '1.5e-20', 'phpValue' => 1.5E-20],
+            'scientific notation at the upper bound' => ['postgresValue' => '1.7976931348623157e+308', 'phpValue' => 1.7976931348623157E+308],
+            'subnormal' => ['postgresValue' => '5e-324', 'phpValue' => 5.0E-324],
+        ];
+    }
+
+    public static function provideValidScientificNotationStrings(): array
+    {
+        return [
+            'no fractional part' => ['1e308'],
+            'positive exponent' => ['1.5e2'],
+            'negative exponent' => ['1.5e-20'],
+            'explicit positive exponent' => ['1.7976931348623157E+308'],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/RealArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/RealArrayTest.php
@@ -6,7 +6,6 @@ namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidFloatArrayItemForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\RealArray;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 final class RealArrayTest extends BaseFloatArrayTestCase
@@ -25,10 +24,12 @@ final class RealArrayTest extends BaseFloatArrayTestCase
     public static function provideInvalidDatabaseValueInputs(): array
     {
         return \array_merge(parent::provideInvalidDatabaseValueInputs(), [
-            'too large' => ['3.402823467E+38'],
-            'too small' => ['-3.402823467E+38'],
+            'too large' => ['3.5E+38'],
+            'too small' => ['-3.5E+38'],
             'too many decimal places' => ['1.1234567'],
-            'scientific notation not allowed' => ['1e38'],
+            'many trailing zeros' => ['1.123000000'],
+            'large number with excess precision' => ['123456.1234567'],
+            'negative with excess precision' => ['-1.1234567'],
             'too close to zero' => ['1.17E-38'],
             'too close to zero (negative)' => ['-1.17E-38'],
         ]);
@@ -71,15 +72,6 @@ final class RealArrayTest extends BaseFloatArrayTestCase
     }
 
     #[Test]
-    public function throws_exception_for_value_too_close_to_zero(): void
-    {
-        $this->expectException(InvalidFloatArrayItemForPHPException::class);
-        $this->expectExceptionMessage('is too close to zero for PostgreSQL real[] type');
-
-        $this->fixture->transformArrayItemForPHP('1.17E-38');
-    }
-
-    #[Test]
     public function throws_exception_for_value_exceeding_range(): void
     {
         $this->expectException(InvalidFloatArrayItemForPHPException::class);
@@ -88,35 +80,29 @@ final class RealArrayTest extends BaseFloatArrayTestCase
         $this->fixture->transformArrayItemForPHP('9999999999999999999999999999999999999999');
     }
 
-    #[Test]
-    public function throws_exception_for_value_exceeding_precision_limit(): void
-    {
-        $this->expectException(InvalidFloatArrayItemForPHPException::class);
-        $this->expectExceptionMessage('exceeds maximum precision for PostgreSQL real[] type');
-
-        $this->fixture->transformArrayItemForPHP('1.1234567');
-    }
-
-    #[DataProvider('providePrecisionExceedingValues')]
-    #[Test]
-    public function throws_exception_for_various_precision_violations(string $value): void
-    {
-        $this->expectException(InvalidFloatArrayItemForPHPException::class);
-        $this->expectExceptionMessage('exceeds maximum precision for PostgreSQL real[] type');
-
-        $this->fixture->transformArrayItemForPHP($value);
-    }
-
-    /**
-     * @return array<string, array{string}>
-     */
-    public static function providePrecisionExceedingValues(): array
+    public static function providePostgresOutputValues(): array
     {
         return [
-            'seven decimals' => ['1.1234567'],
-            'many trailing zeros' => ['1.123000000'],
-            'large number with excess precision' => ['123456.1234567'],
-            'negative with excess precision' => ['-1.1234567'],
+            'seven significant digits' => ['postgresValue' => '1.1234567', 'phpValue' => 1.1234567],
+            'eight fractional digits' => ['postgresValue' => '0.12345679', 'phpValue' => 0.12345679],
+            'trailing zeros beyond the precision limit' => ['postgresValue' => '1.123000000', 'phpValue' => 1.123],
+            'large number with excess precision' => ['postgresValue' => '123456.1234567', 'phpValue' => 123456.1234567],
+            'negative with excess precision' => ['postgresValue' => '-1.1234567', 'phpValue' => -1.1234567],
+            'scientific notation at the upper bound' => ['postgresValue' => '3.4028235e+38', 'phpValue' => 3.4028235E+38],
+            'below the minimum normal magnitude' => ['postgresValue' => '1.17E-38', 'phpValue' => 1.17E-38],
+            'subnormal' => ['postgresValue' => '1e-45', 'phpValue' => 1.0E-45],
+        ];
+    }
+
+    public static function provideValidScientificNotationStrings(): array
+    {
+        return [
+            'no fractional part' => ['1e38'],
+            'positive exponent' => ['1.5e2'],
+            'negative exponent' => ['1.5e-20'],
+            'explicit positive exponent' => ['3.4028235E+38'],
+            'ten significant digits still inside the range' => ['3.402823467E+38'],
+            'negative and inside the range' => ['-3.402823467E+38'],
         ];
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of floating-point arrays returned by PostgreSQL, including scientific notation, subnormal values, and boundary-range values.
  * Valid PostgreSQL floating-point output is now accepted more consistently while values outside supported PHP ranges remain rejected.
  * Scientific-notation values are handled without unnecessary precision-based rejection.

* **Tests**
  * Added coverage for PostgreSQL round trips, scientific notation, subnormal values, and precision-boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->