### PR TITLE
test: pin JSON booleans apart from their string lookalikes in a `jsonb[]`

### DIFF
--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTypeTest.php
@@ -86,6 +86,7 @@ final class JsonbArrayTypeTest extends ArrayTypeTestCase
             'jsonb array of numbers' => [[1, -2, 3.5]],
             'jsonb array of booleans' => [[true, false]],
             'jsonb array of strings' => [['hello', 'null', '1']],
+            'jsonb array of booleans beside their string lookalikes' => [[true, false, 'true', 'false', 't', 'f']],
             'jsonb array of json nulls' => [[null, null]],
             'jsonb array mixing scalars and objects' => [[1, 'two', true, null, ['key' => 'value'], [1, 2]]],
         ];

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
@@ -106,6 +106,15 @@ final class JsonbArrayTest extends TestCase
         $this->assertSame($expectedResult, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
     }
 
+    #[Test]
+    public function keeps_json_booleans_apart_from_their_string_lookalikes(): void
+    {
+        $postgresValue = '{true,false,"\\"true\\"","\\"false\\"","\\"t\\"","\\"f\\"",NULL}';
+        $expectedResult = [true, false, 'true', 'false', 't', 'f', null];
+
+        $this->assertSame($expectedResult, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
     #[DataProvider('provideInvalidTypeInputs')]
     #[Test]
     public function throws_exception_for_invalid_type_inputs(mixed $phpValue): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming JSON boolean values remain distinct from string values such as `"true"`, `"false"`, `"t"`, and `"f"`.
  - Added round-trip verification for boolean values and handling of `NULL` as `null`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->