### PR TITLE
fix: tighten `inet`, `cidr` and `ltree` validators (and their array counter-parts) to match PostgreSQL

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/NetworkAddressValidationTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/NetworkAddressValidationTrait.php
@@ -56,13 +56,15 @@ trait NetworkAddressValidationTrait
 
     private function hasValidCidrFormat(string $value): bool
     {
-        if (!\str_contains($value, '/')) {
+        if (\substr_count($value, '/') !== 1) {
             return false;
         }
 
-        [$ip, $netmask] = \explode('/', $value);
+        [, $netmask] = \explode('/', $value);
 
-        return \is_numeric($netmask);
+        // PostgreSQL's netmask is a plain non-negative integer: no sign, decimal point,
+        // exponent, or surrounding whitespace.
+        return \preg_match('/^\d+\z/', $netmask) === 1;
     }
 
     private function isValidIpv4Netmask(int $netmask): bool

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Ltree.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Ltree.php
@@ -16,10 +16,21 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidLtreeExcept
 class Ltree implements \Stringable, \JsonSerializable
 {
     /**
+     * Accepts Unicode letters and digits (categories L*, Nd, Nl) plus underscore and hyphen, up to 1000 characters.
+     * Symbol-like numerics (category No: superscripts, fractions, circled digits) are excluded.
+     *
+     * PostgreSQL classifies label characters through the server's LC_CTYPE, so a server running the C locale
+     * rejects non-ASCII labels this accepts. Narrowing to ASCII would reject labels every Unicode-aware server
+     * takes, so the permissive end is deliberate.
+     *
+     * @var string
+     */
+    private const LABEL_REGEX = '/^[\p{L}\p{Nd}\p{Nl}_-]{1,1000}\z/u';
+
+    /**
      * @param list<non-empty-string> $pathFromRoot A list with one element represents the root. The list may be empty.
      *
-     * @throws InvalidLtreeException if the pathFromRoot is not a valid ltree path
-     *                               (contains labels which are empty or contains one or more dots)
+     * @throws InvalidLtreeException
      */
     public function __construct(
         private readonly array $pathFromRoot,
@@ -82,9 +93,6 @@ class Ltree implements \Stringable, \JsonSerializable
         return [] === $this->pathFromRoot;
     }
 
-    /**
-     * Checks if the ltree has only one node.
-     */
     public function isRoot(): bool
     {
         return 1 === \count($this->pathFromRoot);
@@ -148,11 +156,9 @@ class Ltree implements \Stringable, \JsonSerializable
     }
 
     /**
-     * Creates a new Ltree instance with the given leaf added to the end of the path.
-     *
      * @param non-empty-string $leaf
      *
-     * @throws InvalidLtreeException if the leaf format is invalid (empty string, contains dots, ...)
+     * @throws InvalidLtreeException if the leaf format is invalid
      */
     public function withLeaf(string $leaf): static
     {
@@ -194,6 +200,10 @@ class Ltree implements \Stringable, \JsonSerializable
 
         if (\str_contains($value, '.')) {
             throw InvalidLtreeException::forInvalidNodeFormat($value, 'string without dot');
+        }
+
+        if (\preg_match(self::LABEL_REGEX, $value) !== 1) {
+            throw InvalidLtreeException::forInvalidNodeFormat($value, 'string of letters, digits, underscores and hyphens (max 1000 characters)');
         }
     }
 

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Ltree.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Ltree.php
@@ -19,9 +19,8 @@ class Ltree implements \Stringable, \JsonSerializable
      * Accepts Unicode letters and digits (categories L*, Nd, Nl) plus underscore and hyphen, up to 1000 characters.
      * Symbol-like numerics (category No: superscripts, fractions, circled digits) are excluded.
      *
-     * PostgreSQL classifies label characters through the server's LC_CTYPE, so a server running the C locale
-     * rejects non-ASCII labels this accepts. Narrowing to ASCII would reject labels every Unicode-aware server
-     * takes, so the permissive end is deliberate.
+     * PostgreSQL classifies label characters through the server's LC_CTYPE. A server with the C locale rejects non-ASCII labels.
+     * Narrowing to ASCII would reject labels every Unicode-aware server takes, so the permissive end is deliberate.
      *
      * @var string
      */

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CidrTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CidrTypeTest.php
@@ -40,14 +40,27 @@ final class CidrTypeTest extends ScalarTypeTestCase
         ];
     }
 
+    #[DataProvider('provideInvalidValues')]
     #[Test]
-    public function rejects_invalid_network(): void
+    public function rejects_invalid_network(string $value): void
     {
         $this->expectException(InvalidCidrForPHPException::class);
 
         $typeName = $this->getTypeName();
         $columnType = $this->getPostgresTypeName();
 
-        $this->runDbalBindingRoundTrip($typeName, $columnType, 'invalid-network');
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $value);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidValues(): array
+    {
+        return [
+            'invalid network format' => ['invalid-network'],
+            'triple segment CIDR' => ['192.168.1.0/24/24'],
+            'decimal netmask' => ['192.168.1.0/24.5'],
+        ];
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/InetTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/InetTypeTest.php
@@ -40,6 +40,28 @@ final class InetTypeTest extends ScalarTypeTestCase
         ];
     }
 
+    /**
+     * PostgreSQL's inet output suppresses a "trivial" all-ones netmask (/32 for IPv4, /128 for IPv6).
+     * These are accepted on input but not echoed back, unlike a non-trivial netmask.
+     */
+    #[Test]
+    public function roundtrips_ipv6_with_full_length_cidr_without_the_trivial_netmask(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTripExpectingDifferentRetrievedValue($typeName, $columnType, '::1/128', '::1');
+    }
+
+    #[Test]
+    public function roundtrips_ipv4_mapped_ipv6_with_full_length_cidr_without_the_trivial_netmask(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTripExpectingDifferentRetrievedValue($typeName, $columnType, '::ffff:192.168.1.1/128', '::ffff:192.168.1.1');
+    }
+
     #[DataProvider('provideInvalidValues')]
     #[Test]
     public function rejects_invalid_value(string $value): void
@@ -60,6 +82,8 @@ final class InetTypeTest extends ScalarTypeTestCase
         return [
             'invalid address format' => ['invalid-address'],
             'empty string' => [''],
+            'triple segment CIDR' => ['1.2.3.4/24/24'],
+            'decimal netmask' => ['1.2.3.4/24.5'],
         ];
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LtreeTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LtreeTypeTest.php
@@ -79,6 +79,7 @@ final class LtreeTypeTest extends TestCase
             'ltree simple numeric' => [new LtreeValueObject(['1', '2', '3'])],
             'ltree single numeric' => [new LtreeValueObject(['1'])],
             'ltree empty' => [new LtreeValueObject([])],
+            'ltree unicode labels' => [new LtreeValueObject(['café', '日本語', 'ü'])],
         ];
     }
 
@@ -102,6 +103,7 @@ final class LtreeTypeTest extends TestCase
         return [
             'consecutive dots produce an empty label' => ['root..child'],
             'non-string value' => [42],
+            'label contains a space' => ['root.child branch'],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CidrArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CidrArrayTest.php
@@ -107,6 +107,7 @@ final class CidrArrayTest extends TestCase
             'valid value mixed with integer array item' => [['192.168.1.0/24', 123]],
             'valid value mixed with boolean array item' => [['192.168.1.0/24', true]],
             'valid value mixed with object array item' => [['192.168.1.0/24', new \stdClass()]],
+            'triple segment CIDR' => [['192.168.1.0/24/24']],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CidrTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CidrTest.php
@@ -121,6 +121,13 @@ final class CidrTest extends TestCase
             'IPv6 invalid netmask high' => ['2001:db8::/129'],
             'CIDR without netmask' => ['192.168.0.0/'],
             'CIDR with non-numeric netmask' => ['192.168.0.0/xyz'],
+            'triple segment IPv4 CIDR' => ['192.168.0.0/24/24'],
+            'triple segment IPv6 CIDR' => ['2001:db8::/32/32'],
+            'decimal netmask' => ['192.168.0.0/24.5'],
+            'signed netmask' => ['192.168.0.0/+24'],
+            'scientific notation netmask' => ['192.168.0.0/1e1'],
+            'netmask with leading space' => ['192.168.0.0/ 24'],
+            'netmask with trailing space' => ['192.168.0.0/24 '],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/InetArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/InetArrayTest.php
@@ -129,6 +129,7 @@ final class InetArrayTest extends TestCase
             'malformed CIDR with spaces' => [['192.168.1.0 / 24']],
             'IPv6 with invalid segment count' => [['2001:db8:1:2:3:4:5:6:7']],
             'IPv6 with invalid segment length' => [['2001:db8:xyz:1:1:1:1:1']],
+            'triple segment CIDR' => [['192.168.1.0/24/24']],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/InetTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/InetTest.php
@@ -98,6 +98,14 @@ final class InetTest extends TestCase
                 'phpValue' => '::ffff:192.168.1.1',
                 'postgresValue' => '::ffff:192.168.1.1',
             ],
+            'IPv4-mapped IPv6 with CIDR' => [
+                'phpValue' => '::ffff:192.168.1.1/128',
+                'postgresValue' => '::ffff:192.168.1.1/128',
+            ],
+            'IPv6 loopback with full-width CIDR' => [
+                'phpValue' => '::1/128',
+                'postgresValue' => '::1/128',
+            ],
         ];
     }
 
@@ -133,6 +141,13 @@ final class InetTest extends TestCase
             'array input' => [['not', 'ip']],
             'boolean input' => [true],
             'object input' => [new \stdClass()],
+            'triple segment IPv4 CIDR' => ['1.2.3.4/24/24'],
+            'triple segment IPv6 CIDR' => ['::ffff:1.2.3.4/24/24'],
+            'decimal netmask' => ['1.2.3.4/24.5'],
+            'signed netmask' => ['1.2.3.4/+24'],
+            'scientific notation netmask' => ['1.2.3.4/1e1'],
+            'netmask with leading space' => ['1.2.3.4/ 24'],
+            'netmask with trailing space' => ['1.2.3.4/24 '],
         ];
     }
 
@@ -167,6 +182,13 @@ final class InetTest extends TestCase
             'array input' => [['not', 'ip']],
             'boolean input' => [false],
             'object input' => [new \stdClass()],
+            'triple segment IPv4 CIDR' => ['1.2.3.4/24/24'],
+            'triple segment IPv6 CIDR' => ['::ffff:1.2.3.4/24/24'],
+            'decimal netmask' => ['1.2.3.4/24.5'],
+            'signed netmask' => ['1.2.3.4/+24'],
+            'scientific notation netmask' => ['1.2.3.4/1e1'],
+            'netmask with leading space' => ['1.2.3.4/ 24'],
+            'netmask with trailing space' => ['1.2.3.4/24 '],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LtreeArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LtreeArrayTest.php
@@ -149,6 +149,7 @@ final class LtreeArrayTest extends TestCase
         return [
             'empty label in array' => ['{foo..bar}'],
             'leading dot in array' => ['{.foo}'],
+            'label with space in array' => ['{foo bar}'],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/LtreeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/LtreeTest.php
@@ -40,6 +40,10 @@ final class LtreeTest extends TestCase
         yield 'list with object' => [['a', new \stdClass(), 'c']];
         yield 'list with null' => [['a', null, 'c']];
         yield 'list with dotted string' => [['a', 'b.c', 'ds']];
+        yield 'list with space in label' => [['a', 'b c', 'd']];
+        yield 'list with emoji label' => [['a', '🎉', 'c']];
+        yield 'list with punctuation label' => [['a', 'b,c', 'd']];
+        yield 'list with label exceeding 1000 characters' => [['a', \str_repeat('x', 1001), 'c']];
     }
 
     #[DataProvider('provideInvalidStringRepresentation')]
@@ -106,6 +110,9 @@ final class LtreeTest extends TestCase
         yield 'multiple nodes' => ['a.b.c', ['a', 'b', 'c']];
         yield 'with numbers' => ['1.2.3', ['1', '2', '3']];
         yield 'with special characters' => ['a.b.c-d_e', ['a', 'b', 'c-d_e']];
+        yield 'with unicode letters' => ['café.日本語.ü', ['café', '日本語', 'ü']];
+        yield 'with ASCII label at the 1000 character limit' => [\str_repeat('x', 1000), [\str_repeat('x', 1000)]];
+        yield 'with multibyte label at the 1000 character limit' => [\str_repeat('é', 1000), [\str_repeat('é', 1000)]];
     }
 
     #[Test]
@@ -522,5 +529,8 @@ final class LtreeTest extends TestCase
         yield 'with leaf with dot' => ['a.b'];
         yield 'with leaf starting by dot' => ['.b'];
         yield 'with leaf ending by dot' => ['a.'];
+        yield 'with leaf containing a space' => ['a b'];
+        yield 'with ASCII leaf exceeding 1000 characters' => [\str_repeat('x', 1001)];
+        yield 'with multibyte leaf exceeding 1000 characters' => [\str_repeat('é', 1001)];
     }
 }


### PR DESCRIPTION
NetworkAddressValidationTrait silently dropped a third `/`-segment via list-assignment (`[$ip, $netmask] = explode('/', $value)`), so `1.2.3.4/24/24` validated and was written verbatim, only for PostgreSQL to reject it at insert time. The netmask check also used `is_numeric()`, which accepts decimals, signs, exponents and surrounding whitespace that PostgreSQL's `inet`/`cidr` parser rejects. Both inet and cidr share this trait and are tightened together.

Ltree::assertValidLtreeNode() only checked for a non-empty, dot-free string, so labels like `'a b'` passed PHP validation and then failed at write time with a PostgreSQL ltree syntax error. The allowed character set and the 1000-character length cap were derived empirically against a live PostgreSQL 18 instance (see probes in the accompanying tests): labels accept Unicode letters and digits (categories L*, Nd, Nl — notably excluding symbol-like numerics such as superscripts/fractions/ circled digits, category No) plus underscore and hyphen, up to 1000 characters.

Both changes only reject values PostgreSQL itself already rejects; nothing newly accepted was added, so the round-trip these types support is unchanged for every currently-valid value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CIDR values now reject multiple separators and non-integer, signed, decimal, scientific-notation, or whitespace-padded netmasks.
  * Ltree labels now enforce PostgreSQL-compatible characters and a 1,000-character limit, including Unicode content.
  * Improved handling of full-length IPv4 and IPv6 CIDR values during database round trips.

* **Tests**
  * Expanded coverage for invalid CIDR formats, netmasks, arrays, Unicode ltree labels, invalid characters, and maximum label lengths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->