### PR TITLE
feat: read and write the non-finite values PostgreSQL stores

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseDateTimeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseDateTimeArray.php
@@ -104,7 +104,7 @@ abstract class BaseDateTimeArray extends BaseArray
             $this->throwInvalidPHPTypeException($item);
         }
 
-        $infinity = DateTimeInfinity::tryFrom($item);
+        $infinity = DateTimeInfinity::tryFromString($item);
         if ($infinity instanceof DateTimeInfinity) {
             return $infinity;
         }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseFloatArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseFloatArray.php
@@ -6,6 +6,7 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidFloatArrayItemForDatabaseException;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidFloatArrayItemForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\PostgresFloatConversionTrait;
 
 /**
  * @since 3.0
@@ -14,6 +15,8 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidFloatArrayItemForPHPExc
  */
 abstract class BaseFloatArray extends BaseArray
 {
+    use PostgresFloatConversionTrait;
+
     /**
      * @var string
      */
@@ -45,7 +48,17 @@ abstract class BaseFloatArray extends BaseArray
             throw InvalidFloatArrayItemForDatabaseException::isNotANumber($item);
         }
 
+        // Infinity and NaN are values PostgreSQL stores and emits.
+        // The precision, range and closeness-to-zero checks below all describe finite numbers.
+        if (\is_float($item) && !\is_finite($item)) {
+            return;
+        }
+
         $stringValue = (string) $item;
+        if (self::isNonFiniteString($stringValue)) {
+            return;
+        }
+
         if (!\preg_match(self::FLOAT_REGEX, $stringValue)) {
             throw InvalidFloatArrayItemForDatabaseException::doesNotMatchRegex($item);
         }
@@ -85,6 +98,17 @@ abstract class BaseFloatArray extends BaseArray
         throw InvalidFloatArrayItemForDatabaseException::isNotANumber($item);
     }
 
+    protected function transformArrayItemForPostgres(mixed $item): string
+    {
+        if (\is_float($item)) {
+            return self::formatFloat($item);
+        }
+
+        \assert(\is_scalar($item));
+
+        return (string) $item;
+    }
+
     public function transformArrayItemForPHP(mixed $item): ?float
     {
         if ($item === null) {
@@ -97,6 +121,10 @@ abstract class BaseFloatArray extends BaseArray
         }
 
         $stringValue = (string) $item;
+        if (self::isNonFiniteString($stringValue)) {
+            return self::parseFloat($stringValue);
+        }
+
         if (!\preg_match(self::FLOAT_REGEX, $stringValue)) {
             throw InvalidFloatArrayItemForPHPException::forValueThatIsNotAValidPHPFloat($item, static::TYPE_NAME);
         }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresFloatConversionTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresFloatConversionTrait.php
@@ -13,7 +13,7 @@ trait PostgresFloatConversionTrait
 {
     /**
      * A float without its sign, for the operands PostgreSQL never accepts a negative value for, such as a radius.
-     * The non-finite spellings (inf, infinity, nan) are part of the grammar; PostgreSQL emits them capitalised.
+     * The non-finite spellings (inf, infinity, nan) are part of the grammar; PostgreSQL emits them capitalized.
      *
      * @var string
      */
@@ -44,6 +44,19 @@ trait PostgresFloatConversionTrait
         }
 
         return \sprintf('%.17H', $value);
+    }
+
+    /**
+     * The spellings PostgreSQL accepts for a value outside the finite range. It emits `Infinity`, `-Infinity` and `NaN`,
+     * but reads any case, the `inf` abbreviation and an explicit `+`.
+     */
+    protected static function isNonFiniteString(string $value): bool
+    {
+        return \in_array(
+            \mb_strtolower($value),
+            ['nan', '+nan', '-nan', 'inf', '+inf', '-inf', 'infinity', '+infinity', '-infinity'],
+            true
+        );
     }
 
     /**

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresInfinityConversionTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresInfinityConversionTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Traits;
+
+/**
+ * Recognizes the tokens PostgreSQL reads for a date, timestamp or range bound that lies outside any calendar or ordering.
+ *
+ * The grammar is narrower than the one the numeric types use. E.g. `inf` is a float and numeric spelling that a date rejects, so it is deliberately absent here.
+ *
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+trait PostgresInfinityConversionTrait
+{
+    protected static function normalizeInfinity(string $value): ?string
+    {
+        return match (\mb_strtolower($value)) {
+            'infinity', '+infinity' => 'infinity',
+            '-infinity' => '-infinity',
+            default => null,
+        };
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/DateTimeInfinity.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/DateTimeInfinity.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Doctrine\DBAL\Types\ValueObject;
 
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\PostgresInfinityConversionTrait;
+
 /**
  * Represents PostgreSQL infinity values for a date, timestamp and timestamptz fields.
  *
@@ -18,6 +20,20 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types\ValueObject;
  */
 enum DateTimeInfinity: string
 {
+    use PostgresInfinityConversionTrait;
+
+    /**
+     * PHP forbids redeclaring an enum's own `tryFrom()`, so the tolerant lookup needs a name of its
+     * own. It follows the `fromString()` the value objects use. The backing values are the spellings
+     * PostgreSQL emits, while it reads any case and an explicit `+` besides.
+     */
+    public static function tryFromString(string $value): ?self
+    {
+        $canonical = self::normalizeInfinity($value);
+
+        return $canonical === null ? null : self::from($canonical);
+    }
+
     case POSITIVE = 'infinity';
 
     case NEGATIVE = '-infinity';

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Range.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/Range.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Doctrine\DBAL\Types\ValueObject;
 
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\PostgresInfinityConversionTrait;
+
 /**
  * @template R
  *
@@ -13,6 +15,8 @@ namespace MartinGeorgiev\Doctrine\DBAL\Types\ValueObject;
  */
 abstract class Range implements \Stringable
 {
+    use PostgresInfinityConversionTrait;
+
     /**
      * @var string
      */
@@ -98,9 +102,7 @@ abstract class Range implements \Stringable
 
     protected static function isInfinityString(string $value): bool
     {
-        $normalized = \strtolower($value);
-
-        return $normalized === 'infinity' || $normalized === '-infinity';
+        return self::normalizeInfinity($value) !== null;
     }
 
     /**

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/DoublePrecisionArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/DoublePrecisionArrayTypeTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
+use PHPUnit\Framework\Attributes\Test;
+
 final class DoublePrecisionArrayTypeTest extends FloatArrayTypeTestCase
 {
     protected function getTypeName(): string
@@ -47,5 +49,13 @@ final class DoublePrecisionArrayTypeTest extends FloatArrayTypeTestCase
                 'expected' => [1.7976931348623157E+308, -1.7976931348623157E+308],
             ],
         ];
+    }
+
+    #[Test]
+    public function roundtrips_non_finite_values(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+        $this->runDbalBindingRoundTrip($typeName, $columnType, [\INF, -\INF, 1.5]);
     }
 }

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/RealArrayTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/RealArrayTypeTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
+use PHPUnit\Framework\Attributes\Test;
+
 final class RealArrayTypeTest extends FloatArrayTypeTestCase
 {
     protected function getTypeName(): string
@@ -47,5 +49,13 @@ final class RealArrayTypeTest extends FloatArrayTypeTestCase
                 'expected' => [3.4028235E+38, -3.4028235E+38],
             ],
         ];
+    }
+
+    #[Test]
+    public function roundtrips_non_finite_values(): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+        $this->runDbalBindingRoundTrip($typeName, $columnType, [\INF, -\INF, 1.5]);
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DoublePrecisionArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DoublePrecisionArrayTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use MartinGeorgiev\Doctrine\DBAL\Types\DoublePrecisionArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidFloatArrayItemForPHPException;
 use PHPUnit\Framework\Attributes\Test;
 
 final class DoublePrecisionArrayTest extends BaseFloatArrayTestCase
@@ -78,5 +80,34 @@ final class DoublePrecisionArrayTest extends BaseFloatArrayTestCase
             'negative exponent' => ['1.5e-20'],
             'explicit positive exponent' => ['1.7976931348623157E+308'],
         ];
+    }
+
+    #[Test]
+    public function throws_exception_for_a_doubled_sign_before_a_non_finite_value(): void
+    {
+        $this->expectException(InvalidFloatArrayItemForPHPException::class);
+
+        $this->fixture->convertToPHPValue('{++inf}', $this->createStub(AbstractPlatform::class));
+    }
+
+    #[Test]
+    public function converts_non_finite_values_to_php_value(): void
+    {
+        $result = $this->fixture->convertToPHPValue('{Infinity,-Infinity,NaN,1.5}', $this->createStub(AbstractPlatform::class));
+
+        $this->assertIsArray($result);
+        $this->assertSame(\INF, $result[0]);
+        $this->assertSame(-\INF, $result[1]);
+        $this->assertNan($result[2]);
+        $this->assertSame(1.5, $result[3]);
+    }
+
+    #[Test]
+    public function converts_non_finite_values_to_database_value(): void
+    {
+        $this->assertSame(
+            '{Infinity,-Infinity,NaN,1.5}',
+            $this->fixture->convertToDatabaseValue([\INF, -\INF, \NAN, 1.5], $this->createStub(AbstractPlatform::class))
+        );
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonArrayTest.php
@@ -111,7 +111,7 @@ final class JsonArrayTest extends TestCase
     {
         return [
             'sql null element' => ['{NULL}'],
-            'json null element stored by the previous behaviour' => ['{"null"}'],
+            'json null element stored by the previous behavior' => ['{"null"}'],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
@@ -112,7 +112,7 @@ final class JsonbArrayTest extends TestCase
     {
         return [
             'sql null element' => ['{NULL}'],
-            'json null element stored by the previous behaviour' => ['{"null"}'],
+            'json null element stored by the previous behavior' => ['{"null"}'],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/RealArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/RealArrayTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidFloatArrayItemForPHPException;
 use MartinGeorgiev\Doctrine\DBAL\Types\RealArray;
 use PHPUnit\Framework\Attributes\Test;
@@ -104,5 +105,34 @@ final class RealArrayTest extends BaseFloatArrayTestCase
             'ten significant digits still inside the range' => ['3.402823467E+38'],
             'negative and inside the range' => ['-3.402823467E+38'],
         ];
+    }
+
+    #[Test]
+    public function throws_exception_for_a_doubled_sign_before_a_non_finite_value(): void
+    {
+        $this->expectException(InvalidFloatArrayItemForPHPException::class);
+
+        $this->fixture->convertToPHPValue('{++inf}', $this->createStub(AbstractPlatform::class));
+    }
+
+    #[Test]
+    public function converts_non_finite_values_to_php_value(): void
+    {
+        $result = $this->fixture->convertToPHPValue('{Infinity,-Infinity,NaN,1.5}', $this->createStub(AbstractPlatform::class));
+
+        $this->assertIsArray($result);
+        $this->assertSame(\INF, $result[0]);
+        $this->assertSame(-\INF, $result[1]);
+        $this->assertNan($result[2]);
+        $this->assertSame(1.5, $result[3]);
+    }
+
+    #[Test]
+    public function converts_non_finite_values_to_database_value(): void
+    {
+        $this->assertSame(
+            '{Infinity,-Infinity,NaN,1.5}',
+            $this->fixture->convertToDatabaseValue([\INF, -\INF, \NAN, 1.5], $this->createStub(AbstractPlatform::class))
+        );
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/DateRangeTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/DateRangeTest.php
@@ -265,6 +265,27 @@ final class DateRangeTest extends BaseRangeTestCase
         yield 'empty range' => ['empty', DateRange::empty()];
     }
 
+    #[DataProvider('provideInfinitySpellings')]
+    #[Test]
+    public function parses_every_accepted_infinity_spelling(string $bound): void
+    {
+        $dateRange = DateRange::fromString(\sprintf('[2023-01-01,%s)', $bound));
+
+        $this->assertSame('[2023-01-01,infinity)', (string) $dateRange);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInfinitySpellings(): array
+    {
+        return [
+            'canonical' => ['infinity'],
+            'capitalized' => ['Infinity'],
+            'explicit plus' => ['+infinity'],
+        ];
+    }
+
     #[Test]
     public function throws_exception_for_invalid_lower_bound(): void
     {

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/DateTimeInfinityTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/DateTimeInfinityTest.php
@@ -45,11 +45,9 @@ final class DateTimeInfinityTest extends TestCase
     public static function provideRejectedSpellings(): array
     {
         return [
-            // the numeric types take `inf`, a date does not
             'float abbreviation' => ['inf'],
             'negative float abbreviation' => ['-inf'],
             'not a number' => ['NaN'],
-            // PostgreSQL reads one optional sign, never a doubled one
             'doubled plus' => ['++infinity'],
             'plus before minus' => ['+-infinity'],
             'minus before plus' => ['-+infinity'],

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/DateTimeInfinityTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/ValueObject/DateTimeInfinityTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types\ValueObject;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateTimeInfinity;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DateTimeInfinityTest extends TestCase
+{
+    #[DataProvider('provideAcceptedSpellings')]
+    #[Test]
+    public function parses_every_accepted_spelling(string $token, DateTimeInfinity $dateTimeInfinity): void
+    {
+        $this->assertSame($dateTimeInfinity, DateTimeInfinity::tryFromString($token));
+    }
+
+    /**
+     * @return array<string, array{string, DateTimeInfinity}>
+     */
+    public static function provideAcceptedSpellings(): array
+    {
+        return [
+            'canonical positive' => ['infinity', DateTimeInfinity::POSITIVE],
+            'canonical negative' => ['-infinity', DateTimeInfinity::NEGATIVE],
+            'capitalized' => ['Infinity', DateTimeInfinity::POSITIVE],
+            'upper case' => ['INFINITY', DateTimeInfinity::POSITIVE],
+            'explicit plus' => ['+infinity', DateTimeInfinity::POSITIVE],
+        ];
+    }
+
+    #[DataProvider('provideRejectedSpellings')]
+    #[Test]
+    public function rejects_spelling_a_date_does_not_accept(string $token): void
+    {
+        $this->assertNull(DateTimeInfinity::tryFromString($token));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideRejectedSpellings(): array
+    {
+        return [
+            // the numeric types take `inf`, a date does not
+            'float abbreviation' => ['inf'],
+            'negative float abbreviation' => ['-inf'],
+            'not a number' => ['NaN'],
+            // PostgreSQL reads one optional sign, never a doubled one
+            'doubled plus' => ['++infinity'],
+            'plus before minus' => ['+-infinity'],
+            'minus before plus' => ['-+infinity'],
+            'a lone sign' => ['+'],
+            'a date' => ['2024-01-01'],
+            'empty' => [''],
+        ];
+    }
+}


### PR DESCRIPTION
`double precision[]` and `real[]` rejected every value outside the finite range.
PostgreSQL emits `{Infinity,-Infinity,NaN}` for a column holding them, and
`BaseFloatArray` gated both directions behind a digits-only regex, so reading
such a column threw `InvalidFloatArrayItemForPHPException` and `INF` or `NAN`
could not be written at all.

The repository already had a parser for exactly these spellings in
`PostgresFloatConversionTrait`, reached only by `Cube` and the geometric value
objects. `BaseFloatArray` now uses it: a non-finite item is parsed to the PHP
constant on the way in and written back through `formatFloat()`, which emits
PostgreSQL's own `Infinity`, `-Infinity` and `NaN`. The precision, range and
closeness-to-zero checks are skipped for it, since each describes a finite
number and says nothing about these values. Casting is avoided before the check
because `(string) NAN` raises a warning on PHP 8.5.

The recognised spellings were also inconsistent across the three places that
reason about infinity. `Range` accepted any case but not the `+infinity` that
PostgreSQL takes, and `DateTimeInfinity::tryFrom()` matched the backing value
exactly, so a capitalised token from another application was read as a date and
rejected. Both now share `PostgresInfinityConversionTrait`.

That trait deliberately does not carry the float grammar. Verified against
PostgreSQL 18: `date` takes `infinity`, `Infinity` and `+infinity` but rejects
`inf`, while `float8` and `numeric` take `inf` and `nan` as well, so a single
token list for every type would accept values the date types refuse.

Two data-provider labels in the JSON array tests carried the British spelling
of "behavior", against the US English the repository settled on in 877d9298.
They are corrected here rather than left for their own change.

The token match lists each accepted spelling in full rather than trimming a
leading `+` before comparing. Trimming also accepted `++infinity` and
`+-infinity`, which PostgreSQL rejects: it reads one optional sign, never a
doubled one. `parseFloat()` keeps its trim, since FLOAT_PATTERN admits a single
sign and no doubled form can reach it.