### PR TITLE
fix: stop rejecting array values that carry a nested-array marker

### DIFF
--- a/src/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformer.php
+++ b/src/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformer.php
@@ -43,7 +43,10 @@ class PostgresArrayToPHPArrayTransformer
             return [];
         }
 
-        if (\str_contains($trimmed, '},{') || \str_starts_with($trimmed, '{{')) {
+        // A nested array is always the first thing PostgreSQL emits for a multi-dimensional one,
+        // and it never quotes it. Braces anywhere else are caught by the quote-aware scan below,
+        // which is the only way to tell a nested array from the same characters inside a value.
+        if (\str_starts_with($trimmed, '{{')) {
             throw InvalidArrayFormatException::multiDimensionalArrayNotSupported();
         }
 

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTypeTest.php
@@ -47,6 +47,9 @@ final class TextArrayTypeTest extends ArrayTypeTestCase
             'text array with null element as string' => [
                 ['foo', 'null', 'baz'],
             ],
+            'text array with elements carrying the nested-array marker' => [
+                ['a},{b', '{x}', '{{1,2},{3,4}}'],
+            ],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
@@ -166,6 +166,10 @@ final class PostgresArrayToPHPArrayTransformerTest extends TestCase
                 'phpValue' => ['  foo  '],
                 'postgresValue' => '{"  foo  "}',
             ],
+            'element carrying the nested-array marker' => [
+                'phpValue' => ['a},{b', '{x}'],
+                'postgresValue' => '{"a},{b","{x}"}',
+            ],
             'github #424 regression: numeric strings should be preserved as strings when unquoted' => [
                 'phpValue' => ['1', 'test', 'true'],
                 'postgresValue' => '{1,test,true}',
@@ -290,6 +294,10 @@ final class PostgresArrayToPHPArrayTransformerTest extends TestCase
             'floats with trailing zeros - issue #482' => [
                 'expectedValue' => ['502.00', '505.00', '123.50'],
                 'postgresValue' => '{502.00,505.00,123.50}',
+            ],
+            'element carrying the nested-array marker' => [
+                'expectedValue' => ['a},{b', '{x}'],
+                'postgresValue' => '{"a},{b","{x}"}',
             ],
             'unterminated array' => [
                 'expectedValue' => [],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PostgreSQL array parsing for text elements containing braces, commas, or nested-array-like characters.
  - Values such as `a},{b`, `{x}`, and quoted strings with braces are now correctly preserved as single text elements instead of being misinterpreted as nested arrays.

- **Tests**
  - Added coverage for valid text-array values containing nested-array marker characters and quoted commas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->