### PR TITLE
chore: drop the disused float array exception factories

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidFloatArrayItemForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidFloatArrayItemForDatabaseException.php
@@ -28,11 +28,6 @@ class InvalidFloatArrayItemForDatabaseException extends ConversionException
         return self::create('Given value of %s does not match float regex.', $value);
     }
 
-    public static function isAScientificNotationWithExcessPrecision(mixed $value): self
-    {
-        return self::create('Given value of %s is a scientific notation with excess precision.', $value);
-    }
-
     public static function isANormalNumberWithExcessPrecision(mixed $value): self
     {
         return self::create('Given value of %s is a normal number with excess precision.', $value);

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidFloatArrayItemForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidFloatArrayItemForPHPException.php
@@ -22,14 +22,4 @@ class InvalidFloatArrayItemForPHPException extends ConversionException
     {
         return self::create('Given value of %s content cannot be transformed to valid PHP float from PostgreSQL %s type', $value, $type);
     }
-
-    public static function forValueThatIsTooCloseToZero(mixed $value, string $type): self
-    {
-        return self::create('Given value of %s is too close to zero for PostgreSQL %s type', $value, $type);
-    }
-
-    public static function forValueThatExceedsMaximumPrecision(mixed $value, string $type): self
-    {
-        return self::create('Given value of %s exceeds maximum precision for PostgreSQL %s type', $value, $type);
-    }
 }


### PR DESCRIPTION
The read path stopped rejecting values on precision and magnitude grounds in #701, and the always-true scientific-notation branch went with it, so no code path can produce these three any more.