### PR TITLE
fix: support `EMPTY` geometries in `WktSpatialData`

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/WktSpatialData.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/WktSpatialData.php
@@ -14,6 +14,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidWktSpatialD
  * - SRID=4326;POINT(-122.4194 37.7749)
  * - LINESTRING(0 0, 1 1)
  * - POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))
+ * - POLYGON EMPTY
  *
  * @since 3.5
  *
@@ -21,10 +22,13 @@ use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\Exceptions\InvalidWktSpatialD
  */
 final readonly class WktSpatialData implements \Stringable
 {
+    /**
+     * Null body means an EMPTY geometry, PostGIS's parenthesis-free form for "no coordinates".
+     */
     private function __construct(
         private ?int $srid,
         private GeometryType $geometryType,
-        private string $wktBody,
+        private ?string $wktBody,
         private ?DimensionalModifier $dimensionalModifier = null
     ) {}
 
@@ -35,7 +39,9 @@ final readonly class WktSpatialData implements \Stringable
             $typeWithModifier .= ' '.$this->dimensionalModifier->value;
         }
 
-        $typeAndBody = $typeWithModifier.'('.$this->wktBody.')';
+        $typeAndBody = $this->wktBody === null
+            ? $typeWithModifier.' EMPTY'
+            : $typeWithModifier.'('.$this->wktBody.')';
         if ($this->srid === null) {
             return $typeAndBody;
         }
@@ -67,16 +73,22 @@ final readonly class WktSpatialData implements \Stringable
             $wkt = \substr($wkt, $sridSeparatorPosition + 1);
         }
 
-        $wktTypeWithOptionalModifiersPattern = '/^([A-Z][A-Z0-9_]*)(?:\s+(ZM|Z|M))?\s*\((.*)\)$/s';
+        $wktTypeWithOptionalModifiersPattern = '/^([A-Z][A-Z0-9_]*)(?:\s+(ZM|Z|M))?(?:\s*\((.*)\)|\s+(EMPTY))$/s';
         if (!\preg_match($wktTypeWithOptionalModifiersPattern, $wkt, $matches)) {
             throw InvalidWktSpatialDataException::forInvalidWktFormat($wkt);
         }
 
         $typeString = $matches[1];
-        $dimensionalModifier = $matches[2] === '' ? null : DimensionalModifier::tryFrom($matches[2]);
-        $body = \trim($matches[3]);
-        if ($body === '') {
-            throw InvalidWktSpatialDataException::forEmptyCoordinateSection();
+        $modifierMatch = $matches[2] ?? '';
+        $dimensionalModifier = $modifierMatch === '' ? null : DimensionalModifier::tryFrom($modifierMatch);
+        $isEmpty = ($matches[4] ?? '') === 'EMPTY';
+        if ($isEmpty) {
+            $body = null;
+        } else {
+            $body = \trim($matches[3] ?? '');
+            if ($body === '') {
+                throw InvalidWktSpatialDataException::forEmptyCoordinateSection();
+            }
         }
 
         $geometryType = GeometryType::tryFrom($typeString);
@@ -161,6 +173,11 @@ final readonly class WktSpatialData implements \Stringable
     public function getDimensionalModifier(): ?DimensionalModifier
     {
         return $this->dimensionalModifier;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->wktBody === null;
     }
 
     public function getWkt(): string

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/GeographyTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/GeographyTypeTest.php
@@ -114,6 +114,10 @@ final class GeographyTypeTest extends TestCase
             'point z' => [WktSpatialData::fromWkt('POINT Z(-122.4194 37.7749 100)')],
             'linestring m' => [WktSpatialData::fromWkt('LINESTRING M(-122.4194 37.7749 1,-122.4094 37.7849 2)')],
             'polygon zm' => [WktSpatialData::fromWkt('POLYGON ZM((-122.5 37.7 0 1,-122.5 37.8 0 1,-122.4 37.8 0 1,-122.4 37.7 0 1,-122.5 37.7 0 1))')],
+            'point empty' => [WktSpatialData::fromWkt('POINT EMPTY')],
+            'polygon empty' => [WktSpatialData::fromWkt('POLYGON EMPTY')],
+            'geometrycollection empty' => [WktSpatialData::fromWkt('GEOMETRYCOLLECTION EMPTY')],
+            'point z empty' => [WktSpatialData::fromWkt('POINT Z EMPTY')],
         ];
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/GeometryTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/GeometryTypeTest.php
@@ -123,6 +123,11 @@ final class GeometryTypeTest extends TestCase
             'linestring m' => [WktSpatialData::fromWkt('LINESTRING M(0 0 1,1 1 2)')],
             'polygon zm' => [WktSpatialData::fromWkt('POLYGON ZM((0 0 0 1,0 1 0 1,1 1 0 1,1 0 0 1,0 0 0 1))')],
             'point z with srid' => [WktSpatialData::fromWkt('SRID=4326;POINT Z(-122.4194 37.7749 100)')],
+            'point empty' => [WktSpatialData::fromWkt('POINT EMPTY')],
+            'polygon empty' => [WktSpatialData::fromWkt('POLYGON EMPTY')],
+            'geometrycollection empty' => [WktSpatialData::fromWkt('GEOMETRYCOLLECTION EMPTY')],
+            'point empty with srid' => [WktSpatialData::fromWkt('SRID=4326;POINT EMPTY')],
+            'point z empty' => [WktSpatialData::fromWkt('POINT Z EMPTY')],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseSpatialTypeTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseSpatialTypeTestCase.php
@@ -184,6 +184,22 @@ abstract class BaseSpatialTypeTestCase extends TestCase
                 'wktSpatialData' => WktSpatialData::fromWkt('SRID=4326;CIRCULARSTRING(0 0, 1 1, 2 0)'),
                 'postgresValue' => 'SRID=4326;CIRCULARSTRING(0 0, 1 1, 2 0)',
             ],
+            'point empty' => [
+                'wktSpatialData' => WktSpatialData::fromWkt('POINT EMPTY'),
+                'postgresValue' => 'POINT EMPTY',
+            ],
+            'polygon empty' => [
+                'wktSpatialData' => WktSpatialData::fromWkt('POLYGON EMPTY'),
+                'postgresValue' => 'POLYGON EMPTY',
+            ],
+            'geometrycollection empty' => [
+                'wktSpatialData' => WktSpatialData::fromWkt('GEOMETRYCOLLECTION EMPTY'),
+                'postgresValue' => 'GEOMETRYCOLLECTION EMPTY',
+            ],
+            'point z empty with srid' => [
+                'wktSpatialData' => WktSpatialData::fromWkt('SRID=4326;POINT Z EMPTY'),
+                'postgresValue' => 'SRID=4326;POINT Z EMPTY',
+            ],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/WktSpatialDataTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/WktSpatialDataTest.php
@@ -62,6 +62,27 @@ final class WktSpatialDataTest extends TestCase
             'circular geometry with srid' => ['SRID=4326;CIRCULARSTRING(0 0, 1 1, 2 0)', 'CIRCULARSTRING', 4326],
             'polygon with holes' => ['POLYGON((0 0, 0 3, 3 3, 3 0, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))', 'POLYGON', null],
             'complex geometrycollection' => ['GEOMETRYCOLLECTION(POINT(1 2), MULTILINESTRING((0 0, 1 1), (2 2, 3 3)), POLYGON((0 0, 0 1, 1 1, 1 0, 0 0)))', 'GEOMETRYCOLLECTION', null],
+            // EMPTY forms, as emitted by ST_AsText() for every geometry type this library supports
+            'point empty' => ['POINT EMPTY', 'POINT', null],
+            'linestring empty' => ['LINESTRING EMPTY', 'LINESTRING', null],
+            'polygon empty' => ['POLYGON EMPTY', 'POLYGON', null],
+            'multipoint empty' => ['MULTIPOINT EMPTY', 'MULTIPOINT', null],
+            'multilinestring empty' => ['MULTILINESTRING EMPTY', 'MULTILINESTRING', null],
+            'multipolygon empty' => ['MULTIPOLYGON EMPTY', 'MULTIPOLYGON', null],
+            'geometrycollection empty' => ['GEOMETRYCOLLECTION EMPTY', 'GEOMETRYCOLLECTION', null],
+            'circularstring empty' => ['CIRCULARSTRING EMPTY', 'CIRCULARSTRING', null],
+            'compoundcurve empty' => ['COMPOUNDCURVE EMPTY', 'COMPOUNDCURVE', null],
+            'curvepolygon empty' => ['CURVEPOLYGON EMPTY', 'CURVEPOLYGON', null],
+            'multicurve empty' => ['MULTICURVE EMPTY', 'MULTICURVE', null],
+            'multisurface empty' => ['MULTISURFACE EMPTY', 'MULTISURFACE', null],
+            'polyhedralsurface empty' => ['POLYHEDRALSURFACE EMPTY', 'POLYHEDRALSURFACE', null],
+            'tin empty' => ['TIN EMPTY', 'TIN', null],
+            'triangle empty' => ['TRIANGLE EMPTY', 'TRIANGLE', null],
+            'point empty with srid' => ['SRID=4326;POINT EMPTY', 'POINT', 4326],
+            'point z empty' => ['POINT Z EMPTY', 'POINT', null],
+            'point m empty' => ['POINT M EMPTY', 'POINT', null],
+            'point zm empty' => ['POINT ZM EMPTY', 'POINT', null],
+            'point z empty with srid' => ['SRID=4326;POINT Z EMPTY', 'POINT', 4326],
         ];
     }
 
@@ -107,6 +128,9 @@ final class WktSpatialDataTest extends TestCase
             // Complex SRID combinations with dimensional modifiers
             'complex geometry with srid and z' => ['SRID=4326;MULTIPOLYGON Z(((0 0 0, 0 1 0, 1 1 0, 1 0 0, 0 0 0)), ((2 2 0, 2 3 0, 3 3 0, 3 2 0, 2 2 0)))', DimensionalModifier::Z],
             'circular geometry with srid and m' => ['SRID=4326;CIRCULARSTRING M(0 0 1, 1 1 2, 2 0 1)', DimensionalModifier::M],
+            'point z empty' => ['POINT Z EMPTY', DimensionalModifier::Z],
+            'point m empty' => ['POINT M EMPTY', DimensionalModifier::M],
+            'point zm empty' => ['POINT ZM EMPTY', DimensionalModifier::ZM],
         ];
     }
 
@@ -131,6 +155,7 @@ final class WktSpatialDataTest extends TestCase
             'invalid format' => ['INVALID_WKT'],
             'unsupported geometry type' => ['UNSUPPORTED(1 2)'],
             'whitespace-only coordinates' => ['POINT(   )'],
+            'missing space before empty' => ['POINTEMPTY'],
         ];
     }
 
@@ -165,6 +190,54 @@ final class WktSpatialDataTest extends TestCase
             'geometrycollection z' => ['GEOMETRYCOLLECTION Z(POINT Z(1 2 3), LINESTRING Z(0 0 1, 1 1 2))'],
             'srid with point z' => ['SRID=4326;POINT Z(-122.4194 37.7749 100)'],
             'srid with polygon zm' => ['SRID=4326;POLYGON ZM((-122.5 37.7 0 1, -122.5 37.8 0 1, -122.4 37.8 0 1, -122.4 37.7 0 1, -122.5 37.7 0 1))'],
+            'point empty' => ['POINT EMPTY'],
+            'polygon empty' => ['POLYGON EMPTY'],
+            'geometrycollection empty' => ['GEOMETRYCOLLECTION EMPTY'],
+            'point z empty' => ['POINT Z EMPTY'],
+            'point zm empty' => ['POINT ZM EMPTY'],
+            'srid with point empty' => ['SRID=4326;POINT EMPTY'],
+            'srid with point z empty' => ['SRID=4326;POINT Z EMPTY'],
+        ];
+    }
+
+    #[DataProvider('provideEmptyWkt')]
+    #[Test]
+    public function is_empty_for_empty_geometries(string $wkt): void
+    {
+        $wktSpatialData = WktSpatialData::fromWkt($wkt);
+
+        $this->assertTrue($wktSpatialData->isEmpty());
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideEmptyWkt(): array
+    {
+        return [
+            'point empty' => ['POINT EMPTY'],
+            'polygon empty' => ['POLYGON EMPTY'],
+            'point z empty with srid' => ['SRID=4326;POINT Z EMPTY'],
+        ];
+    }
+
+    #[DataProvider('provideNonEmptyWkt')]
+    #[Test]
+    public function is_not_empty_for_non_empty_geometries(string $wkt): void
+    {
+        $wktSpatialData = WktSpatialData::fromWkt($wkt);
+
+        $this->assertFalse($wktSpatialData->isEmpty());
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideNonEmptyWkt(): array
+    {
+        return [
+            'point' => ['POINT(1 2)'],
+            'polygon' => ['POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'],
         ];
     }
 


### PR DESCRIPTION
PostGIS emits parenthesis-free EMPTY forms (POLYGON EMPTY, POINT Z EMPTY,
SRID=4326;POINT EMPTY, ...) for every geometry type, but WktSpatialData
required parentheses around the body, so hydrating any row holding an
empty geometry threw InvalidGeometryForDatabaseException.

Represent emptiness with a nullable body (null = EMPTY) instead of a
sentinel string, parse both the parenthesized and EMPTY forms, and
re-emit the exact PostGIS spelling from __toString() so the round-trip
invariant holds. Adds isEmpty() for callers that need to detect
emptiness without string-sniffing; no existing public API changed.