### PR TITLE
fix: preserve item types when reading PostgreSQL string arrays

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseStringArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseStringArray.php
@@ -27,9 +27,15 @@ abstract class BaseStringArray extends BaseArray
         return $this->quoteAndEscapeArrayItem($item);
     }
 
+    /**
+     * @return array<int, mixed>
+     */
     protected function transformPostgresArrayToPHPArray(string $postgresArray): array
     {
-        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray);
+        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray(
+            $postgresArray,
+            preserveStringTypes: true
+        );
     }
 
     public function transformArrayItemForPHP(mixed $item): ?string

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BitArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BitArray.php
@@ -9,7 +9,6 @@ use MartinGeorgiev\Doctrine\DBAL\Type;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBitArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBitArrayItemForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Traits\BitValidationTrait;
-use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
 
 /**
  * Implementation of PostgreSQL BIT[] data type.
@@ -37,11 +36,6 @@ class BitArray extends BaseStringArray
         }
 
         return \strtoupper(self::TYPE_NAME);
-    }
-
-    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
-    {
-        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray, true);
     }
 
     public function isValidArrayItemForDatabase(mixed $item): bool

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BitArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BitArray.php
@@ -53,7 +53,7 @@ class BitArray extends BaseStringArray
 
     public function transformArrayItemForPHP(mixed $item): ?string
     {
-        if ($item === null || $item === 'NULL') {
+        if ($item === null) {
             return null;
         }
 

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BitVaryingArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BitVaryingArray.php
@@ -9,7 +9,6 @@ use MartinGeorgiev\Doctrine\DBAL\Type;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBitVaryingArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidBitVaryingArrayItemForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Traits\BitValidationTrait;
-use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
 
 /**
  * Implementation of PostgreSQL BIT VARYING[] data type.
@@ -37,11 +36,6 @@ class BitVaryingArray extends BaseStringArray
         }
 
         return \strtoupper(self::TYPE_NAME);
-    }
-
-    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
-    {
-        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray, true);
     }
 
     public function isValidArrayItemForDatabase(mixed $item): bool

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BitVaryingArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BitVaryingArray.php
@@ -53,7 +53,7 @@ class BitVaryingArray extends BaseStringArray
 
     public function transformArrayItemForPHP(mixed $item): ?string
     {
-        if ($item === null || $item === 'NULL') {
+        if ($item === null) {
             return null;
         }
 

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
@@ -49,15 +49,6 @@ class NumericArray extends BaseStringArray
         return \preg_match(self::NUMERIC_REGEX, $item) === 1;
     }
 
-    public function transformArrayItemForPHP(mixed $item): ?string
-    {
-        if ($item === 'NULL') {
-            return null;
-        }
-
-        return parent::transformArrayItemForPHP($item);
-    }
-
     protected function createInvalidTypeExceptionForPHP(mixed $item): InvalidNumericArrayItemForPHPException
     {
         return InvalidNumericArrayItemForPHPException::forInvalidType($item);

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/NumericArray.php
@@ -7,7 +7,6 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types;
 use MartinGeorgiev\Doctrine\DBAL\Type;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidNumericArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidNumericArrayItemForPHPException;
-use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
 
 /**
  * Implementation of PostgreSQL NUMERIC[] data type.
@@ -48,14 +47,6 @@ class NumericArray extends BaseStringArray
         }
 
         return \preg_match(self::NUMERIC_REGEX, $item) === 1;
-    }
-
-    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
-    {
-        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray(
-            $postgresArray,
-            preserveStringTypes: true
-        );
     }
 
     public function transformArrayItemForPHP(mixed $item): ?string

--- a/src/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformer.php
+++ b/src/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformer.php
@@ -171,7 +171,9 @@ class PostgresArrayToPHPArrayTransformer
                 return self::processQuotedString($value);
             }
 
-            return $value;
+            // PostgreSQL quotes any element whose text would otherwise read as NULL,
+            // so an unquoted one is always the SQL null and never the four-letter label.
+            return self::isNullValue($value) ? null : $value;
         }
 
         if (self::isNullValue($value)) {

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTypeTest.php
@@ -18,6 +18,9 @@ final class CitextArrayTypeTest extends ArrayTypeTestCase
         return 'citext[]';
     }
 
+    /**
+     * @return array<string, array{array<int, string|null>}>
+     */
     public static function provideValidTransformations(): array
     {
         return [
@@ -26,6 +29,9 @@ final class CitextArrayTypeTest extends ArrayTypeTestCase
             'array with special chars' => [['café', 'naïve']],
             'array with null item' => [[null, 'hello']],
             'array with empty string' => [['', 'hello']],
+            'array with numeric-looking values' => [['123', '2.5', '0', '1e3']],
+            'array with boolean-looking values' => [['t', 'f', 'true', 'false']],
+            'array with null-looking values' => [['null', 'NULL']],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CitextArrayTest.php
@@ -84,6 +84,15 @@ final class CitextArrayTest extends TestCase
         ];
     }
 
+    #[Test]
+    public function converts_unquoted_postgres_items_to_strings(): void
+    {
+        $postgresValue = '{123,2.5,t,false,hello}';
+        $expectedResult = ['123', '2.5', 't', 'false', 'hello'];
+
+        $this->assertSame($expectedResult, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
     #[DataProvider('provideInvalidDatabaseValueInputs')]
     #[Test]
     public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
@@ -165,11 +165,16 @@ final class TextArrayTest extends TestCase
                 'postgresValue' => '{1,"2",true,"false",3.14,"test"}',
                 'expectedResult' => ['1', '2', 'true', 'false', '3.14', 'test'],
             ],
-            'null values should be converted to strings' => [
-                'postgresValue' => '{"",null,"null","NULL"}',
-                'expectedResult' => ['', 'null', 'null', 'NULL'],
-            ],
         ];
+    }
+
+    #[Test]
+    public function converts_unquoted_null_element_to_null(): void
+    {
+        $postgresValue = '{"",null,"null","NULL"}';
+        $expectedResult = ['', null, 'null', 'NULL'];
+
+        $this->assertSame($expectedResult, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
     }
 
     #[Test]

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TextArrayTest.php
@@ -123,6 +123,9 @@ final class TextArrayTest extends TestCase
         $this->assertSame($expectedValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
     }
 
+    /**
+     * @param array<int, string> $expectedResult
+     */
     #[DataProvider('provideGithubIssue424TestCases')]
     #[Test]
     public function preserves_string_types_retrieved_from_database_for_github_issue_424(string $postgresValue, array $expectedResult): void

--- a/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
@@ -293,6 +293,14 @@ final class PostgresArrayToPHPArrayTransformerTest extends TestCase
         }
     }
 
+    #[Test]
+    public function converts_unquoted_null_to_null_when_preserving_string_types(): void
+    {
+        $result = PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray('{null,NULL,"null","NULL"}', preserveStringTypes: true);
+
+        $this->assertSame([null, null, 'null', 'NULL'], $result);
+    }
+
     /**
      * @return array<string, array{expectedValue: array, postgresValue: string}>
      */
@@ -339,9 +347,9 @@ final class PostgresArrayToPHPArrayTransformerTest extends TestCase
                 'expectedValue' => ['true', 'false', 't', 'f'],
                 'postgresValue' => '{true,false,t,f}',
             ],
-            'null values as strings' => [
+            'quoted null-looking labels' => [
                 'expectedValue' => ['null', 'NULL'],
-                'postgresValue' => '{null,NULL}',
+                'postgresValue' => '{"null","NULL"}',
             ],
             'empty strings preserved' => [
                 'expectedValue' => ['', 'text', ''],

--- a/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
@@ -198,6 +198,9 @@ final class PostgresArrayToPHPArrayTransformerTest extends TestCase
         ];
     }
 
+    /**
+     * @param array<int, mixed> $phpValue
+     */
     #[DataProvider('provideManualParsingArrays')]
     #[Test]
     public function recovers_from_json_decode_failure_and_transform_value_through_manual_parsing(array $phpValue, string $postgresValue): void
@@ -279,6 +282,9 @@ final class PostgresArrayToPHPArrayTransformerTest extends TestCase
         ];
     }
 
+    /**
+     * @param array<int, mixed> $expectedValue
+     */
     #[DataProvider('providePreserveStringTypesTestCases')]
     #[Test]
     public function preserves_string_types_when_requested(array $expectedValue, string $postgresValue): void
@@ -291,14 +297,6 @@ final class PostgresArrayToPHPArrayTransformerTest extends TestCase
         foreach ($result as $value) {
             $this->assertIsString($value, \sprintf('All values should be strings when preserveStringTypes is true, but found a non-string value: %s', \var_export($value, true)));
         }
-    }
-
-    #[Test]
-    public function converts_unquoted_null_to_null_when_preserving_string_types(): void
-    {
-        $result = PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray('{null,NULL,"null","NULL"}', preserveStringTypes: true);
-
-        $this->assertSame([null, null, 'null', 'NULL'], $result);
     }
 
     /**
@@ -356,5 +354,13 @@ final class PostgresArrayToPHPArrayTransformerTest extends TestCase
                 'postgresValue' => '{"",text,""}',
             ],
         ];
+    }
+
+    #[Test]
+    public function converts_unquoted_null_to_null_when_preserving_string_types(): void
+    {
+        $result = PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray('{null,NULL,"null","NULL"}', preserveStringTypes: true);
+
+        $this->assertSame([null, null, 'null', 'NULL'], $result);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected PostgreSQL array conversion so unquoted `null` and `NULL` values become PHP `null`.
  - Preserved quoted `"null"` and `"NULL"` values as strings.
  - Ensured array values resembling numbers, booleans, or null labels remain strings where appropriate.

- **Tests**
  - Added coverage for null handling and string preservation across supported array types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->