### PR TITLE
fix: pass NULL through variadic functions instead of crashing with a TypeError

### DIFF
--- a/fixtures/MartinGeorgiev/Doctrine/Function/TestNewValueArgumentFunction.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Function/TestNewValueArgumentFunction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\MartinGeorgiev\Doctrine\Function;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * A NewValue-mapped argument, used to exercise BaseVariadicFunction with a literal NULL —
+ * NewValue() is the only parser method it calls that returns PHP null instead of a Node.
+ */
+class TestNewValueArgumentFunction extends BaseVariadicFunction
+{
+    protected function getNodeMappingPattern(): array
+    {
+        return ['StringPrimary,NewValue'];
+    }
+
+    protected function getFunctionName(): string
+    {
+        return 'test_new_value_argument';
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 2;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 2;
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\ParserException;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\NullLiteral;
 use MartinGeorgiev\Utils\DoctrineLexer;
 use MartinGeorgiev\Utils\DoctrineOrm;
 
@@ -205,7 +206,7 @@ abstract class BaseVariadicFunction extends BaseFunction
 
             // Parsing a phantom first argument here is what used to make zero-argument functions work by accident.
             if ($lookaheadType !== $closeParenthesisType) {
-                $this->nodes[] = $parser->{$nodeMapping[0]}(); // @phpstan-ignore-line
+                $this->nodes[] = $this->parseArgumentNode($parser, $nodeMapping[0]);
             }
         } catch (\Throwable $throwable) {
             throw ParserException::withThrowable($throwable);
@@ -243,7 +244,7 @@ abstract class BaseVariadicFunction extends BaseFunction
                 }
 
                 try {
-                    $this->nodes[] = $parser->{$nodeMapping[$expectedNodeIndex]}(); // @phpstan-ignore-line
+                    $this->nodes[] = $this->parseArgumentNode($parser, $nodeMapping[$expectedNodeIndex]);
                 } catch (\Throwable $throwable) {
                     throw ParserException::withThrowable($throwable);
                 }
@@ -260,6 +261,16 @@ abstract class BaseVariadicFunction extends BaseFunction
 
         // Final validation ensures all arguments meet requirements, including any special rules in subclass implementations
         $this->validateArguments(...$this->nodes); // @phpstan-ignore-line
+    }
+
+    /**
+     * NewValue() returns PHP null rather than a Node for a literal NULL, which validateArguments(Node ...) cannot take.
+     */
+    private function parseArgumentNode(Parser $parser, string $parserMethod): Node
+    {
+        $node = $parser->{$parserMethod}(); // @phpstan-ignore-line
+
+        return $node ?? new NullLiteral(); // @phpstan-ignore-line
     }
 
     /**

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/NullLiteral.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/NullLiteral.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST;
+
+use Doctrine\ORM\Query\AST\Node;
+
+/**
+ * Represents a literal SQL NULL.
+ *
+ * Doctrine's Literal node carries STRING, BOOLEAN and NUMERIC but has no NULL type, and NewValue() returns
+ * PHP null rather than a Node for a literal NULL token. BaseVariadicFunction wraps that result in this node
+ * to keep the argument a Node while still rendering as SQL NULL.
+ *
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+final class NullLiteral extends Node
+{
+    /**
+     * The walker is typed `mixed` because Doctrine ORM 2.14 declares the parameter untyped,
+     * and narrowing it to SqlWalker there would break parameter contravariance.
+     */
+    public function dispatch(mixed $sqlWalker): string
+    {
+        return 'NULL';
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayFillTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayFillTest.php
@@ -28,6 +28,7 @@ final class ArrayFillTest extends TestCase
             'fills array with boolean value using cast' => "SELECT array_fill(cast('true' as BOOLEAN), ARRAY['2']::int[]) AS sclr_0 FROM ContainsArrays c0_",
             'fills multi-dimensional array' => "SELECT array_fill(11, ARRAY['2', '3']::int[]) AS sclr_0 FROM ContainsArrays c0_",
             'fills array with custom lower bounds' => "SELECT array_fill(7, ARRAY['3']::int[], ARRAY['2']::int[]) AS sclr_0 FROM ContainsArrays c0_",
+            'fills array with NULL value' => "SELECT array_fill(NULL, ARRAY['3']::int[]) AS sclr_0 FROM ContainsArrays c0_",
         ];
     }
 
@@ -39,6 +40,7 @@ final class ArrayFillTest extends TestCase
             'fills array with boolean value using cast' => \sprintf("SELECT ARRAY_FILL(CAST('true' AS BOOLEAN), ARRAY('2')) FROM %s e", ContainsArrays::class),
             'fills multi-dimensional array' => \sprintf("SELECT ARRAY_FILL(11, ARRAY('2', '3')) FROM %s e", ContainsArrays::class),
             'fills array with custom lower bounds' => \sprintf("SELECT ARRAY_FILL(7, ARRAY('3'), ARRAY('2')) FROM %s e", ContainsArrays::class),
+            'fills array with NULL value' => \sprintf("SELECT ARRAY_FILL(NULL, ARRAY('3')) FROM %s e", ContainsArrays::class),
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPositionTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/ArrayPositionTest.php
@@ -34,6 +34,8 @@ final class ArrayPositionTest extends BaseVariadicFunctionTestCase
             'with zero start position' => "SELECT array_position(c0_.textArray, 'value', 0) AS sclr_0 FROM ContainsArrays c0_",
             'with negative start position' => "SELECT array_position(c0_.textArray, 'value', -1) AS sclr_0 FROM ContainsArrays c0_",
             'with arithmetic expression as start position' => "SELECT array_position(c0_.textArray, 'value', 1 + 1) AS sclr_0 FROM ContainsArrays c0_",
+            'with NULL element' => 'SELECT array_position(c0_.textArray, NULL) AS sclr_0 FROM ContainsArrays c0_',
+            'with NULL element and start position' => 'SELECT array_position(c0_.textArray, NULL, 2) AS sclr_0 FROM ContainsArrays c0_',
         ];
     }
 
@@ -47,6 +49,8 @@ final class ArrayPositionTest extends BaseVariadicFunctionTestCase
             'with zero start position' => \sprintf("SELECT ARRAY_POSITION(e.textArray, 'value', 0) FROM %s e", ContainsArrays::class),
             'with negative start position' => \sprintf("SELECT ARRAY_POSITION(e.textArray, 'value', -1) FROM %s e", ContainsArrays::class),
             'with arithmetic expression as start position' => \sprintf("SELECT ARRAY_POSITION(e.textArray, 'value', 1+1) FROM %s e", ContainsArrays::class),
+            'with NULL element' => \sprintf('SELECT ARRAY_POSITION(e.textArray, NULL) FROM %s e', ContainsArrays::class),
+            'with NULL element and start position' => \sprintf('SELECT ARRAY_POSITION(e.textArray, NULL, 2) FROM %s e', ContainsArrays::class),
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionNullArgumentTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionNullArgumentTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts;
+use Fixtures\MartinGeorgiev\Doctrine\Function\TestNewValueArgumentFunction;
+
+final class BaseVariadicFunctionNullArgumentTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'TEST_NEW_VALUE_ARGUMENT' => TestNewValueArgumentFunction::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'literal NULL on a NewValue-mapped argument becomes SQL NULL' => 'SELECT test_new_value_argument(c0_.text1, NULL) AS sclr_0 FROM ContainsTexts c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'literal NULL on a NewValue-mapped argument becomes SQL NULL' => \sprintf('SELECT TEST_NEW_VALUE_ARGUMENT(e.text1, NULL) FROM %s e', ContainsTexts::class),
+        ];
+    }
+}


### PR DESCRIPTION
BaseVariadicFunction spread $this->nodes into validateArguments(Node
...$arguments). Doctrine's NewValue() parser method returns PHP null,
not a Node, for a literal NULL token, so a NULL argument on any
NewValue-mapped function (ARRAY_POSITION, ARRAY_FILL) crashed with a
raw TypeError instead of producing SQL. PostgreSQL accepts NULL in
these positions, so wrap the null return in a NullArgumentNode that
renders as SQL NULL.