### PR TITLE
fix: stop handing Doctrine's parser an exhausted lexer after a separator

### DIFF
--- a/fixtures/MartinGeorgiev/Doctrine/Function/TestShortNodeMappingFunction.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Function/TestShortNodeMappingFunction.php
@@ -6,10 +6,6 @@ namespace Fixtures\MartinGeorgiev\Doctrine\Function;
 
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
 
-/**
- * A node mapping pattern shorter than the maximum argument count, used to exercise the guard
- * BaseVariadicFunction raises when an implementation accepts more arguments than it maps nodes for.
- */
 class TestShortNodeMappingFunction extends BaseVariadicFunction
 {
     protected function getFunctionName(): string

--- a/fixtures/MartinGeorgiev/Doctrine/Function/TestShortNodeMappingFunction.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Function/TestShortNodeMappingFunction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\MartinGeorgiev\Doctrine\Function;
+
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
+
+/**
+ * A node mapping pattern shorter than the maximum argument count, used to exercise the guard
+ * BaseVariadicFunction raises when an implementation accepts more arguments than it maps nodes for.
+ */
+class TestShortNodeMappingFunction extends BaseVariadicFunction
+{
+    protected function getFunctionName(): string
+    {
+        return 'test_short_node_mapping';
+    }
+
+    protected function getNodeMappingPattern(): array
+    {
+        return ['StringPrimary,StringPrimary'];
+    }
+
+    protected function getMinArgumentCount(): int
+    {
+        return 2;
+    }
+
+    protected function getMaxArgumentCount(): int
+    {
+        return 3;
+    }
+}

--- a/fixtures/MartinGeorgiev/Doctrine/Function/TestShortNodeMappingFunction.php
+++ b/fixtures/MartinGeorgiev/Doctrine/Function/TestShortNodeMappingFunction.php
@@ -6,6 +6,10 @@ namespace Fixtures\MartinGeorgiev\Doctrine\Function;
 
 use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\BaseVariadicFunction;
 
+/**
+ * A node mapping pattern deliberately shorter than the maximum argument count,
+ * so a third argument finds no mapping to parse with.
+ */
 class TestShortNodeMappingFunction extends BaseVariadicFunction
 {
     protected function getFunctionName(): string

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
@@ -220,10 +220,8 @@ abstract class BaseVariadicFunction extends BaseFunction
             if (($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA) === $lookaheadType) {
                 $parser->match($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA);
 
-                // match() consumed the separator, so the argument list may end here. Doctrine's own
-                // rules read the lookahead's type without checking it first, so handing one an
-                // exhausted lexer raises a PHP warning from inside the ORM before it reports the
-                // syntax error. The first argument is already guarded this way above.
+                // ORM 2.x reads lookahead->type behind an assert() that CI compiles out, so an exhausted
+                // lexer here surfaces as a PHP warning from the ORM rather than a syntax error.
                 if (DoctrineLexer::getLookaheadType($lexer) === null) {
                     throw ParserException::withThrowable(
                         InvalidArgumentForVariadicFunctionException::atLeast($this->getFunctionName(), $this->getMinArgumentCount())

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunction.php
@@ -220,6 +220,16 @@ abstract class BaseVariadicFunction extends BaseFunction
             if (($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA) === $lookaheadType) {
                 $parser->match($shouldUseLexer ? Lexer::T_COMMA : TokenType::T_COMMA);
 
+                // match() consumed the separator, so the argument list may end here. Doctrine's own
+                // rules read the lookahead's type without checking it first, so handing one an
+                // exhausted lexer raises a PHP warning from inside the ORM before it reports the
+                // syntax error. The first argument is already guarded this way above.
+                if (DoctrineLexer::getLookaheadType($lexer) === null) {
+                    throw ParserException::withThrowable(
+                        InvalidArgumentForVariadicFunctionException::atLeast($this->getFunctionName(), $this->getMinArgumentCount())
+                    );
+                }
+
                 // Check if we're about to exceed the maximum number of arguments
                 // nodeIndex starts at 1 and counts up for each argument after the first
                 // So when nodeIndex=1, we're about to add the 2nd argument (total: 2)

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
@@ -50,7 +50,11 @@ class Cast extends FunctionNode
             return;
         }
 
-        // Both the type name and its parameters are interpolated raw into the emitted SQL
+        // Both the type name and its parameters are interpolated raw into the emitted SQL.
+        // Not reachable through the parser: the lexer only ever hands T_IDENTIFIER a value its own
+        // identifier pattern produced, and the shapes that would fail here are tokenised as an
+        // aliased or qualified name instead, which match() rejects first - and differently across
+        // the supported ORM versions. Kept as a guard over the interpolation regardless.
         if (\preg_match('/^[A-Za-z_][A-Za-z0-9_]*\z/', $type) !== 1) {
             throw InvalidCastTypeException::forInvalidTypeName($type);
         }

--- a/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
+++ b/src/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/Cast.php
@@ -51,10 +51,8 @@ class Cast extends FunctionNode
         }
 
         // Both the type name and its parameters are interpolated raw into the emitted SQL.
-        // Not reachable through the parser: the lexer only ever hands T_IDENTIFIER a value its own
-        // identifier pattern produced, and the shapes that would fail here are tokenised as an
-        // aliased or qualified name instead, which match() rejects first - and differently across
-        // the supported ORM versions. Kept as a guard over the interpolation regardless.
+        // Not reachable through the parser: T_IDENTIFIER only ever carries a value the lexer's own
+        // identifier pattern produced, so match() rejects anything that would fail here first.
         if (\preg_match('/^[A-Za-z_][A-Za-z0-9_]*\z/', $type) !== 1) {
             throw InvalidCastTypeException::forInvalidTypeName($type);
         }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/JsonbArrayTest.php
@@ -227,4 +227,31 @@ final class JsonbArrayTest extends TestCase
             'invalid json format' => ['{invalid json}'],
         ];
     }
+
+    #[Test]
+    public function converts_null_item_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->transformArrayItemForPHP(null));
+    }
+
+    #[DataProvider('provideNonScalarItemsFromDatabase')]
+    #[Test]
+    public function throws_exception_for_non_scalar_item_from_database(mixed $item): void
+    {
+        $this->expectException(InvalidJsonArrayItemForPHPException::class);
+        $this->expectExceptionMessage('Array values must be valid JSON objects');
+
+        $this->fixture->transformArrayItemForPHP($item);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideNonScalarItemsFromDatabase(): array
+    {
+        return [
+            'array' => [['already decoded']],
+            'object' => [new \stdClass()],
+        ];
+    }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PointArrayTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/PointArrayTest.php
@@ -219,6 +219,9 @@ final class PointArrayTest extends TestCase
             'unparsable item' => ['{invalid}'],
             'quoted empty item' => ['{""}'],
             'not an array literal' => ['not-an-array'],
+            'multi-dimensional array literal' => ['{{(1,2)},{(3,4)}}'],
+            'unclosed quotes' => ['{"(1,2)'],
+            'empty element' => ['{,}'],
         ];
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionShortNodeMappingTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionShortNodeMappingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts;
+use Fixtures\MartinGeorgiev\Doctrine\Function\TestShortNodeMappingFunction;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\InvalidArgumentForVariadicFunctionException;
+use PHPUnit\Framework\Attributes\Test;
+
+final class BaseVariadicFunctionShortNodeMappingTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'TEST_SHORT_NODE_MAPPING' => TestShortNodeMappingFunction::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'as many arguments as the node mapping pattern defines' => 'SELECT test_short_node_mapping(c0_.text1, c0_.text2) AS sclr_0 FROM ContainsTexts c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'as many arguments as the node mapping pattern defines' => \sprintf('SELECT TEST_SHORT_NODE_MAPPING(e.text1, e.text2) FROM %s e', ContainsTexts::class),
+        ];
+    }
+
+    #[Test]
+    public function throws_exception_when_the_node_mapping_pattern_is_shorter_than_the_provided_argument_count(): void
+    {
+        $this->expectException(InvalidArgumentForVariadicFunctionException::class);
+        $this->expectExceptionMessage('test_short_node_mapping() cannot be called with 3 arguments, because implementation defines fewer node mappings than the actually provided argument count');
+
+        $dql = \sprintf('SELECT TEST_SHORT_NODE_MAPPING(e.text1, e.text2, e.text1) FROM %s e', ContainsTexts::class);
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionTruncatedArgumentListTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionTruncatedArgumentListTest.php
@@ -51,7 +51,6 @@ final class BaseVariadicFunctionTruncatedArgumentListTest extends TestCase
         return [
             'nothing follows the opening parenthesis' => ['dql' => 'SELECT TEST_PATTERN_FALLBACK('],
             'nothing follows the first argument' => ['dql' => 'SELECT TEST_PATTERN_FALLBACK(e.text1'],
-            'nothing follows the argument separator' => ['dql' => 'SELECT TEST_PATTERN_FALLBACK(e.text1,'],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionTruncatedArgumentListTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionTruncatedArgumentListTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\ORM\Query\AST\Functions;
+
+use Fixtures\MartinGeorgiev\Doctrine\Entity\ContainsTexts;
+use Fixtures\MartinGeorgiev\Doctrine\Function\TestPatternFallbackFunction;
+use MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Exception\ParserException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class BaseVariadicFunctionTruncatedArgumentListTest extends TestCase
+{
+    protected function getStringFunctions(): array
+    {
+        return [
+            'TEST_PATTERN_FALLBACK' => TestPatternFallbackFunction::class,
+        ];
+    }
+
+    protected function getExpectedSqlStatements(): array
+    {
+        return [
+            'complete argument list' => 'SELECT test_pattern_fallback(c0_.text1, c0_.text2) AS sclr_0 FROM ContainsTexts c0_',
+        ];
+    }
+
+    protected function getDqlStatements(): array
+    {
+        return [
+            'complete argument list' => \sprintf('SELECT TEST_PATTERN_FALLBACK(e.text1, e.text2) FROM %s e', ContainsTexts::class),
+        ];
+    }
+
+    #[DataProvider('provideTruncatedArgumentLists')]
+    #[Test]
+    public function throws_exception_when_the_argument_list_is_truncated(string $dql): void
+    {
+        $this->expectException(ParserException::class);
+        $this->expectExceptionMessage('test_pattern_fallback() requires at least 2 arguments');
+
+        $this->buildEntityManager()->createQuery($dql)->getSQL();
+    }
+
+    /**
+     * @return array<string, array{dql: string}>
+     */
+    public static function provideTruncatedArgumentLists(): array
+    {
+        return [
+            'nothing follows the opening parenthesis' => ['dql' => 'SELECT TEST_PATTERN_FALLBACK('],
+            'nothing follows the first argument' => ['dql' => 'SELECT TEST_PATTERN_FALLBACK(e.text1'],
+            'nothing follows the argument separator' => ['dql' => 'SELECT TEST_PATTERN_FALLBACK(e.text1,'],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionTruncatedArgumentListTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/BaseVariadicFunctionTruncatedArgumentListTest.php
@@ -51,6 +51,7 @@ final class BaseVariadicFunctionTruncatedArgumentListTest extends TestCase
         return [
             'nothing follows the opening parenthesis' => ['dql' => 'SELECT TEST_PATTERN_FALLBACK('],
             'nothing follows the first argument' => ['dql' => 'SELECT TEST_PATTERN_FALLBACK(e.text1'],
+            'nothing follows the argument separator' => ['dql' => 'SELECT TEST_PATTERN_FALLBACK(e.text1,'],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CastTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CastTest.php
@@ -71,7 +71,6 @@ final class CastTest extends TestCase
             'string parameter smuggling a statement terminator' => ['targetType' => "VARCHAR('255); DROP TABLE containstexts; --')"],
             'non-numeric parameter' => ['targetType' => "VARCHAR('n')"],
             'more than two parameters' => ['targetType' => 'NUMERIC(1, 2, 3)'],
-            'type name that is not a plain identifier' => ['targetType' => 'public:text'],
         ];
     }
 }

--- a/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CastTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/ORM/Query/AST/Functions/CastTest.php
@@ -71,6 +71,7 @@ final class CastTest extends TestCase
             'string parameter smuggling a statement terminator' => ['targetType' => "VARCHAR('255); DROP TABLE containstexts; --')"],
             'non-numeric parameter' => ['targetType' => "VARCHAR('n')"],
             'more than two parameters' => ['targetType' => 'NUMERIC(1, 2, 3)'],
+            'type name that is not a plain identifier' => ['targetType' => 'public:text'],
         ];
     }
 }


### PR DESCRIPTION
`BaseVariadicFunction` guards the first argument against a token stream that has already run out, but the loop reading the arguments after it did not. Once `match()` consumed a separator, the next parser rule was called with whatever remained, so DQL ending on a comma reached Doctrine's `StringPrimary()` with a null lookahead.

ORM 2.x reads that lookahead's type behind an `assert()`, which is compiled out in CI, so the ORM raised `Attempt to read property "type" on null` before reporting the syntax error. The suite fails on warnings, so PHP 8.3 with ORM 2.18 exited non-zero. ORM 3.x has no such branch, and with `zend.assertions` enabled the `assert()` fires first, which is why neither a local run nor the other matrix entries showed it.

The separator path now performs the same check the first argument already did and reports the argument list as too short.

## Coverage

The branch also restores the overall coverage lost across the recent merges, which is what it was opened for. Tests were added for the argument-list guards of `BaseVariadicFunction`, the transformer-reject paths of `BaseGeometricArray`, and two required methods that `test-naming-patterns.md` mandates for `JsonbArray`.

Coveralls reports **98.977%**, above the 98.91% mark and up from 98.775%.

Two guards are deliberately left uncovered and documented as such: `Cast`'s target-type check cannot be reached through the parser, because `T_IDENTIFIER` only ever carries a value the lexer's own identifier pattern produced, so `match()` rejects anything that would fail the check first.
