### PR TITLE
fix(#58): read back every JSON value that a `jsonb[]` column can hold

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArray.php
@@ -43,18 +43,32 @@ class JsonbArray extends BaseArray
         return $this->quoteAndEscapeArrayItem($this->transformToPostgresJson($item));
     }
 
+    /**
+     * @return array<int, mixed>
+     */
     protected function transformPostgresArrayToPHPArray(string $postgresArray): array
     {
         return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray);
     }
 
-    /**
-     * @param string $item
-     */
-    public function transformArrayItemForPHP($item): array
+    public function transformArrayItemForPHP(mixed $item): array|bool|float|int|string|null
     {
+        if ($item === null) {
+            return null;
+        }
+
+        // PostgreSQL leaves a JSON number or boolean unquoted inside the array literal, and the array parser
+        // already turns those into the very PHP value a JSON decode would produce. Only quoted items still carry JSON text.
+        if (\is_int($item) || \is_float($item) || \is_bool($item)) {
+            return $item;
+        }
+
+        if (!\is_string($item)) {
+            throw InvalidJsonArrayItemForPHPException::forInvalidType($item);
+        }
+
         try {
-            return PostgresJsonToPHPArrayTransformer::transformPostgresJsonEncodedValueToPHPArray($item);
+            return PostgresJsonToPHPArrayTransformer::transformPostgresJsonEncodedValueToPHPValue($item);
         } catch (InvalidJsonFormatException) {
             throw InvalidJsonArrayItemForPHPException::forInvalidFormat($item);
         }

--- a/src/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformer.php
+++ b/src/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformer.php
@@ -33,6 +33,8 @@ class PostgresArrayToPHPArrayTransformer
      * @param bool $preserveStringTypes When true, all unquoted values are preserved as strings without type inference.
      *                                  This is useful for text arrays where PostgreSQL may omit quotes for values that look numeric.
      *
+     * @return array<int, mixed>
+     *
      * @throws InvalidArrayFormatException when the input is a multi-dimensional array or has an invalid format
      */
     public static function transformPostgresArrayToPHPArray(string $postgresArray, bool $preserveStringTypes = false): array
@@ -102,6 +104,9 @@ class PostgresArrayToPHPArrayTransformer
         return (array) $decoded;
     }
 
+    /**
+     * @return array<int, mixed>
+     */
     private static function parsePostgresArrayManually(string $content, bool $preserveStringTypes): array
     {
         if ($content === '') {
@@ -221,13 +226,17 @@ class PostgresArrayToPHPArrayTransformer
         return \is_numeric($value);
     }
 
-    private static function processNumericValue(string $value): float|int
+    private static function processNumericValue(string $value): float|int|string
     {
         if (\str_contains($value, '.') || \stripos($value, 'e') !== false) {
             return (float) $value;
         }
 
-        return (int) $value;
+        $asInteger = (int) $value;
+
+        // An integer wider than PHP's range saturates to PHP_INT_MAX on cast, so anything the cast
+        // cannot reproduce stays textual - the choice JSON_BIGINT_AS_STRING makes on the decoding path.
+        return (string) $asInteger === $value ? $asInteger : $value;
     }
 
     private static function unescapeString(string $value): string

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTypeTest.php
@@ -14,8 +14,12 @@ final class JsonbArrayTypeTest extends ArrayTypeTestCase
         return 'jsonb[]';
     }
 
+    /**
+     * @param array<int, mixed> $arrayValue
+     */
     #[DataProvider('provideValidTransformations')]
     #[DataProvider('provideTypeInferenceTestCases')]
+    #[DataProvider('provideScalarItemTestCases')]
     #[Test]
     public function roundtrips_value(array $arrayValue): void
     {
@@ -74,8 +78,21 @@ final class JsonbArrayTypeTest extends ArrayTypeTestCase
     }
 
     /**
-     * Verify that JsonbArray performs type inference correctly (default behavior) as
-     * JSON values should maintain their proper types (integers, floats, booleans, null).
+     * @return array<string, array{array<int, mixed>}>
+     */
+    public static function provideScalarItemTestCases(): array
+    {
+        return [
+            'jsonb array of numbers' => [[1, -2, 3.5]],
+            'jsonb array of booleans' => [[true, false]],
+            'jsonb array of strings' => [['hello', 'null', '1']],
+            'jsonb array of json nulls' => [[null, null]],
+            'jsonb array mixing scalars and objects' => [[1, 'two', true, null, ['key' => 'value'], [1, 2]]],
+        ];
+    }
+
+    /**
+     * @return array<string, array{array<int, array<string, mixed>>}>
      */
     public static function provideTypeInferenceTestCases(): array
     {

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
@@ -88,6 +88,24 @@ final class JsonbArrayTest extends TestCase
         ];
     }
 
+    #[Test]
+    public function converts_json_scalars_to_php_value(): void
+    {
+        $postgresValue = '{"\"hello\"",1,-2.5,"null","{\"a\": 1}",true,NULL}';
+        $expectedResult = ['hello', 1, -2.5, null, ['a' => 1], true, null];
+
+        $this->assertSame($expectedResult, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    #[Test]
+    public function converts_integer_wider_than_the_php_integer_range_to_string(): void
+    {
+        $postgresValue = '{9223372036854775808,NULL}';
+        $expectedResult = ['9223372036854775808', null];
+
+        $this->assertSame($expectedResult, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
     #[DataProvider('provideInvalidTypeInputs')]
     #[Test]
     public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void
@@ -108,6 +126,9 @@ final class JsonbArrayTest extends TestCase
         ];
     }
 
+    /**
+     * @param array<int, mixed> $phpValue
+     */
     #[DataProvider('provideInvalidDatabaseValueInputs')]
     #[Test]
     public function throws_exception_for_invalid_database_value_inputs(array $phpValue): void

--- a/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
@@ -227,6 +227,14 @@ final class PostgresArrayToPHPArrayTransformerTest extends TestCase
                 'phpValue' => ['unquoted text', 1.5],
                 'postgresValue' => '{unquoted text,1.5}',
             ],
+            'manual parsing of an integer wider than the PHP integer range' => [
+                'phpValue' => ['9223372036854775808', null],
+                'postgresValue' => '{9223372036854775808,NULL}',
+            ],
+            'manual parsing of a negative integer wider than the PHP integer range' => [
+                'phpValue' => ['-9223372036854775809', null],
+                'postgresValue' => '{-9223372036854775809,NULL}',
+            ],
         ];
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - JSONB arrays now support scalar values such as integers, decimals, booleans, strings, and nulls.
  - Scalar values retain their original types when converted for application use.
  - Arrays containing mixed scalar values and nested objects are handled correctly.
  - Integers exceeding the platform’s native range are preserved as strings.

- **Bug Fixes**
  - Improved handling of JSON `null` and the string `"null"`.
  - Invalid values and malformed JSON continue to produce clear conversion errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->