### PR TITLE
chore: document the array shapes that native types cannot carry

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/EnumArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/EnumArray.php
@@ -109,6 +109,9 @@ abstract class EnumArray extends BaseArray
         return $case;
     }
 
+    /**
+     * @return array<int, mixed>
+     */
     protected function transformPostgresArrayToPHPArray(string $postgresArray): array
     {
         try {

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/HstoreTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/HstoreTypeTest.php
@@ -22,6 +22,9 @@ final class HstoreTypeTest extends ScalarTypeTestCase
         return 'hstore';
     }
 
+    /**
+     * @param array<string, string|null> $value
+     */
     #[DataProvider('provideValidRoundTrips')]
     #[Test]
     public function roundtrips_value(array $value): void

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTypeTest.php
@@ -14,6 +14,9 @@ final class TextArrayTypeTest extends ArrayTypeTestCase
         return 'text[]';
     }
 
+    /**
+     * @param array<int, string> $arrayValue
+     */
     #[DataProvider('provideValidTransformations')]
     #[DataProvider('provideGithubIssue424TestCases')]
     #[DataProvider('provideGithubIssue482TestCases')]
@@ -57,6 +60,8 @@ final class TextArrayTypeTest extends ArrayTypeTestCase
      * This test scenarios specifically verify the scenarios from GitHub issue #424
      * where PostgreSQL optimizes {"1","test"} to {1,test} and we have to ensure
      * that TextArray correctly preserves string types when converted back for PHP.
+     *
+     * @return array<string, array{array<int, string>}>
      */
     public static function provideGithubIssue424TestCases(): array
     {
@@ -82,6 +87,8 @@ final class TextArrayTypeTest extends ArrayTypeTestCase
      * being truncated to "502" and "505" when round-tripping through the database.
      * PostgreSQL returns these unquoted as {502.00,505.00}, and the fix ensures
      * they are preserved as strings with trailing zeros intact.
+     *
+     * @return array<string, array{array<int, string>}>
      */
     public static function provideGithubIssue482TestCases(): array
     {

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/HstoreTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/HstoreTest.php
@@ -87,6 +87,9 @@ final class HstoreTest extends TestCase
         ];
     }
 
+    /**
+     * @param array<string, string|null> $expected
+     */
     #[DataProvider('provideHstoreToArrayConversions')]
     #[Test]
     public function parses_hstore_string_to_array(string $input, array $expected): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PHPDoc type annotations to test methods and data providers, improving clarity around expected array structures and parameter types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->