### PR TITLE
fix: collect the ORM layer deptrac was configured to guard

### DIFF
--- a/ci/deptrac/config.yml
+++ b/ci/deptrac/config.yml
@@ -5,10 +5,12 @@ deptrac:
     - ../../tests
 
   layers:
+    # Covers the whole ORM subtree rather than AST\Functions alone, so that plain AST
+    # nodes sitting outside the Functions subnamespace stay inside the layer.
     - name: Functions
       collectors:
         - type: class
-          value: ^MartinGeorgiev\\Doctrine\\ORM\\AST\\Functions\\.*
+          value: ^MartinGeorgiev\\Doctrine\\ORM\\.*
     - name: Types
       collectors:
         - type: class
@@ -41,6 +43,7 @@ deptrac:
       - Utils
     Fixtures:
       - Fixtures
+      - Functions
       - Types
       - Utils
     Integration Tests:


### PR DESCRIPTION
The Functions layer collected `^MartinGeorgiev\Doctrine\ORM\AST\Functions\.*`,
which is missing the `Query` segment the namespace actually carries. No class
ever matched it, so `deptrac debug:layer Functions` returned an empty table and
every rule naming the layer - the Functions ruleset itself, and the Functions
entry under both test rulesets - enforced nothing.

The collector now takes the whole ORM subtree instead of `AST\Functions` alone,
so a plain AST node added outside the Functions subnamespace is guarded too
rather than silently escaping the layer. That puts 458 classes in the layer.

Enforcing the rules for the first time surfaced 39 violations, all of one kind:
the fixture DQL functions extend BaseVariadicFunction, and the Fixtures ruleset
did not list Functions. The fixtures depend on the function base classes for the
same reason the fixture entities depend on the DBAL types, which the ruleset
already allows, so Functions joins Types there. src/ needed no change - the
library layering was already clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency analysis rules to cover the full Doctrine ORM namespace.
  * Allowed fixture components to depend on ORM functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->