### PR TITLE
fix: throw a database-direction exception when an array item is rejected on write

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseFloatArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseFloatArray.php
@@ -84,6 +84,13 @@ abstract class BaseFloatArray extends BaseArray
         }
     }
 
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        $this->throwIfInvalidArrayItemForDatabase($item);
+
+        throw InvalidFloatArrayItemForDatabaseException::isNotANumber($item);
+    }
+
     public function transformArrayItemForPHP(mixed $item): ?float
     {
         if ($item === null) {

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArray.php
@@ -61,6 +61,13 @@ abstract class BaseIntegerArray extends BaseArray
         }
     }
 
+    protected function throwInvalidItemException(mixed $item): never
+    {
+        $this->throwIfInvalidArrayItemForDatabase($item);
+
+        throw InvalidIntegerArrayItemForDatabaseException::isNotANumber($item);
+    }
+
     public function transformArrayItemForPHP(mixed $item): ?int
     {
         if ($item === null) {

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseNetworkTypeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseNetworkTypeArray.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
-use Doctrine\DBAL\Types\ConversionException;
-
 /**
  * Base class for network-related PostgreSQL array types (INET[], CIDR[], MACADDR[]).
  *
@@ -25,7 +23,7 @@ abstract class BaseNetworkTypeArray extends BaseArray
         }
 
         if (!\is_string($item)) {
-            throw new ConversionException(\sprintf("Value %s can't be resolved to valid network array item", \var_export($item, true)));
+            $this->throwInvalidItemException($item);
         }
 
         return '"'.$item.'"';

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/CidrArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/CidrArray.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
 use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCidrArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCidrArrayItemForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Traits\CidrValidationTrait;
 
@@ -42,6 +43,10 @@ class CidrArray extends BaseNetworkTypeArray
 
     protected function throwInvalidItemException(mixed $item): never
     {
-        throw InvalidCidrArrayItemForPHPException::forInvalidFormat($item);
+        if (!\is_string($item)) {
+            throw InvalidCidrArrayItemForDatabaseException::forInvalidType($item);
+        }
+
+        throw InvalidCidrArrayItemForDatabaseException::forInvalidFormat($item);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCidrArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCidrArrayItemForDatabaseException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCidrArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid CIDR address format in array: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInetArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInetArrayItemForDatabaseException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidInetArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid INET address format in array: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddr8ArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddr8ArrayItemForDatabaseException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidMacaddr8ArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid EUI-64 MAC address format in array: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddrArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddrArrayItemForDatabaseException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidMacaddrArrayItemForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Array items must be strings, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid MAC address format in array: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/InetArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/InetArray.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
 use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInetArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInetArrayItemForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Traits\InetValidationTrait;
 
@@ -42,6 +43,10 @@ class InetArray extends BaseNetworkTypeArray
 
     protected function throwInvalidItemException(mixed $item): never
     {
-        throw InvalidInetArrayItemForPHPException::forInvalidFormat($item);
+        if (!\is_string($item)) {
+            throw InvalidInetArrayItemForDatabaseException::forInvalidType($item);
+        }
+
+        throw InvalidInetArrayItemForDatabaseException::forInvalidFormat($item);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8Array.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8Array.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
 use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddr8ArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddr8ArrayItemForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Traits\Macaddr8ValidationTrait;
 
@@ -42,6 +43,10 @@ final class Macaddr8Array extends BaseNetworkTypeArray
 
     protected function throwInvalidItemException(mixed $item): never
     {
-        throw InvalidMacaddr8ArrayItemForPHPException::forInvalidFormat($item);
+        if (!\is_string($item)) {
+            throw InvalidMacaddr8ArrayItemForDatabaseException::forInvalidType($item);
+        }
+
+        throw InvalidMacaddr8ArrayItemForDatabaseException::forInvalidFormat($item);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrArray.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
 use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddrArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddrArrayItemForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Traits\MacaddrValidationTrait;
 
@@ -42,6 +43,10 @@ class MacaddrArray extends BaseNetworkTypeArray
 
     protected function throwInvalidItemException(mixed $item): never
     {
-        throw InvalidMacaddrArrayItemForPHPException::forInvalidFormat($item);
+        if (!\is_string($item)) {
+            throw InvalidMacaddrArrayItemForDatabaseException::forInvalidType($item);
+        }
+
+        throw InvalidMacaddrArrayItemForDatabaseException::forInvalidFormat($item);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CidrArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CidrArrayTypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
-use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCidrArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCidrArrayItemForDatabaseException;
 use PHPUnit\Framework\Attributes\Test;
 
 final class CidrArrayTypeTest extends ArrayTypeTestCase
@@ -41,7 +41,7 @@ final class CidrArrayTypeTest extends ArrayTypeTestCase
     #[Test]
     public function rejects_invalid_network_item(): void
     {
-        $this->expectException(InvalidCidrArrayItemForPHPException::class);
+        $this->expectException(InvalidCidrArrayItemForDatabaseException::class);
 
         $typeName = $this->getTypeName();
         $columnType = $this->getPostgresTypeName();

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/InetArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/InetArrayTypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
-use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInetArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInetArrayItemForDatabaseException;
 use PHPUnit\Framework\Attributes\Test;
 
 final class InetArrayTypeTest extends ArrayTypeTestCase
@@ -40,7 +40,7 @@ final class InetArrayTypeTest extends ArrayTypeTestCase
     #[Test]
     public function rejects_invalid_address_item(): void
     {
-        $this->expectException(InvalidInetArrayItemForPHPException::class);
+        $this->expectException(InvalidInetArrayItemForDatabaseException::class);
 
         $typeName = $this->getTypeName();
         $columnType = $this->getPostgresTypeName();

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8ArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8ArrayTypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
-use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddr8ArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddr8ArrayItemForDatabaseException;
 use PHPUnit\Framework\Attributes\Test;
 
 final class Macaddr8ArrayTypeTest extends ArrayTypeTestCase
@@ -31,7 +31,7 @@ final class Macaddr8ArrayTypeTest extends ArrayTypeTestCase
     #[Test]
     public function rejects_invalid_address_item(): void
     {
-        $this->expectException(InvalidMacaddr8ArrayItemForPHPException::class);
+        $this->expectException(InvalidMacaddr8ArrayItemForDatabaseException::class);
 
         $typeName = $this->getTypeName();
         $columnType = $this->getPostgresTypeName();

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrArrayTypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
-use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddrArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddrArrayItemForDatabaseException;
 use PHPUnit\Framework\Attributes\Test;
 
 final class MacaddrArrayTypeTest extends ArrayTypeTestCase
@@ -38,7 +38,7 @@ final class MacaddrArrayTypeTest extends ArrayTypeTestCase
     #[Test]
     public function rejects_invalid_address_item(): void
     {
-        $this->expectException(InvalidMacaddrArrayItemForPHPException::class);
+        $this->expectException(InvalidMacaddrArrayItemForDatabaseException::class);
 
         $typeName = $this->getTypeName();
         $columnType = $this->getPostgresTypeName();

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseFloatArrayTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseFloatArrayTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidFloatArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidFloatArrayItemForPHPException;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -12,6 +13,11 @@ abstract class BaseFloatArrayTestCase extends BaseNumericArrayTestCase
     protected static function getInvalidItemException(): string
     {
         return InvalidFloatArrayItemForPHPException::class;
+    }
+
+    protected static function getInvalidDatabaseItemException(): string
+    {
+        return InvalidFloatArrayItemForDatabaseException::class;
     }
 
     /**

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArrayTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseIntegerArrayTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidIntegerArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidIntegerArrayItemForPHPException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -13,6 +14,11 @@ abstract class BaseIntegerArrayTestCase extends BaseNumericArrayTestCase
     protected static function getInvalidItemException(): string
     {
         return InvalidIntegerArrayItemForPHPException::class;
+    }
+
+    protected static function getInvalidDatabaseItemException(): string
+    {
+        return InvalidIntegerArrayItemForDatabaseException::class;
     }
 
     /**

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseNumericArrayTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseNumericArrayTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use MartinGeorgiev\Doctrine\DBAL\Types\BaseArray;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -20,10 +21,24 @@ abstract class BaseNumericArrayTestCase extends TestCase
         $this->assertFalse($this->fixture->isValidArrayItemForDatabase($phpValue));
     }
 
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
+    {
+        $this->expectException(static::getInvalidDatabaseItemException());
+
+        $this->fixture->convertToDatabaseValue([$phpValue], $this->createStub(AbstractPlatform::class));
+    }
+
     /**
      * @return array<string, array{mixed}>
      */
     abstract public static function provideInvalidDatabaseValueInputs(): array;
+
+    /**
+     * @return class-string<\Throwable>
+     */
+    abstract protected static function getInvalidDatabaseItemException(): string;
 
     /**
      * @return array<string, array{mixed}>

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CidrArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CidrArrayTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use MartinGeorgiev\Doctrine\DBAL\Types\CidrArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCidrArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCidrArrayItemForPHPException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -83,7 +84,7 @@ final class CidrArrayTest extends TestCase
     #[Test]
     public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
     {
-        $this->expectException(InvalidCidrArrayItemForPHPException::class);
+        $this->expectException(InvalidCidrArrayItemForDatabaseException::class);
         $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
     }
 
@@ -93,6 +94,7 @@ final class CidrArrayTest extends TestCase
     public static function provideInvalidDatabaseValueInputs(): array
     {
         return [
+            'integer item' => [[123]],
             'invalid IPv4' => [['256.256.256.0/24']],
             'invalid IPv6' => [['2001:xyz::/32']],
             'missing netmask' => [['192.168.1.0']],

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/InetArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/InetArrayTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInetArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInetArrayItemForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\InetArray;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -103,7 +104,7 @@ final class InetArrayTest extends TestCase
     #[Test]
     public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
     {
-        $this->expectException(InvalidInetArrayItemForPHPException::class);
+        $this->expectException(InvalidInetArrayItemForDatabaseException::class);
         $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
     }
 
@@ -113,6 +114,7 @@ final class InetArrayTest extends TestCase
     public static function provideInvalidDatabaseValueInputs(): array
     {
         return [
+            'integer item' => [[123]],
             'invalid IPv4' => [['256.256.256.256']],
             'invalid IPv6' => [['2001:xyz::1']],
             'invalid CIDR format' => [['192.168.1.0/xyz']],

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8ArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8ArrayTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddr8ArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddr8ArrayItemForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Macaddr8Array;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -79,7 +80,7 @@ final class Macaddr8ArrayTest extends TestCase
     #[Test]
     public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
     {
-        $this->expectException(InvalidMacaddr8ArrayItemForPHPException::class);
+        $this->expectException(InvalidMacaddr8ArrayItemForDatabaseException::class);
         $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
     }
 
@@ -89,6 +90,7 @@ final class Macaddr8ArrayTest extends TestCase
     public static function provideInvalidDatabaseValueInputs(): array
     {
         return [
+            'integer item' => [[123]],
             'too long' => [['08:00:2b:ff:fe:01:02:03:04']],
             'invalid hex chars' => [['08:00:2b:zz:fe:01:02:03']],
             'empty string' => [['']],

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrArrayTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddrArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddrArrayItemForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\MacaddrArray;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -87,7 +88,7 @@ final class MacaddrArrayTest extends TestCase
     #[Test]
     public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
     {
-        $this->expectException(InvalidMacaddrArrayItemForPHPException::class);
+        $this->expectException(InvalidMacaddrArrayItemForDatabaseException::class);
         $this->fixture->convertToDatabaseValue($phpValue, $this->platform); // @phpstan-ignore-line
     }
 
@@ -97,6 +98,7 @@ final class MacaddrArrayTest extends TestCase
     public static function provideInvalidDatabaseValueInputs(): array
     {
         return [
+            'integer item' => [[123]],
             'invalid MAC format' => [['00:11:22:33:44:ZZ']],
             'too short' => [['00:11:22:33:44']],
             'too long' => [['00:11:22:33:44:55:66']],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for database-bound numeric, network, CIDR, and MAC address arrays.
  - Invalid values now produce database-specific conversion errors.
  - Error reporting distinguishes unsupported value types from incorrectly formatted strings.
  - Error messages include the offending value to make troubleshooting easier.
  - Invalid non-string items in network-related arrays are now handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->