### PR TITLE
fix: escape DQL string literals reaching emitted SQL

### DIFF
--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidCastTypeException;
 use MartinGeorgiev\Utils\DoctrineLexer;
 use MartinGeorgiev\Utils\DoctrineOrm;
 
@@ -49,17 +50,26 @@ class Cast extends FunctionNode
             return;
         }
 
+        // Both the type name and its parameters are interpolated raw into the emitted SQL
+        if (\preg_match('/^[A-Za-z_][A-Za-z0-9_]*\z/', $type) !== 1) {
+            throw InvalidCastTypeException::forInvalidTypeName($type);
+        }
+
         // Handle parameterized types (e.g., DECIMAL(10, 2))
         if ($lexer->isNextToken($shouldUseLexer ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS)) {
             $parser->match($shouldUseLexer ? Lexer::T_OPEN_PARENTHESIS : TokenType::T_OPEN_PARENTHESIS);
             $parameter = $parser->Literal();
             \assert(\is_scalar($parameter->value));
-            $parameters = [(string) $parameter->value];
+            $parameters = [$this->assertTypeParameter($parameter->value)];
             while ($lexer->isNextToken($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA)) {
                 $parser->match($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA);
                 $parameter = $parser->Literal();
                 \assert(\is_scalar($parameter->value));
-                $parameters[] = (string) $parameter->value;
+                $parameters[] = $this->assertTypeParameter($parameter->value);
+            }
+
+            if (\count($parameters) > 2) {
+                throw InvalidCastTypeException::forTooManyTypeParameters(\count($parameters));
             }
 
             $parser->match($shouldUseLexer ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
@@ -84,6 +94,16 @@ class Cast extends FunctionNode
         $this->targetType = $type;
 
         $parser->match($shouldUseLexer ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
+    }
+
+    private function assertTypeParameter(bool|float|int|string $parameter): string
+    {
+        $parameter = (string) $parameter;
+        if (\preg_match('/^\d+\z/', $parameter) !== 1) {
+            throw InvalidCastTypeException::forInvalidTypeParameter($parameter);
+        }
+
+        return $parameter;
     }
 
     public function getSql(SqlWalker $sqlWalker): string

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CompositeField.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CompositeField.php
@@ -52,6 +52,10 @@ class CompositeField extends BaseFunction
             throw InvalidFieldNameException::forNonStringValue('COMPOSITE_FIELD');
         }
 
+        if ($fieldName === '') {
+            throw InvalidFieldNameException::forEmptyValue('COMPOSITE_FIELD');
+        }
+
         $this->fieldName = $fieldName;
 
         $parser->match($shouldUseLexer ? Lexer::T_CLOSE_PARENTHESIS : TokenType::T_CLOSE_PARENTHESIS);
@@ -61,6 +65,6 @@ class CompositeField extends BaseFunction
     {
         $columnSql = $this->compositeColumn->dispatch($sqlWalker);
 
-        return \sprintf('(%s)."%s"', $columnSql, $this->fieldName);
+        return \sprintf('(%s)."%s"', $columnSql, \str_replace('"', '""', $this->fieldName));
     }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Exception/InvalidCastTypeException.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Exception/InvalidCastTypeException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception;
+
+/**
+ * Extends \InvalidArgumentException because this is a malformed-DQL error raised while parsing,
+ * not a per-value conversion failure.
+ *
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidCastTypeException extends \InvalidArgumentException
+{
+    public static function forInvalidTypeName(string $typeName): self
+    {
+        return new self(\sprintf(
+            'CAST() target type must be a plain type name, %s given',
+            \var_export($typeName, true)
+        ));
+    }
+
+    public static function forInvalidTypeParameter(string $parameter): self
+    {
+        return new self(\sprintf(
+            'CAST() target type parameters must be non-negative integers, %s given',
+            \var_export($parameter, true)
+        ));
+    }
+
+    public static function forTooManyTypeParameters(int $count): self
+    {
+        return new self(\sprintf(
+            'CAST() target type accepts at most two parameters, %d given',
+            $count
+        ));
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Exception/InvalidFieldNameException.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Exception/InvalidFieldNameException.php
@@ -18,4 +18,12 @@ class InvalidFieldNameException extends \InvalidArgumentException
             $functionName
         ));
     }
+
+    public static function forEmptyValue(string $functionName): self
+    {
+        return new self(\sprintf(
+            '%s() requires a non-empty string literal as the field name argument',
+            $functionName
+        ));
+    }
 }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Exception/InvalidXmlPiTargetException.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Exception/InvalidXmlPiTargetException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception;
+
+/**
+ * Extends \InvalidArgumentException because this is a malformed-DQL error raised while parsing,
+ * not a per-value conversion failure.
+ *
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidXmlPiTargetException extends \InvalidArgumentException
+{
+    public static function forEmptyTarget(string $functionName): self
+    {
+        return new self(\sprintf(
+            '%s() requires a non-empty string literal as the target argument',
+            $functionName
+        ));
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/XmlPi.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/XmlPi.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidXmlPiTargetException;
 use MartinGeorgiev\Utils\DoctrineLexer;
 use MartinGeorgiev\Utils\DoctrineOrm;
 
@@ -18,11 +19,12 @@ use MartinGeorgiev\Utils\DoctrineOrm;
  * Creates an XML processing instruction.
  *
  * PostgreSQL requires NAME keyword syntax: XMLPI(NAME target [, content])
- * The target must be a string literal in DQL — it becomes an *unquoted* SQL NAME identifier.
+ * The target must be a string literal in DQL — it becomes a quoted SQL NAME identifier,
+ * so its casing is preserved and PostgreSQL escapes any character illegal in an XML name.
  * The optional content can be a literal or entity property.
  *
- * DQL: XMLPI('target')          → SQL: xmlpi(NAME target)
- * DQL: XMLPI('target', content) → SQL: xmlpi(NAME target, content)
+ * DQL: XMLPI('target')          → SQL: xmlpi(NAME "target")
+ * DQL: XMLPI('target', content) → SQL: xmlpi(NAME "target", content)
  *
  * @see https://www.postgresql.org/docs/18/functions-xml.html
  * @since 4.6
@@ -40,7 +42,7 @@ class XmlPi extends BaseFunction
 
     protected function customizeFunction(): void
     {
-        $this->setFunctionPrototype('xmlpi(NAME %s%s)');
+        $this->setFunctionPrototype('xmlpi(NAME "%s"%s)');
     }
 
     public function parse(Parser $parser): void
@@ -56,7 +58,11 @@ class XmlPi extends BaseFunction
         $parser->match($shouldUseLexer ? Lexer::T_STRING : TokenType::T_STRING);
 
         $target = DoctrineLexer::getTokenValue($lexer);
-        $this->target = \is_string($target) ? $target : '';
+        if (!\is_string($target) || $target === '') {
+            throw InvalidXmlPiTargetException::forEmptyTarget('XMLPI');
+        }
+
+        $this->target = $target;
 
         $commaType = $shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA;
         if (DoctrineLexer::getLookaheadType($lexer) === $commaType) {
@@ -73,6 +79,6 @@ class XmlPi extends BaseFunction
             ? ', '.$this->content->dispatch($sqlWalker)
             : '';
 
-        return \vsprintf($this->functionPrototype, [$this->target, $contentSql]);
+        return \vsprintf($this->functionPrototype, [\str_replace('"', '""', $this->target), $contentSql]);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/XmlPiTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/XmlPiTest.php
@@ -28,6 +28,17 @@ final class XmlPiTest extends TextTestCase
     }
 
     #[Test]
+    public function creates_xmlpi_with_hyphenated_target(): void
+    {
+        $dql = "SELECT XMLPI('php-app') as result
+                FROM Fixtures\\MartinGeorgiev\\Doctrine\\Entity\\ContainsTexts t
+                WHERE t.id = 1";
+
+        $result = $this->executeDqlQuery($dql);
+        $this->assertSame('<?php-app?>', $result[0]['result']);
+    }
+
+    #[Test]
     public function creates_xmlpi_with_content_from_literals(): void
     {
         $dql = "SELECT XMLPI('php', 'echo \"hello world\";') as result

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CastTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CastTest.php
@@ -6,6 +6,9 @@ namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 
 use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Cast;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidCastTypeException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 
 final class CastTest extends TestCase
 {
@@ -45,6 +48,29 @@ final class CastTest extends TestCase
             'cast as text array' => \sprintf('SELECT CAST(e.text1 AS TEXT[]) FROM %s e', ContainsTexts::class),
             'cast as boolean array' => \sprintf('SELECT CAST(e.text1 AS BOOLEAN[]) FROM %s e', ContainsTexts::class),
             'cast as decimal array' => \sprintf('SELECT CAST(e.text1 AS DECIMAL(10, 2)[]) FROM %s e', ContainsTexts::class),
+        ];
+    }
+
+    #[DataProvider('provideRejectedTargetTypes')]
+    #[Test]
+    public function throws_exception_for_invalid_target_type(string $targetType): void
+    {
+        $this->expectException(InvalidCastTypeException::class);
+
+        $dql = \sprintf('SELECT CAST(e.text1 AS %s) FROM %s e', $targetType, ContainsTexts::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+
+    /**
+     * @return array<string, array{targetType: string}>
+     */
+    public static function provideRejectedTargetTypes(): array
+    {
+        return [
+            'string parameter smuggling a subquery' => ['targetType' => "NUMERIC('10), (SELECT version()), (1', 2)"],
+            'string parameter smuggling a statement terminator' => ['targetType' => "VARCHAR('255); DROP TABLE containstexts; --')"],
+            'non-numeric parameter' => ['targetType' => "VARCHAR('n')"],
+            'more than two parameters' => ['targetType' => 'NUMERIC(1, 2, 3)'],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CompositeFieldTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CompositeFieldTest.php
@@ -7,6 +7,8 @@ namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 use Doctrine\ORM\Query\QueryException;
 use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsComposites;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\CompositeField;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidFieldNameException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 final class CompositeFieldTest extends TestCase
@@ -39,5 +41,39 @@ final class CompositeFieldTest extends TestCase
 
         $dql = \sprintf('SELECT COMPOSITE_FIELD(e.item, 123) FROM %s e', ContainsComposites::class);
         $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+
+    #[Test]
+    public function throws_exception_for_empty_field_name(): void
+    {
+        $this->expectException(InvalidFieldNameException::class);
+
+        $dql = \sprintf("SELECT COMPOSITE_FIELD(e.item, '') FROM %s e", ContainsComposites::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+
+    #[DataProvider('provideInjectionPayloads')]
+    #[Test]
+    public function escapes_field_name_into_a_single_quoted_identifier(string $fieldName, string $expectedSql): void
+    {
+        $dql = \sprintf("SELECT COMPOSITE_FIELD(e.item, '%s') FROM %s e", $fieldName, ContainsComposites::class);
+        $this->assertSqlFromDql($expectedSql, $dql);
+    }
+
+    /**
+     * @return array<string, array{fieldName: string, expectedSql: string}>
+     */
+    public static function provideInjectionPayloads(): array
+    {
+        return [
+            'double quote breaking out of the identifier' => [
+                'fieldName' => 'a", (SELECT version()) AS "x',
+                'expectedSql' => 'SELECT (c0_.item)."a"", (SELECT version()) AS ""x" AS sclr_0 FROM ContainsComposites c0_',
+            ],
+            'trailing double quote' => [
+                'fieldName' => 'name"',
+                'expectedSql' => 'SELECT (c0_.item)."name""" AS sclr_0 FROM ContainsComposites c0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/XmlPiTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/XmlPiTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
 
 use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidXmlPiTargetException;
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\XmlPi;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 
 final class XmlPiTest extends TestCase
 {
@@ -19,8 +22,9 @@ final class XmlPiTest extends TestCase
     protected function getExpectedSqlStatements(): array
     {
         return [
-            'creates processing instruction from target only' => 'SELECT xmlpi(NAME foo) AS sclr_0 FROM ContainsTexts c0_',
-            'creates processing instruction from target and content field' => 'SELECT xmlpi(NAME foo, c0_.text2) AS sclr_0 FROM ContainsTexts c0_',
+            'creates processing instruction from target only' => 'SELECT xmlpi(NAME "foo") AS sclr_0 FROM ContainsTexts c0_',
+            'creates processing instruction from target and content field' => 'SELECT xmlpi(NAME "foo", c0_.text2) AS sclr_0 FROM ContainsTexts c0_',
+            'creates processing instruction from target containing a hyphen' => 'SELECT xmlpi(NAME "php-app") AS sclr_0 FROM ContainsTexts c0_',
         ];
     }
 
@@ -29,6 +33,41 @@ final class XmlPiTest extends TestCase
         return [
             'creates processing instruction from target only' => \sprintf("SELECT XMLPI('foo') FROM %s e", ContainsTexts::class),
             'creates processing instruction from target and content field' => \sprintf("SELECT XMLPI('foo', e.text2) FROM %s e", ContainsTexts::class),
+            'creates processing instruction from target containing a hyphen' => \sprintf("SELECT XMLPI('php-app') FROM %s e", ContainsTexts::class),
         ];
+    }
+
+    #[DataProvider('provideInjectionPayloads')]
+    #[Test]
+    public function escapes_target_into_a_single_quoted_identifier(string $target, string $expectedSql): void
+    {
+        $dql = \sprintf("SELECT XMLPI('%s') FROM %s e", $target, ContainsTexts::class);
+        $this->assertSqlFromDql($expectedSql, $dql);
+    }
+
+    /**
+     * @return array<string, array{target: string, expectedSql: string}>
+     */
+    public static function provideInjectionPayloads(): array
+    {
+        return [
+            'comma smuggling a subquery' => [
+                'target' => 'php, (SELECT version())',
+                'expectedSql' => 'SELECT xmlpi(NAME "php, (SELECT version())") AS sclr_0 FROM ContainsTexts c0_',
+            ],
+            'double quote breaking out of the identifier' => [
+                'target' => 'php", (SELECT version()) AS "x',
+                'expectedSql' => 'SELECT xmlpi(NAME "php"", (SELECT version()) AS ""x") AS sclr_0 FROM ContainsTexts c0_',
+            ],
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_for_empty_target(): void
+    {
+        $this->expectException(InvalidXmlPiTargetException::class);
+
+        $dql = \sprintf("SELECT XMLPI('') FROM %s e", ContainsTexts::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
     }
 }


### PR DESCRIPTION
XMLPI(), COMPOSITE_FIELD() and CAST() interpolated DQL string literals into
the generated SQL verbatim, so a literal could carry arbitrary SQL into the
final statement.

- XMLPI() now emits the target as a quoted identifier with embedded double
  quotes doubled, and rejects an empty target. This also fixes legitimate
  targets that PostgreSQL rejected unquoted, such as 'php-app'. Target casing
  is now preserved instead of being folded to lower case by PostgreSQL.
- COMPOSITE_FIELD() now doubles embedded double quotes in the field name and
  rejects an empty name.
- CAST() now validates the target type name and its parameters instead of
  interpolating them, accepting only TYPE, TYPE(n) and TYPE(p, s).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for `CAST()` type names and parameters, rejecting malformed or unsafe inputs.
  - Added validation for empty `COMPOSITE_FIELD` names.
  - Escaped embedded quotes in composite field names and XML processing-instruction targets.
  - `XMLPI` now safely supports targets containing characters such as hyphens while correctly quoting identifiers.
  - Empty or invalid XML processing-instruction targets now produce clear validation errors.
- **Tests**
  - Expanded coverage for invalid inputs, escaping behavior, injection attempts, and hyphenated XMLPI targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->