### PR TITLE
chore: remove dead PostgresJsonToPHPArrayTransformer methods

### DIFF
--- a/.ai-tools/rules/exceptions.md
+++ b/.ai-tools/rules/exceptions.md
@@ -48,7 +48,7 @@ throw InvalidJsonFormatException::invalidFormat('the value is not decodable JSON
 
 // ...and in the DBAL type:
 try {
-    return PostgresJsonToPHPArrayTransformer::transformPostgresJsonEncodedValueToPHPArray($item);
+    return PostgresJsonToPHPArrayTransformer::transformPostgresJsonEncodedValueToPHPValue($item);
 } catch (InvalidJsonFormatException) {
     throw InvalidJsonArrayItemForPHPException::forInvalidFormat($item);
 }

--- a/src/MartinGeorgiev/Utils/PostgresJsonToPHPArrayTransformer.php
+++ b/src/MartinGeorgiev/Utils/PostgresJsonToPHPArrayTransformer.php
@@ -16,43 +16,6 @@ use MartinGeorgiev\Utils\Exception\InvalidJsonFormatException;
 class PostgresJsonToPHPArrayTransformer
 {
     /**
-     * @var string
-     */
-    private const POSTGRESQL_EMPTY_ARRAY = '{}';
-
-    public static function transformPostgresArrayToPHPArray(string $postgresValue): array
-    {
-        if ($postgresValue === self::POSTGRESQL_EMPTY_ARRAY) {
-            return [];
-        }
-
-        $trimmedPostgresArray = \mb_substr($postgresValue, 2, -2);
-        $phpArray = \explode('},{', $trimmedPostgresArray);
-        foreach ($phpArray as &$item) {
-            $item = '{'.$item.'}';
-        }
-
-        return $phpArray;
-    }
-
-    /**
-     * @throws InvalidJsonFormatException When the PostgreSQL value is not a JSON array
-     */
-    public static function transformPostgresJsonEncodedValueToPHPArray(string $postgresValue): array
-    {
-        try {
-            $transformedValue = \json_decode($postgresValue, true, 512, JSON_THROW_ON_ERROR | JSON_BIGINT_AS_STRING);
-            if (!\is_array($transformedValue)) {
-                throw InvalidJsonFormatException::invalidFormat('the value does not decode to an array');
-            }
-
-            return $transformedValue;
-        } catch (\JsonException) {
-            throw InvalidJsonFormatException::invalidFormat('the value is not decodable JSON');
-        }
-    }
-
-    /**
      * @throws InvalidJsonFormatException When the PostgreSQL value is not JSON-decodable
      */
     public static function transformPostgresJsonEncodedValueToPHPValue(string $postgresValue): array|bool|float|int|string|null

--- a/tests/Unit/MartinGeorgiev/Utils/PostgresJsonToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresJsonToPHPArrayTransformerTest.php
@@ -56,79 +56,11 @@ final class PostgresJsonToPHPArrayTransformerTest extends TestCase
         ];
     }
 
-    #[DataProvider('provideValidJsonbArrayTransformations')]
-    #[Test]
-    public function converts_json_array_to_php_array(array $phpArray, string $postgresArray): void
-    {
-        $this->assertSame($phpArray, PostgresJsonToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray));
-    }
-
-    /**
-     * @return array<string, array{phpArray: array, postgresArray: string}>
-     */
-    public static function provideValidJsonbArrayTransformations(): array
-    {
-        return [
-            'empty array' => [
-                'phpArray' => [],
-                'postgresArray' => '{}',
-            ],
-            'array with one object' => [
-                'phpArray' => ['{key:value}'],
-                'postgresArray' => '{{key:value}}',
-            ],
-            'array with multiple objects' => [
-                'phpArray' => ['{key1:value1}', '{key2:value2}'],
-                'postgresArray' => '{{key1:value1},{key2:value2}}',
-            ],
-        ];
-    }
-
-    #[DataProvider('provideValidJsonbArrayItemTransformations')]
-    #[Test]
-    public function converts_json_array_item_to_php_array(array $phpArray, string $item): void
-    {
-        $this->assertSame($phpArray, PostgresJsonToPHPArrayTransformer::transformPostgresJsonEncodedValueToPHPArray($item));
-    }
-
-    /**
-     * @return array<string, array{phpArray: array, item: string}>
-     */
-    public static function provideValidJsonbArrayItemTransformations(): array
-    {
-        return [
-            'simple object' => [
-                'phpArray' => ['key' => 'value'],
-                'item' => '{"key":"value"}',
-            ],
-            'nested object' => [
-                'phpArray' => ['key' => ['nested' => 'value']],
-                'item' => '{"key":{"nested":"value"}}',
-            ],
-        ];
-    }
-
     #[Test]
     public function throws_exception_for_invalid_json(): void
     {
         $this->expectException(InvalidJsonFormatException::class);
         $this->expectExceptionMessage('Invalid JSON format: the value is not decodable JSON');
         PostgresJsonToPHPArrayTransformer::transformPostgresJsonEncodedValueToPHPValue('{invalid json}');
-    }
-
-    #[Test]
-    public function throws_exception_for_invalid_json_array_item(): void
-    {
-        $this->expectException(InvalidJsonFormatException::class);
-        $this->expectExceptionMessage('Invalid JSON format: the value is not decodable JSON');
-        PostgresJsonToPHPArrayTransformer::transformPostgresJsonEncodedValueToPHPArray('{invalid json}');
-    }
-
-    #[Test]
-    public function throws_exception_for_non_array_json_array_item(): void
-    {
-        $this->expectException(InvalidJsonFormatException::class);
-        $this->expectExceptionMessage('Invalid JSON format: the value does not decode to an array');
-        PostgresJsonToPHPArrayTransformer::transformPostgresJsonEncodedValueToPHPArray('"string"');
     }
 }


### PR DESCRIPTION
Removes two public static methods from `PostgresJsonToPHPArrayTransformer` that have no remaining production caller:

- `transformPostgresJsonEncodedValueToPHPArray()`: its sole production caller in `JsonbArray` was replaced by `transformPostgresJsonEncodedValueToPHPValue()` in #706 (the scalar-aware variant that now backs `jsonb[]` item reads).
- `transformPostgresArrayToPHPArray()`: no longer planned a production caller; not to be confused with the differently named `PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray()`, which remains heavily used throughout the array types.

Also removes the now-orphaned `POSTGRESQL_EMPTY_ARRAY` constant, the tests that existed solely to exercise these methods, and updates a code example in [.ai-tools/rules/exceptions.md](.ai-tools/rules/exceptions.md) that demonstrated the `Utils`-exception catch/rethrow pattern using the now-removed array method.

## 🚨 BC note
these are public static methods on a non-final class, so this is technically a public API removal for any external code that called them directly (bypassing this library's own DBAL types). No production code in this repo ever called them after #706 merged, and the odds of an external consumer reaching into an internal Utils namespace to call a JSON-array-literal parser are low, but the removal is still a signature change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Removed Features**
  - Removed support for PostgreSQL array and JSONB array-item transformation methods.
  - JSON-encoded PostgreSQL values are now handled through the remaining value transformation behavior.

- **Documentation**
  - Updated the exception-handling example to reference the current transformation method name.

- **Tests**
  - Removed tests covering the discontinued array and array-item transformations.
  - Retained coverage for invalid JSON handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->