### PR TITLE
fix: read a null element in geometric/spatial array types instead of silently dropping the whole array

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseGeometricArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseGeometricArray.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
+use MartinGeorgiev\Utils\Exception\InvalidArrayFormatException;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
+
 /**
  * Base class of PostgreSQL geometric array data types.
  *
@@ -29,6 +32,10 @@ abstract class BaseGeometricArray extends BaseArray
 
     protected function transformArrayItemForPostgres(mixed $item): string
     {
+        if ($item === null) {
+            return 'NULL';
+        }
+
         $class = $this->getValueObjectClass();
         if (!$item instanceof $class) {
             $this->throwTypedInvalidItemExceptionForDatabase($item);
@@ -39,16 +46,14 @@ abstract class BaseGeometricArray extends BaseArray
 
     protected function transformPostgresArrayToPHPArray(string $postgresArray): array
     {
-        if (!\str_starts_with($postgresArray, '{"') || !\str_ends_with($postgresArray, '"}')) {
-            return [];
+        try {
+            return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray(
+                $postgresArray,
+                preserveStringTypes: true
+            );
+        } catch (InvalidArrayFormatException) {
+            $this->throwTypedInvalidFormatExceptionForPHP($postgresArray);
         }
-
-        $trimmedPostgresArray = \mb_substr($postgresArray, 2, -2);
-        if ($trimmedPostgresArray === '') {
-            return [];
-        }
-
-        return \explode('","', $trimmedPostgresArray);
     }
 
     public function transformArrayItemForPHP(mixed $item): ?\Stringable
@@ -70,7 +75,7 @@ abstract class BaseGeometricArray extends BaseArray
 
     public function isValidArrayItemForDatabase(mixed $item): bool
     {
-        return $item instanceof ($this->getValueObjectClass());
+        return $item === null || $item instanceof ($this->getValueObjectClass());
     }
 
     protected function throwInvalidTypeException(mixed $value): never

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BoxArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BoxArray.php
@@ -51,6 +51,12 @@ class BoxArray extends BaseGeometricArray
                 $this->throwInvalidItemException($item);
             }
 
+            if ($item === null) {
+                $transformedItems[] = 'NULL';
+
+                continue;
+            }
+
             \assert($item instanceof BoxValueObject);
             $transformedItems[] = $item->__toString();
         }
@@ -65,7 +71,11 @@ class BoxArray extends BaseGeometricArray
             return [];
         }
 
-        return \explode(';', $trimmed);
+        // PostgreSQL never quotes box[] elements because ';' already disambiguates, so a bare NULL is the null marker.
+        return \array_map(
+            static fn (string $item): ?string => $item === 'NULL' ? null : $item,
+            \explode(';', $trimmed)
+        );
     }
 
     protected function throwTypedInvalidArrayTypeException(mixed $value): never

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/SpatialDataArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/SpatialDataArray.php
@@ -9,6 +9,8 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DimensionalModifier;
 use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidWktSpatialDataException;
 use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\GeometryType;
 use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\WktSpatialData;
+use MartinGeorgiev\Utils\Exception\InvalidArrayFormatException;
+use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
 
 /**
  * Base class for PostgreSQL array types containing WKT/EWKT spatial data.
@@ -92,75 +94,29 @@ abstract class SpatialDataArray extends BaseArray
             return [];
         }
 
-        // Handle quoted array format: {"item1","item2","item3"}
-        $isQuotedArray = \str_starts_with($trimmedArray, '{"') && \str_ends_with($trimmedArray, '"}');
-        if ($isQuotedArray) {
-            $arrayContentWithoutBraces = \substr($trimmedArray, 2, -2);
-            if ($arrayContentWithoutBraces === '') {
-                return [];
-            }
-
-            return $this->parseQuotedWktArray($arrayContentWithoutBraces);
-        }
-
-        // Handle unquoted array format: {item1,item2,item3} (fallback for backward compatibility)
         $arrayContentWithoutBraces = \substr($trimmedArray, 1, -1);
         if ($arrayContentWithoutBraces === '') {
             return [];
         }
 
-        return $this->parseUnquotedWktArray($arrayContentWithoutBraces);
-    }
-
-    private function parseQuotedWktArray(string $content): array
-    {
-        $wktItems = [];
-        $currentWktItem = '';
-        $nestedBracketDepth = 0;
-        $contentLength = \strlen($content);
-        $charIndex = 0;
-
-        while ($charIndex < $contentLength) {
-            $currentChar = $content[$charIndex];
-
-            // Track nested parentheses within the quoted WKT
-            if ($currentChar === '(') {
-                $nestedBracketDepth++;
-                $currentWktItem .= $currentChar;
-            } elseif ($currentChar === ')') {
-                $nestedBracketDepth--;
-                $currentWktItem .= $currentChar;
-            } elseif ($currentChar === '"' && $nestedBracketDepth === 0) {
-                // Found end quote at top level - this ends the current item
-                if ($currentWktItem !== '') {
-                    $wktItems[] = $currentWktItem;
-                    $currentWktItem = '';
-                }
-
-                // Skip the quote and comma separator: ","
-                $charIndex++; // Skip the quote
-                if ($charIndex < $contentLength && $content[$charIndex] === ',') {
-                    $charIndex++; // Skip the comma
-                }
-
-                if ($charIndex < $contentLength && $content[$charIndex] === '"') {
-                    $charIndex++; // Skip the opening quote of next item
-                }
-
-                continue;
-            } else {
-                $currentWktItem .= $currentChar;
+        // Every WKT string contains a space, so PostgreSQL always quotes it; content carrying no quote and
+        // no WKT body is a list of bare NULL tokens. Either shape is what the shared transformer expects.
+        $isPostgresEmittedShape = \str_contains($arrayContentWithoutBraces, '"')
+            || !\str_contains($arrayContentWithoutBraces, '(');
+        if ($isPostgresEmittedShape) {
+            try {
+                return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray(
+                    $postgresArray,
+                    preserveStringTypes: true
+                );
+            } catch (InvalidArrayFormatException) {
+                return [];
             }
-
-            $charIndex++;
         }
 
-        // Add the last item if there's content
-        if ($currentWktItem !== '') {
-            $wktItems[] = $currentWktItem;
-        }
-
-        return $wktItems;
+        // Literals this library wrote itself are unquoted, so a WKT body's own commas need
+        // parenthesis-aware splitting that the shared transformer does not do.
+        return $this->parseUnquotedWktArray($arrayContentWithoutBraces);
     }
 
     private function parseUnquotedWktArray(string $content): array

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/BoxArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/BoxArrayTypeTest.php
@@ -16,7 +16,7 @@ final class BoxArrayTypeTest extends ArrayTypeTestCase
     }
 
     /**
-     * @return array<string, array{array<int, BoxValueObject>}>
+     * @return array<string, array{array<int, BoxValueObject|null>}>
      */
     public static function provideValidTransformations(): array
     {
@@ -29,6 +29,10 @@ final class BoxArrayTypeTest extends ArrayTypeTestCase
                 BoxValueObject::fromString('(-1,-2),(-3,-4)'),
             ]],
             'empty box array' => [[]],
+            'box array with null element' => [[
+                BoxValueObject::fromString('(3,4),(1,2)'),
+                null,
+            ]],
         ];
     }
 

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CircleArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CircleArrayTypeTest.php
@@ -16,7 +16,7 @@ final class CircleArrayTypeTest extends ArrayTypeTestCase
     }
 
     /**
-     * @return array<string, array{array<int, CircleValueObject>}>
+     * @return array<string, array{array<int, CircleValueObject|null>}>
      */
     public static function provideValidTransformations(): array
     {
@@ -29,6 +29,10 @@ final class CircleArrayTypeTest extends ArrayTypeTestCase
                 CircleValueObject::fromString('<(-10,-20),5>'),
             ]],
             'empty circle array' => [[]],
+            'circle array with null element' => [[
+                CircleValueObject::fromString('<(0,0),1>'),
+                null,
+            ]],
         ];
     }
 

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/GeographyArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/GeographyArrayTypeTest.php
@@ -25,6 +25,37 @@ final class GeographyArrayTypeTest extends SpatialArrayTypeTestCase
         );
     }
 
+    #[Test]
+    public function roundtrips_null_element(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+        [$tableName, $columnName] = $this->prepareTestTable($columnType);
+
+        try {
+            // This type writes a comma-joined literal, but geography[] is delimited by ':',
+            // so it cannot bind a multi-element array at all (issue #724). Insert directly
+            // via SQL to exercise the read-side fix against PostgreSQL's own literal.
+            $sql = \sprintf(
+                'INSERT INTO %s.%s ("%s") VALUES (ARRAY[ST_GeogFromText(\'POINT(1 2)\'), NULL]::geography[])',
+                self::DATABASE_SCHEMA,
+                $tableName,
+                $columnName
+            );
+            $this->connection->executeStatement($sql);
+
+            $retrieved = $this->fetchConvertedValue($typeName, $tableName, $columnName);
+
+            $this->assertIsArray($retrieved);
+            $this->assertCount(2, $retrieved);
+            $this->assertInstanceOf(WktSpatialData::class, $retrieved[0]);
+            $this->assertSame('SRID=4326;POINT(1 2)', (string) $retrieved[0]);
+            $this->assertNull($retrieved[1]);
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
+    }
+
     #[DataProvider('provideSingleItemArrays')]
     #[Test]
     public function roundtrips_value(array $values): void

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/GeometryArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/GeometryArrayTypeTest.php
@@ -15,6 +15,37 @@ final class GeometryArrayTypeTest extends SpatialArrayTypeTestCase
         return 'geometry[]';
     }
 
+    #[Test]
+    public function roundtrips_null_element(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+        [$tableName, $columnName] = $this->prepareTestTable($columnType);
+
+        try {
+            // This type writes a comma-joined literal, but geometry[] is delimited by ':',
+            // so it cannot bind a multi-element array at all (issue #724). Insert directly
+            // via SQL to exercise the read-side fix against PostgreSQL's own literal.
+            $sql = \sprintf(
+                'INSERT INTO %s.%s ("%s") VALUES (ARRAY[ST_GeomFromText(\'POINT(1 2)\'), NULL]::geometry[])',
+                self::DATABASE_SCHEMA,
+                $tableName,
+                $columnName
+            );
+            $this->connection->executeStatement($sql);
+
+            $retrieved = $this->fetchConvertedValue($typeName, $tableName, $columnName);
+
+            $this->assertIsArray($retrieved);
+            $this->assertCount(2, $retrieved);
+            $this->assertInstanceOf(WktSpatialData::class, $retrieved[0]);
+            $this->assertSame('POINT(1 2)', (string) $retrieved[0]);
+            $this->assertNull($retrieved[1]);
+        } finally {
+            $this->dropTestTableIfItExists($tableName);
+        }
+    }
+
     protected function getSelectExpression(string $columnName): string
     {
         return \sprintf(

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LineArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LineArrayTypeTest.php
@@ -16,7 +16,7 @@ final class LineArrayTypeTest extends ArrayTypeTestCase
     }
 
     /**
-     * @return array<string, array{array<int, LineValueObject>}>
+     * @return array<string, array{array<int, LineValueObject|null>}>
      */
     public static function provideValidTransformations(): array
     {
@@ -29,6 +29,10 @@ final class LineArrayTypeTest extends ArrayTypeTestCase
                 LineValueObject::fromString('{-1,-2,-3}'),
             ]],
             'empty line array' => [[]],
+            'line array with null element' => [[
+                LineValueObject::fromString('{1,0,0}'),
+                null,
+            ]],
         ];
     }
 

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LsegArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/LsegArrayTypeTest.php
@@ -16,7 +16,7 @@ final class LsegArrayTypeTest extends ArrayTypeTestCase
     }
 
     /**
-     * @return array<string, array{array<int, LsegValueObject>}>
+     * @return array<string, array{array<int, LsegValueObject|null>}>
      */
     public static function provideValidTransformations(): array
     {
@@ -29,6 +29,10 @@ final class LsegArrayTypeTest extends ArrayTypeTestCase
                 LsegValueObject::fromString('[(-1,-2),(-3,-4)]'),
             ]],
             'empty lseg array' => [[]],
+            'lseg array with null element' => [[
+                LsegValueObject::fromString('[(0,0),(1,1)]'),
+                null,
+            ]],
         ];
     }
 

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PathArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PathArrayTypeTest.php
@@ -16,7 +16,7 @@ final class PathArrayTypeTest extends ArrayTypeTestCase
     }
 
     /**
-     * @return array<string, array{array<int, PathValueObject>}>
+     * @return array<string, array{array<int, PathValueObject|null>}>
      */
     public static function provideValidTransformations(): array
     {
@@ -29,6 +29,10 @@ final class PathArrayTypeTest extends ArrayTypeTestCase
                 PathValueObject::fromString('((0,0),(1,1),(2,0))'),
             ]],
             'empty path array' => [[]],
+            'path array with null element' => [[
+                PathValueObject::fromString('[(0,0),(1,1),(2,0)]'),
+                null,
+            ]],
         ];
     }
 

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PointArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PointArrayTypeTest.php
@@ -18,7 +18,7 @@ final class PointArrayTypeTest extends ArrayTypeTestCase
     }
 
     /**
-     * @return array<string, array{array<int, PointValueObject>}>
+     * @return array<string, array{array<int, PointValueObject|null>}>
      */
     public static function provideValidTransformations(): array
     {
@@ -40,6 +40,10 @@ final class PointArrayTypeTest extends ArrayTypeTestCase
                 new PointValueObject(-50, -100),
             ]],
             'empty point array' => [[]],
+            'point array with null element' => [[
+                new PointValueObject(1.23, 4.56),
+                null,
+            ]],
         ];
     }
 
@@ -78,6 +82,12 @@ final class PointArrayTypeTest extends ArrayTypeTestCase
         $this->assertCount(\count($expected), $actual, \sprintf('Point array count mismatch for type %s', $typeName));
 
         foreach ($expected as $index => $expectedPoint) {
+            if ($expectedPoint === null) {
+                $this->assertNull($actual[$index], \sprintf('Expected null point at index %d for type %s', $index, $typeName));
+
+                continue;
+            }
+
             if ($expectedPoint instanceof PointValueObject && $actual[$index] instanceof PointValueObject) {
                 $this->assertPointEquals($expectedPoint, $actual[$index], $typeName);
             }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PointAssertionTrait.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PointAssertionTrait.php
@@ -37,7 +37,7 @@ trait PointAssertionTrait
     protected function isPointArray(array $array): bool
     {
         foreach ($array as $item) {
-            if (!$item instanceof PointValueObject) {
+            if ($item !== null && !$item instanceof PointValueObject) {
                 return false;
             }
         }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PolygonArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/PolygonArrayTypeTest.php
@@ -16,7 +16,7 @@ final class PolygonArrayTypeTest extends ArrayTypeTestCase
     }
 
     /**
-     * @return array<string, array{array<int, PolygonValueObject>}>
+     * @return array<string, array{array<int, PolygonValueObject|null>}>
      */
     public static function provideValidTransformations(): array
     {
@@ -29,6 +29,10 @@ final class PolygonArrayTypeTest extends ArrayTypeTestCase
                 PolygonValueObject::fromString('((-1,-2),(-3,-4),(-5,-6))'),
             ]],
             'empty polygon array' => [[]],
+            'polygon array with null element' => [[
+                PolygonValueObject::fromString('((0,0),(1,1),(2,0))'),
+                null,
+            ]],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BoxArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BoxArrayTest.php
@@ -51,7 +51,7 @@ final class BoxArrayTest extends TestCase
 
     /**
      * @return array<string, array{
-     *     phpValue: array<BoxValueObject>|null,
+     *     phpValue: array<BoxValueObject|null>|null,
      *     postgresValue: string|null
      * }>
      */
@@ -77,6 +77,12 @@ final class BoxArrayTest extends TestCase
                     BoxValueObject::fromString('(-1,-2),(-3,-4)'),
                 ],
                 'postgresValue' => '{(1,2),(3,4);(0,0),(1,1);(-1,-2),(-3,-4)}',
+            ],
+            // Box[] uses ';' as its element delimiter and never quotes elements (unlike the
+            // other geometric array types), so the NULL marker sits bare next to a bare box.
+            'array with null element' => [
+                'phpValue' => [BoxValueObject::fromString('(1,2),(3,4)'), null],
+                'postgresValue' => '{(1,2),(3,4);NULL}',
             ],
         ];
     }
@@ -230,6 +236,7 @@ final class BoxArrayTest extends TestCase
             'standard box' => [BoxValueObject::fromString('(1,2),(3,4)')],
             'zero coordinates' => [BoxValueObject::fromString('(0,0),(1,1)')],
             'negative coordinates' => [BoxValueObject::fromString('(-1,-2),(-3,-4)')],
+            'null' => [null],
         ];
     }
 
@@ -249,7 +256,6 @@ final class BoxArrayTest extends TestCase
             'string box format' => ['(1,2),(3,4)'],
             'invalid string' => ['invalid'],
             'integer' => [123],
-            'null' => [null],
             'empty string' => [''],
             'boolean' => [true],
         ];

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CircleArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CircleArrayTest.php
@@ -51,7 +51,7 @@ final class CircleArrayTest extends TestCase
 
     /**
      * @return array<string, array{
-     *     phpValue: array<CircleValueObject>|null,
+     *     phpValue: array<CircleValueObject|null>|null,
      *     postgresValue: string|null
      * }>
      */
@@ -77,6 +77,10 @@ final class CircleArrayTest extends TestCase
                     CircleValueObject::fromString('<(-10,-20),5>'),
                 ],
                 'postgresValue' => '{"<(0,0),1>","<(1.5,2.5),3.5>","<(-10,-20),5>"}',
+            ],
+            'array with null element' => [
+                'phpValue' => [CircleValueObject::fromString('<(0,0),1>'), null],
+                'postgresValue' => '{"<(0,0),1>",NULL}',
             ],
         ];
     }
@@ -152,9 +156,11 @@ final class CircleArrayTest extends TestCase
 
     #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(string $postgresValue): void
+    public function throws_exception_for_malformed_array_literal(string $postgresValue): void
     {
-        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+        $this->expectException(InvalidCircleArrayItemForPHPException::class);
+
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
     }
 
     /**
@@ -163,9 +169,9 @@ final class CircleArrayTest extends TestCase
     public static function provideMalformedInputs(): array
     {
         return [
-            'empty array literal' => ['{}'],
             'unparsable item' => ['{invalid}'],
             'quoted empty item' => ['{""}'],
+            'not an array literal' => ['not-an-array'],
         ];
     }
 
@@ -242,6 +248,7 @@ final class CircleArrayTest extends TestCase
             'standard circle' => [CircleValueObject::fromString('<(0,0),1>')],
             'decimal values' => [CircleValueObject::fromString('<(1.5,2.5),3.5>')],
             'negative coordinates' => [CircleValueObject::fromString('<(-10,-20),5>')],
+            'null' => [null],
         ];
     }
 
@@ -261,7 +268,6 @@ final class CircleArrayTest extends TestCase
             'string circle format' => ['<(0,0),1>'],
             'invalid string' => ['invalid'],
             'integer' => [123],
-            'null' => [null],
             'empty string' => [''],
             'boolean' => [true],
         ];

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/GeographyArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/GeographyArrayTest.php
@@ -148,6 +148,19 @@ final class GeographyArrayTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    #[Test]
+    public function converts_null_element_from_database_to_php_value(): void
+    {
+        // Exact literal PostgreSQL emits for ARRAY(SELECT ST_AsText(...) ...) with a null geography.
+        $result = $this->type->convertToPHPValue('{"SRID=4326;POINT(1 2)",NULL}', $this->platform);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertInstanceOf(WktSpatialData::class, $result[0]);
+        $this->assertSame('SRID=4326;POINT(1 2)', (string) $result[0]);
+        $this->assertNull($result[1]);
+    }
+
     #[DataProvider('provideValidPostgresArraysForPHP')]
     #[Test]
     public function converts_to_php_value(string $postgresArray, array $expectedPHPArray): void

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/GeometryArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/GeometryArrayTest.php
@@ -139,6 +139,19 @@ final class GeometryArrayTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    #[Test]
+    public function converts_null_element_from_database_to_php_value(): void
+    {
+        // Exact literal PostgreSQL emits for ARRAY(SELECT ST_AsText(...) ...) with a null geometry.
+        $result = $this->type->convertToPHPValue('{"POINT(1 2)",NULL}', $this->platform);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertInstanceOf(WktSpatialData::class, $result[0]);
+        $this->assertSame('POINT(1 2)', (string) $result[0]);
+        $this->assertNull($result[1]);
+    }
+
     #[DataProvider('provideValidPostgresArraysForPHP')]
     #[Test]
     public function converts_to_php_value(string $postgresArray, array $expectedPHPArray): void
@@ -242,10 +255,6 @@ final class GeometryArrayTest extends TestCase
             'empty quoted array' => [
                 '{}',
                 [],
-            ],
-            'single empty quoted item' => [
-                '{"POINT(1 2)",""}',
-                ['POINT(1 2)'],
             ],
             // Complex nested structures that test bracket depth tracking
             'complex nested with multiple parentheses' => [
@@ -381,6 +390,26 @@ final class GeometryArrayTest extends TestCase
         $this->type->transformArrayItemForPHP(123);
     }
 
+    #[DataProvider('provideLiteralsWithAnEmptyQuotedItem')]
+    #[Test]
+    public function throws_exception_for_empty_quoted_item(string $postgresValue): void
+    {
+        $this->expectException(InvalidGeometryForPHPException::class);
+
+        $this->type->convertToPHPValue($postgresValue, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideLiteralsWithAnEmptyQuotedItem(): array
+    {
+        return [
+            'only an empty quoted item' => ['{""}'],
+            'empty quoted item beside a valid one' => ['{"POINT(1 2)",""}'],
+        ];
+    }
+
     #[Test]
     public function throws_exception_for_invalid_format_from_database(): void
     {
@@ -438,7 +467,6 @@ final class GeometryArrayTest extends TestCase
     public static function provideMalformedInputs(): array
     {
         return [
-            'quoted empty item' => ['{""}'],
             'whitespace only' => ['  '],
             'lone opening brace' => ['{'],
         ];

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LineArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LineArrayTest.php
@@ -51,7 +51,7 @@ final class LineArrayTest extends TestCase
 
     /**
      * @return array<string, array{
-     *     phpValue: array<LineValueObject>|null,
+     *     phpValue: array<LineValueObject|null>|null,
      *     postgresValue: string|null
      * }>
      */
@@ -77,6 +77,12 @@ final class LineArrayTest extends TestCase
                     LineValueObject::fromString('{-1,-2,-3}'),
                 ],
                 'postgresValue' => '{"{1,0,0}","{1.5,2.5,3.5}","{-1,-2,-3}"}',
+            ],
+            // A Line's own string form contains braces, so this also pins that the array
+            // parser tracks quotes (not brace depth) to find the NULL token that follows.
+            'array with null element' => [
+                'phpValue' => [LineValueObject::fromString('{1,0,0}'), null],
+                'postgresValue' => '{"{1,0,0}",NULL}',
             ],
         ];
     }
@@ -152,9 +158,11 @@ final class LineArrayTest extends TestCase
 
     #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(string $postgresValue): void
+    public function throws_exception_for_malformed_array_literal(string $postgresValue): void
     {
-        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+        $this->expectException(InvalidLineArrayItemForPHPException::class);
+
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
     }
 
     /**
@@ -163,9 +171,9 @@ final class LineArrayTest extends TestCase
     public static function provideMalformedInputs(): array
     {
         return [
-            'empty array literal' => ['{}'],
             'unparsable item' => ['{invalid}'],
             'quoted empty item' => ['{""}'],
+            'not an array literal' => ['not-an-array'],
         ];
     }
 
@@ -242,6 +250,7 @@ final class LineArrayTest extends TestCase
             'standard line' => [LineValueObject::fromString('{1,0,0}')],
             'decimal values' => [LineValueObject::fromString('{1.5,2.5,3.5}')],
             'negative coefficients' => [LineValueObject::fromString('{-1,-2,-3}')],
+            'null' => [null],
         ];
     }
 
@@ -261,7 +270,6 @@ final class LineArrayTest extends TestCase
             'string line format' => ['{1,0,0}'],
             'invalid string' => ['invalid'],
             'integer' => [123],
-            'null' => [null],
             'empty string' => [''],
             'boolean' => [true],
         ];

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LsegArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/LsegArrayTest.php
@@ -51,7 +51,7 @@ final class LsegArrayTest extends TestCase
 
     /**
      * @return array<string, array{
-     *     phpValue: array<LsegValueObject>|null,
+     *     phpValue: array<LsegValueObject|null>|null,
      *     postgresValue: string|null
      * }>
      */
@@ -77,6 +77,10 @@ final class LsegArrayTest extends TestCase
                     LsegValueObject::fromString('[(-1,-2),(-3,-4)]'),
                 ],
                 'postgresValue' => '{"[(0,0),(1,1)]","[(1.5,2.5),(3.5,4.5)]","[(-1,-2),(-3,-4)]"}',
+            ],
+            'array with null element' => [
+                'phpValue' => [LsegValueObject::fromString('[(0,0),(1,1)]'), null],
+                'postgresValue' => '{"[(0,0),(1,1)]",NULL}',
             ],
         ];
     }
@@ -152,9 +156,11 @@ final class LsegArrayTest extends TestCase
 
     #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(string $postgresValue): void
+    public function throws_exception_for_malformed_array_literal(string $postgresValue): void
     {
-        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+        $this->expectException(InvalidLsegArrayItemForPHPException::class);
+
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
     }
 
     /**
@@ -163,9 +169,9 @@ final class LsegArrayTest extends TestCase
     public static function provideMalformedInputs(): array
     {
         return [
-            'empty array literal' => ['{}'],
             'unparsable item' => ['{invalid}'],
             'quoted empty item' => ['{""}'],
+            'not an array literal' => ['not-an-array'],
         ];
     }
 
@@ -242,6 +248,7 @@ final class LsegArrayTest extends TestCase
             'standard lseg' => [LsegValueObject::fromString('[(0,0),(1,1)]')],
             'decimal values' => [LsegValueObject::fromString('[(1.5,2.5),(3.5,4.5)]')],
             'negative coordinates' => [LsegValueObject::fromString('[(-1,-2),(-3,-4)]')],
+            'null' => [null],
         ];
     }
 
@@ -261,7 +268,6 @@ final class LsegArrayTest extends TestCase
             'string lseg format' => ['[(0,0),(1,1)]'],
             'invalid string' => ['invalid'],
             'integer' => [123],
-            'null' => [null],
             'empty string' => [''],
             'boolean' => [true],
         ];

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PathArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PathArrayTest.php
@@ -51,7 +51,7 @@ final class PathArrayTest extends TestCase
 
     /**
      * @return array<string, array{
-     *     phpValue: array<PathValueObject>|null,
+     *     phpValue: array<PathValueObject|null>|null,
      *     postgresValue: string|null
      * }>
      */
@@ -77,6 +77,10 @@ final class PathArrayTest extends TestCase
                     PathValueObject::fromString('[(1.5,2.5),(3.5,4.5)]'),
                 ],
                 'postgresValue' => '{"[(0,0),(1,1)]","((1,2),(3,4))","[(1.5,2.5),(3.5,4.5)]"}',
+            ],
+            'array with null element' => [
+                'phpValue' => [PathValueObject::fromString('[(0,0),(1,1)]'), null],
+                'postgresValue' => '{"[(0,0),(1,1)]",NULL}',
             ],
         ];
     }
@@ -152,9 +156,11 @@ final class PathArrayTest extends TestCase
 
     #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(string $postgresValue): void
+    public function throws_exception_for_malformed_array_literal(string $postgresValue): void
     {
-        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+        $this->expectException(InvalidPathArrayItemForPHPException::class);
+
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
     }
 
     /**
@@ -163,9 +169,9 @@ final class PathArrayTest extends TestCase
     public static function provideMalformedInputs(): array
     {
         return [
-            'empty array literal' => ['{}'],
             'unparsable item' => ['{invalid}'],
             'quoted empty item' => ['{""}'],
+            'not an array literal' => ['not-an-array'],
         ];
     }
 
@@ -242,6 +248,7 @@ final class PathArrayTest extends TestCase
             'open path' => [PathValueObject::fromString('[(0,0),(1,1)]')],
             'closed path' => [PathValueObject::fromString('((1,2),(3,4))')],
             'decimal values' => [PathValueObject::fromString('[(1.5,2.5),(3.5,4.5)]')],
+            'null' => [null],
         ];
     }
 
@@ -261,7 +268,6 @@ final class PathArrayTest extends TestCase
             'string path format' => ['[(0,0),(1,1)]'],
             'invalid string' => ['invalid'],
             'integer' => [123],
-            'null' => [null],
             'empty string' => [''],
             'boolean' => [true],
         ];

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PointArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PointArrayTest.php
@@ -51,7 +51,7 @@ final class PointArrayTest extends TestCase
 
     /**
      * @return array<string, array{
-     *     phpValue: array<Point>|null,
+     *     phpValue: array<Point|null>|null,
      *     postgresValue: string|null
      * }>
      */
@@ -83,6 +83,10 @@ final class PointArrayTest extends TestCase
                     new Point(10.5, -3.7),
                 ],
                 'postgresValue' => '{"(0,0)","(10.5,-3.7)"}',
+            ],
+            'array with null element' => [
+                'phpValue' => [new Point(1.23, 4.56), null],
+                'postgresValue' => '{"(1.23,4.56)",NULL}',
             ],
         ];
     }
@@ -199,9 +203,11 @@ final class PointArrayTest extends TestCase
 
     #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(string $postgresValue): void
+    public function throws_exception_for_malformed_array_literal(string $postgresValue): void
     {
-        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+        $this->expectException(InvalidPointArrayItemForPHPException::class);
+
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
     }
 
     /**
@@ -210,20 +216,18 @@ final class PointArrayTest extends TestCase
     public static function provideMalformedInputs(): array
     {
         return [
-            'empty array literal' => ['{}'],
             'unparsable item' => ['{invalid}'],
             'quoted empty item' => ['{""}'],
+            'not an array literal' => ['not-an-array'],
         ];
     }
 
     #[Test]
-    public function returns_empty_array_for_non_standard_postgres_array_format(): void
+    public function throws_exception_for_non_standard_postgres_array_format(): void
     {
-        $result1 = $this->fixture->convertToPHPValue('[test]', $this->platform);
-        $result2 = $this->fixture->convertToPHPValue('not-an-array', $this->platform);
+        $this->expectException(InvalidPointArrayItemForPHPException::class);
 
-        $this->assertSame([], $result1);
-        $this->assertSame([], $result2);
+        $this->fixture->convertToPHPValue('[test]', $this->platform);
     }
 
     #[Test]
@@ -279,6 +283,7 @@ final class PointArrayTest extends TestCase
             'origin point' => [new Point(0.0, 0.0)],
             'negative coordinates' => [new Point(-7.89, -0.12)],
             'large coordinates' => [new Point(180.0, 90.0)],
+            'null' => [null],
         ];
     }
 
@@ -298,7 +303,6 @@ final class PointArrayTest extends TestCase
             'string point format' => ['(1.23, 4.56)'],
             'invalid string' => ['invalid'],
             'integer' => [123],
-            'null' => [null],
             'empty string' => [''],
             'boolean' => [true],
         ];

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PolygonArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PolygonArrayTest.php
@@ -51,7 +51,7 @@ final class PolygonArrayTest extends TestCase
 
     /**
      * @return array<string, array{
-     *     phpValue: array<PolygonValueObject>|null,
+     *     phpValue: array<PolygonValueObject|null>|null,
      *     postgresValue: string|null
      * }>
      */
@@ -77,6 +77,10 @@ final class PolygonArrayTest extends TestCase
                     PolygonValueObject::fromString('((-1,-2),(-3,-4),(-5,-6))'),
                 ],
                 'postgresValue' => '{"((0,0),(1,1),(2,0))","((1.5,2.5),(3.5,4.5),(5.5,6.5))","((-1,-2),(-3,-4),(-5,-6))"}',
+            ],
+            'array with null element' => [
+                'phpValue' => [PolygonValueObject::fromString('((0,0),(1,1),(2,0))'), null],
+                'postgresValue' => '{"((0,0),(1,1),(2,0))",NULL}',
             ],
         ];
     }
@@ -152,9 +156,11 @@ final class PolygonArrayTest extends TestCase
 
     #[DataProvider('provideMalformedInputs')]
     #[Test]
-    public function returns_empty_array_for_malformed_input(string $postgresValue): void
+    public function throws_exception_for_malformed_array_literal(string $postgresValue): void
     {
-        $this->assertSame([], $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+        $this->expectException(InvalidPolygonArrayItemForPHPException::class);
+
+        $this->fixture->convertToPHPValue($postgresValue, $this->platform);
     }
 
     /**
@@ -163,9 +169,9 @@ final class PolygonArrayTest extends TestCase
     public static function provideMalformedInputs(): array
     {
         return [
-            'empty array literal' => ['{}'],
             'unparsable item' => ['{invalid}'],
             'quoted empty item' => ['{""}'],
+            'not an array literal' => ['not-an-array'],
         ];
     }
 
@@ -242,6 +248,7 @@ final class PolygonArrayTest extends TestCase
             'triangle' => [PolygonValueObject::fromString('((0,0),(1,1),(2,0))')],
             'decimal values' => [PolygonValueObject::fromString('((1.5,2.5),(3.5,4.5),(5.5,6.5))')],
             'negative coordinates' => [PolygonValueObject::fromString('((-1,-2),(-3,-4),(-5,-6))')],
+            'null' => [null],
         ];
     }
 
@@ -261,7 +268,6 @@ final class PolygonArrayTest extends TestCase
             'string polygon format' => ['((0,0),(1,1),(2,0))'],
             'invalid string' => ['invalid'],
             'integer' => [123],
-            'null' => [null],
             'empty string' => [''],
             'boolean' => [true],
         ];


### PR DESCRIPTION
`BaseGeometricArray::transformPostgresArrayToPHPArray()` (point[], circle[],
line[], lseg[], path[], polygon[]) required every array literal to match a
strict `{"..."}` shape. A single NULL element breaks that shape (PostgreSQL
emits e.g. `{"(1,2)",NULL}`), so the whole array silently came back as `[]`.

Two related, louder failures in the same family:
- `BoxArray` parsed its `;`-delimited literal but then tried to construct a
  `Box` from the literal string "NULL", throwing
  `InvalidBoxArrayItemForPHPException`.
- `SpatialDataArray` (geometry[]/geography[]) detected "quoted" vs "unquoted"
  array shape by sniffing the whole string's first/last two characters; a
  trailing bare NULL broke that sniff and routed into the unquoted parser,
  which left the surrounding quotes on the real WKT item and threw
  `InvalidGeometryForPHPException`/`InvalidGeographyForPHPException`.

Replaced the read-side parsing in all three types with scanners that
recognise a bare NULL token alongside quoted/otherwise-valid items, matching
the pattern already used by CubeArray/BaseStringArray.

Also relaxed `BaseGeometricArray`/`BoxArray` write-side validation
(`isValidArrayItemForDatabase`) to accept `null` and emit the unquoted NULL
token, matching `BaseStringArray`/`EnumArray`/`BaseNetworkTypeArray`. This
moves the `'null'` case from each type's `provideInvalidArrayItemsForDatabase`
unit-test provider to `provideValidArrayItemsForDatabase`, since null is now
a valid database-bound item for these value-object array types.

`SpatialDataArray`'s write path is intentionally left unchanged: geometry[]
and geography[] use `:` as their real array element delimiter, not `,`, so
this type's own comma-joined write format cannot represent a real multi-item
array at all (a pre-existing, unrelated limitation) - adding NULL there
would not produce anything usable. Its read path is still fixed and covered
by an integration test that inserts via `ARRAY[...]` SQL directly.

Tests: unit coverage per type reads PostgreSQL's exact literal with a NULL
element (verified against a live PostgreSQL 18 + PostGIS instance); each
affected type also gets an integration round-trip through a real column with
a null element.