### PR TITLE
fix: restore writing a null `jsonb[]` item as a SQL NULL element

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArray.php
@@ -40,6 +40,10 @@ class JsonbArray extends BaseArray
 
     protected function transformArrayItemForPostgres(mixed $item): string
     {
+        if ($item === null) {
+            return 'NULL';
+        }
+
         return $this->quoteAndEscapeArrayItem($this->transformToPostgresJson($item));
     }
 

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTypeTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
+use PHPUnit\Framework\Attributes\Test;
+
 final class JsonArrayTypeTest extends ArrayTypeTestCase
 {
     protected function getTypeName(): string
@@ -11,12 +13,51 @@ final class JsonArrayTypeTest extends ArrayTypeTestCase
         return 'json[]';
     }
 
+    #[Test]
+    public function writes_a_null_item_as_a_sql_null_element(): void
+    {
+        [$tableName, $columnName] = $this->prepareTestTable($this->getPostgresTypeName());
+
+        try {
+            $this->connection->createQueryBuilder()
+                ->insert(self::DATABASE_SCHEMA.'.'.$tableName)
+                ->values([$columnName => ':value'])
+                ->setParameter('value', [null, 1], $this->getTypeName())
+                ->executeStatement();
+
+            $storedLiteral = $this->connection->fetchOne(\sprintf(
+                'SELECT ("%s")::text FROM %s.%s WHERE id = 1',
+                $columnName,
+                self::DATABASE_SCHEMA,
+                $tableName
+            ));
+            $this->assertSame('{NULL,1}', $storedLiteral);
+
+            // json_typeof answers 'null' for a JSON null and SQL NULL only for a SQL NULL element - the sole way to tell them apart.
+            $firstElementType = $this->connection->fetchOne(\sprintf(
+                'SELECT json_typeof(("%s")[1]) FROM %s.%s WHERE id = 1',
+                $columnName,
+                self::DATABASE_SCHEMA,
+                $tableName
+            ));
+            $this->assertNull($firstElementType);
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
+    }
+
     /**
-     * @return array<string, array{array<int, array<string, mixed>>}>
+     * @return array<string, array{array<int, mixed>}>
      */
     public static function provideValidTransformations(): array
     {
         return [
+            'json array with null items among json values' => [[
+                null,
+                ['key' => 'value'],
+                null,
+                1,
+            ]],
             'simple json array' => [[
                 ['key1' => 'value1', 'key2' => false],
                 ['key1' => 'value2', 'key2' => true],

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTypeTest.php
@@ -14,6 +14,39 @@ final class JsonbArrayTypeTest extends ArrayTypeTestCase
         return 'jsonb[]';
     }
 
+    #[Test]
+    public function writes_a_null_item_as_a_sql_null_element(): void
+    {
+        [$tableName, $columnName] = $this->prepareTestTable($this->getPostgresTypeName());
+
+        try {
+            $this->connection->createQueryBuilder()
+                ->insert(self::DATABASE_SCHEMA.'.'.$tableName)
+                ->values([$columnName => ':value'])
+                ->setParameter('value', [null, 1], $this->getTypeName())
+                ->executeStatement();
+
+            $storedLiteral = $this->connection->fetchOne(\sprintf(
+                'SELECT ("%s")::text FROM %s.%s WHERE id = 1',
+                $columnName,
+                self::DATABASE_SCHEMA,
+                $tableName
+            ));
+            $this->assertSame('{NULL,1}', $storedLiteral);
+
+            // jsonb_typeof answers 'null' for a JSON null and SQL NULL only for a SQL NULL element - the sole way to tell them apart.
+            $firstElementType = $this->connection->fetchOne(\sprintf(
+                'SELECT jsonb_typeof(("%s")[1]) FROM %s.%s WHERE id = 1',
+                $columnName,
+                self::DATABASE_SCHEMA,
+                $tableName
+            ));
+            $this->assertNull($firstElementType);
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
+    }
+
     /**
      * @param array<int, mixed> $arrayValue
      */

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTest.php
@@ -84,6 +84,34 @@ final class JsonArrayTest extends TestCase
                 ],
                 'postgresValue' => '{"{\"key1\":\"value1\",\"key2\":false,\"key3\":\"15\",\"key4\":15,\"key5\":[112,242,309,310]}","{\"key1\":\"value2\",\"key2\":true,\"key3\":\"115\",\"key4\":115,\"key5\":[304,404,504,604]}"}',
             ],
+            'array with only a null item' => [
+                'phpValue' => [null],
+                'postgresValue' => '{NULL}',
+            ],
+            'array with null items among json values' => [
+                'phpValue' => [null, ['key' => 'value'], null, 1],
+                'postgresValue' => '{NULL,"{\"key\":\"value\"}",NULL,"1"}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideStoredNullElementRepresentations')]
+    #[Test]
+    public function converts_every_stored_null_element_representation_to_php_null(string $postgresValue): void
+    {
+        $this->assertSame([null], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * Guards the readability of rows written before a null item became a SQL NULL element.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function provideStoredNullElementRepresentations(): array
+    {
+        return [
+            'sql null element' => ['{NULL}'],
+            'json null element stored by the previous behaviour' => ['{"null"}'],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
@@ -85,6 +85,34 @@ final class JsonbArrayTest extends TestCase
                 ],
                 'postgresValue' => '{"{\"key1\":\"value1\",\"key2\":false,\"key3\":\"15\",\"key4\":15,\"key5\":[112,242,309,310]}","{\"key1\":\"value2\",\"key2\":true,\"key3\":\"115\",\"key4\":115,\"key5\":[304,404,504,604]}"}',
             ],
+            'array with only a null item' => [
+                'phpValue' => [null],
+                'postgresValue' => '{NULL}',
+            ],
+            'array with null items among json values' => [
+                'phpValue' => [null, ['key' => 'value'], null, 1],
+                'postgresValue' => '{NULL,"{\"key\":\"value\"}",NULL,"1"}',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideStoredNullElementRepresentations')]
+    #[Test]
+    public function converts_every_stored_null_element_representation_to_php_null(string $postgresValue): void
+    {
+        $this->assertSame([null], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * Guards the readability of rows written before a null item became a SQL NULL element.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function provideStoredNullElementRepresentations(): array
+    {
+        return [
+            'sql null element' => ['{NULL}'],
+            'json null element stored by the previous behaviour' => ['{"null"}'],
         ];
     }
 


### PR DESCRIPTION
#442 (released in v3.5.0) fixed broken escaping of `jsonb[]` items by quoting
every element. A PHP `null` reaches `transformArrayItemForPostgres()` as the
`json_encode` output `null`, so quoting turned `{null}` into `{"null"}`.
PostgreSQL reads an unquoted `null` in an array literal as a SQL NULL element
and a quoted one as the four-character JSON text, so from v3.5.0 onwards
`convertToDatabaseValue([null], $platform)` stored a jsonb value of JSON type
`null` where every earlier version had stored a NULL array element. Nulls are
not mentioned anywhere in #442 - the change was collateral to the escaping fix.

`JsonbArray` emits the unquoted `NULL` token again, as it did before v3.5.0.
`JsonArray` extends it without overriding the write path, so `json[]` regressed
the same way and is restored with it.

This also puts both types back in line with the rest of the library: every
sibling array type that accepts a null item writes the unquoted token
(`BaseStringArray`, `EnumArray`, `BaseNetworkTypeArray`), and the scalar `Jsonb`
type has mapped a PHP `null` to SQL NULL since its first commit.

Round-tripping is unaffected and always was: `[null]` reads back as `[null]`
whichever form is stored, because the read path maps both to PHP `null`. Rows
written by v3.5.0 through v4.7.0 stay readable - the read path is untouched.

What changes is element-level SQL against rows written from here on:
`jsonb_typeof(elem) = 'null'` no longer matches (it returns SQL NULL for a NULL
element), `elem IS NULL` now matches where it previously did not, and
`array_position`/`ANY` comparisons against `'null'::jsonb` stop finding those
items. A column written across the upgrade boundary holds both encodings.

The trade-off is that a JSON `null` is not writable from PHP through these
types, which matches the scalar `Jsonb` type - it can only ever write SQL NULL,
because `convertToDatabaseValue` short-circuits on null before the encoder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Null items in JSON and JSONB arrays are now stored as SQL `NULL` elements instead of JSON `null`.
  - Existing JSON `null` values remain compatible and continue to convert back to PHP `null`.

- **Tests**
  - Added coverage for storing, retrieving, and round-tripping null elements in JSON and JSONB arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->