### PR TITLE
fix: let a variadic function fall back to its next node mapping pattern

### DIFF
--- a/fixtures/MartinGeorgiev/Doctrine/Function/TestPatternFallbackFunction.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Function/TestPatternFallbackFunction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\MartinGeorgiev\Doctrine\Function;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * Two same-length patterns that diverge on the second argument's type,
+ * so the first pattern only fails once it is already parsing that later argument.
+ */
+class TestPatternFallbackFunction extends BaseVariadicFunction
+{
+    protected function getFunctionName(): string
+    {
+        return 'test_pattern_fallback';
+    }
+
+    protected function getNodeMappingPattern(): array
+    {
+        return [
+            'StringPrimary,StringPrimary',
+            'ArithmeticPrimary,ArithmeticPrimary',
+        ];
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 2;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 2;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
@@ -50,20 +50,26 @@ abstract class BaseVariadicFunction extends BaseFunction
             }
         }
 
+        $lastParserException = null;
         foreach ($patterns as $pattern) {
             try {
                 $this->feedParserWithNodesForNodeMappingPattern($parser, $pattern);
 
-                break;
-            } catch (ParserException) {
-                // swallow and continue with next pattern
+                return;
+            } catch (ParserException $parserException) {
+                $lastParserException = $parserException;
             }
+        }
+
+        // Without this the nodes stay empty and getSql() silently emits broken SQL.
+        if ($lastParserException instanceof ParserException) {
+            throw $lastParserException;
         }
     }
 
     /**
-     * Peeks at tokens ahead of parsing to select the correct pattern when multiple
-     * patterns share the same prefix but diverge on argument types.
+     * Peeks at tokens ahead of parsing to select the correct pattern when multiple patterns share the same prefix
+     * but diverge on argument types.
      *
      * @param array<string> $patterns
      */
@@ -188,6 +194,8 @@ abstract class BaseVariadicFunction extends BaseFunction
     {
         $nodeMapping = \explode(',', $nodeMappingPattern);
         $lexer = $parser->getLexer();
+        $shouldUseLexer = DoctrineOrm::isPre219();
+        $closeParenthesisType = $shouldUseLexer ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS;
 
         try {
             $lookaheadType = DoctrineLexer::getLookaheadType($lexer);
@@ -195,17 +203,19 @@ abstract class BaseVariadicFunction extends BaseFunction
                 throw InvalidArgumentForVariadicFunctionException::atLeast($this->getFunctionName(), $this->getMinArgumentCount());
             }
 
-            $this->nodes[] = $parser->{$nodeMapping[0]}(); // @phpstan-ignore-line
+            // Parsing a phantom first argument here is what used to make zero-argument functions work by accident.
+            if ($lookaheadType !== $closeParenthesisType) {
+                $this->nodes[] = $parser->{$nodeMapping[0]}(); // @phpstan-ignore-line
+            }
         } catch (\Throwable $throwable) {
             throw ParserException::withThrowable($throwable);
         }
 
-        $shouldUseLexer = DoctrineOrm::isPre219();
         $isNodeMappingASimplePattern = \count($nodeMapping) === 1;
         $nodeIndex = 1;
         // The read above happened before the first argument was parsed, so it still names that argument's own token.
         $lookaheadType = DoctrineLexer::getLookaheadType($lexer);
-        while (($shouldUseLexer ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS) !== $lookaheadType) {
+        while ($closeParenthesisType !== $lookaheadType) {
             if (($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA) === $lookaheadType) {
                 $parser->match($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA);
 
@@ -232,7 +242,12 @@ abstract class BaseVariadicFunction extends BaseFunction
                     );
                 }
 
-                $this->nodes[] = $parser->{$nodeMapping[$expectedNodeIndex]}(); // @phpstan-ignore-line
+                try {
+                    $this->nodes[] = $parser->{$nodeMapping[$expectedNodeIndex]}(); // @phpstan-ignore-line
+                } catch (\Throwable $throwable) {
+                    throw ParserException::withThrowable($throwable);
+                }
+
                 $nodeIndex++;
             } else {
                 // Nothing above consumed a token, so re-reading the lookahead would return this one forever.

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionPatternFallbackTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionPatternFallbackTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts;
+use Fixtures\MartinGeorgiev\Doctrine\Function\TestPatternFallbackFunction;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\ParserException;
+use PHPUnit\Framework\Attributes\Test;
+
+final class BaseVariadicFunctionPatternFallbackTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'TEST_PATTERN_FALLBACK' => TestPatternFallbackFunction::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'falls back to the next pattern once the first pattern fails on the second argument' => 'SELECT test_pattern_fallback(c0_.text1, 1) AS sclr_0 FROM ContainsTexts c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'falls back to the next pattern once the first pattern fails on the second argument' => \sprintf('SELECT TEST_PATTERN_FALLBACK(e.text1, TRUE) FROM %s e', ContainsTexts::class),
+        ];
+    }
+
+    #[Test]
+    public function throws_parser_exception_when_no_pattern_can_parse_the_argument_list(): void
+    {
+        $this->expectException(ParserException::class);
+
+        $dql = \sprintf('SELECT TEST_PATTERN_FALLBACK(NULL, NULL) FROM %s e', ContainsTexts::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/RegexpMatchTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/RegexpMatchTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\QueryException;
 use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\ParserException;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\RegexpMatch;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -53,7 +53,8 @@ final class RegexpMatchTest extends BaseVariadicFunctionTestCase
     #[Test]
     public function throws_exception_for_argument_list_without_separators(): void
     {
-        $this->expectException(QueryException::class);
+        $this->expectException(ParserException::class);
+        $this->expectExceptionMessage('Cannot parse the argument list of regexp_match()');
 
         $dql = \sprintf('SELECT REGEXP_MATCH(e.text1 e.text2) FROM %s e', ContainsTexts::class);
         $this->buildEntityManager()->createQuery($dql)->getSQL();


### PR DESCRIPTION
Errors while parsing a variadic function's 2nd argument onward escaped raw instead of being wrapped as ParserException, so a shorter or differently-typed fallback pattern was never tried. Separately, when every pattern failed, the loop returned silently instead of surfacing the last parse failure, leaving getSql() to emit broken SQL or letting a confusing downstream Doctrine syntax error surface instead.

Wrap every node-mapping-pattern argument parse (not just the first) in the same ParserException translation, and rethrow the last ParserException when no pattern succeeds.

Guard the first-argument parse against an empty argument list so zero-argument functions (PI(), RANDOM(), ...) are not affected — they previously relied on that same silent-swallow bug to skip a phantom first-argument parse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing for variadic functions with multiple argument patterns, ensuring valid alternatives are selected correctly.
  * Empty argument lists are now handled without attempting to parse nonexistent arguments.
  * Invalid or unsupported argument lists now produce a clear parser error instead of silently generating incomplete SQL.
  * Improved error reporting for malformed `regexp_match()` argument lists.

* **Tests**
  * Added coverage for pattern fallback, unsupported arguments, and malformed argument lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->