### PR TITLE
fix: read SQL NULL element in a `bool[]` column as `null` instead of `true` in PHP

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArray.php
@@ -6,6 +6,7 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
 
 /**
  * Implementation of PostgreSQL BOOL[] data type.
@@ -35,6 +36,28 @@ class BooleanArray extends BaseArray
         return parent::convertToDatabaseValue($phpArray, $platform);
     }
 
+    protected function transformArrayItemForPostgres(mixed $item): string
+    {
+        if ($item === null) {
+            return 'NULL';
+        }
+
+        \assert(\is_scalar($item));
+
+        return (string) $item;
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    protected function transformPostgresArrayToPHPArray(string $postgresArray): array
+    {
+        return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray(
+            $postgresArray,
+            preserveStringTypes: true
+        );
+    }
+
     public function convertToPHPValue($postgresArray, AbstractPlatform $platform): ?array
     {
         $phpArray = parent::convertToPHPValue($postgresArray, $platform);
@@ -42,6 +65,9 @@ class BooleanArray extends BaseArray
             return null;
         }
 
-        return \array_map($platform->convertFromBoolean(...), $phpArray);
+        return \array_map(
+            static fn (mixed $item): ?bool => $item === null ? null : $platform->convertFromBoolean($item),
+            $phpArray
+        );
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArrayTypeTest.php
@@ -12,7 +12,7 @@ final class BooleanArrayTypeTest extends ArrayTypeTestCase
     }
 
     /**
-     * @return array<string, array{array<int, bool>}>
+     * @return array<string, array{array<int, bool|null>}>
      */
     public static function provideValidTransformations(): array
     {
@@ -21,6 +21,8 @@ final class BooleanArrayTypeTest extends ArrayTypeTestCase
             'boolean array with all true' => [[true, true, true]],
             'boolean array with all false' => [[false, false, false]],
             'boolean array mixed' => [[true, false, true, false, true]],
+            'boolean array with a null element' => [[true, null, false]],
+            'boolean array of only null elements' => [[null, null]],
             'empty boolean array' => [[]],
         ];
     }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BooleanArrayTest.php
@@ -4,25 +4,21 @@ declare(strict_types=1);
 
 namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
-use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use MartinGeorgiev\Doctrine\DBAL\Types\BooleanArray;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class BooleanArrayTest extends TestCase
 {
-    /**
-     * @var AbstractPlatform&MockObject
-     */
-    private MockObject $platform;
+    private PostgreSQLPlatform $platform;
 
     private BooleanArray $fixture;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = new PostgreSQLPlatform();
 
         $this->fixture = new BooleanArray();
     }
@@ -35,31 +31,22 @@ final class BooleanArrayTest extends TestCase
 
     #[DataProvider('provideValidTransformations')]
     #[Test]
-    public function converts_to_database_value(?array $phpValue, ?string $postgresValue, ?array $platformValue): void
+    public function converts_to_database_value(?array $phpValue, ?string $postgresValue): void
     {
-        $this->platform->method('convertBooleansToDatabaseValue')
-            ->with($phpValue)
-            ->willReturn($platformValue);
-
         $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
     }
 
     #[DataProvider('provideValidTransformations')]
     #[Test]
-    public function converts_to_php_value(?array $phpValue, ?string $postgresValue, ?array $platformValue = null): void
+    public function converts_to_php_value(?array $phpValue, ?string $postgresValue): void
     {
-        $this->platform->method('convertFromBoolean')
-            ->with($this->anything())
-            ->willReturnCallback('boolval');
-
         $this->assertSame($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
     }
 
     /**
      * @return array<string, array{
      *     phpValue: array|null,
-     *     postgresValue: string|null,
-     *     platformValue: array|null
+     *     postgresValue: string|null
      * }>
      */
     public static function provideValidTransformations(): array
@@ -68,18 +55,43 @@ final class BooleanArrayTest extends TestCase
             'null' => [
                 'phpValue' => null,
                 'postgresValue' => null,
-                'platformValue' => null,
             ],
             'empty array' => [
                 'phpValue' => [],
                 'postgresValue' => '{}',
-                'platformValue' => [],
             ],
             'mixed boolean array' => [
                 'phpValue' => [true, false, true],
                 'postgresValue' => '{1,0,1}',
-                'platformValue' => ['1', '0', '1'],
             ],
+            'array with a null element' => [
+                'phpValue' => [true, null, false],
+                'postgresValue' => '{1,NULL,0}',
+            ],
+            'array of only a null element' => [
+                'phpValue' => [null],
+                'postgresValue' => '{NULL}',
+            ],
+        ];
+    }
+
+    #[DataProvider('providePostgresWrittenValues')]
+    #[Test]
+    public function converts_postgres_written_value_to_php_value(string $postgresValue, array $expectedResult): void
+    {
+        $this->assertSame($expectedResult, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{postgresValue: string, expectedResult: array<int, bool|null>}>
+     */
+    public static function providePostgresWrittenValues(): array
+    {
+        return [
+            'unquoted items' => ['postgresValue' => '{t,f}', 'expectedResult' => [true, false]],
+            'quoted items' => ['postgresValue' => '{"t","f"}', 'expectedResult' => [true, false]],
+            'null element among values' => ['postgresValue' => '{t,f,NULL}', 'expectedResult' => [true, false, null]],
+            'only a null element' => ['postgresValue' => '{NULL}', 'expectedResult' => [null]],
         ];
     }
 


### PR DESCRIPTION
BooleanArray inherited BaseArray's naive explode-based parser, so a SQL NULL element arrived as the string 'NULL' and `PostgreSQLPlatform::convertFromBoolean` returned true for it - PostgreSQL emits `{t,f,NULL}` for a `bool[]` holding a null, and the library read that as `[true, false, true]`. Quoted elements were mishandled for the same reason: `{"t","f"}` read as `[true, true]`.

Writing was broken too. convertBooleansToDatabaseValue maps a null item to null, which then hit BaseArray's scalar assertion, so any array containing a null threw an `AssertionError` instead of producing `{1,NULL,0}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Boolean arrays now correctly support `null` elements when stored and retrieved.
  - Boolean and `null` values are preserved when converting between PostgreSQL and PHP.
  - PostgreSQL array values in quoted, unquoted, and mixed formats are handled consistently.

- **Tests**
  - Added coverage for nullable boolean arrays and PostgreSQL array representations to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->