### PR TITLE
test: align the Utils transformer test namespaces with their path

### DIFF
--- a/tests/Unit/MartinGeorgiev/Utils/PHPArrayToPostgresRecordTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PHPArrayToPostgresRecordTransformerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\MartinGeorgiev\Utils;
+namespace Tests\Unit\MartinGeorgiev\Utils;
 
 use MartinGeorgiev\Utils\PHPArrayToPostgresRecordTransformer;
 use MartinGeorgiev\Utils\PostgresRecordToPHPArrayTransformer;

--- a/tests/Unit/MartinGeorgiev/Utils/PHPArrayToPostgresValueTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PHPArrayToPostgresValueTransformerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\MartinGeorgiev\Utils;
+namespace Tests\Unit\MartinGeorgiev\Utils;
 
 use MartinGeorgiev\Utils\Exception\InvalidArrayFormatException;
 use MartinGeorgiev\Utils\PHPArrayToPostgresValueTransformer;

--- a/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\MartinGeorgiev\Utils;
+namespace Tests\Unit\MartinGeorgiev\Utils;
 
 use MartinGeorgiev\Utils\Exception\InvalidArrayFormatException;
 use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;

--- a/tests/Unit/MartinGeorgiev/Utils/PostgresJsonToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresJsonToPHPArrayTransformerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\MartinGeorgiev\Utils;
+namespace Tests\Unit\MartinGeorgiev\Utils;
 
 use MartinGeorgiev\Utils\Exception\InvalidJsonFormatException;
 use MartinGeorgiev\Utils\PostgresJsonToPHPArrayTransformer;

--- a/tests/Unit/MartinGeorgiev/Utils/PostgresRecordToPHPArrayTransformerTest.php
+++ b/tests/Unit/MartinGeorgiev/Utils/PostgresRecordToPHPArrayTransformerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\MartinGeorgiev\Utils;
+namespace Tests\Unit\MartinGeorgiev\Utils;
 
 use MartinGeorgiev\Utils\Exception\InvalidRecordFormatException;
 use MartinGeorgiev\Utils\PostgresRecordToPHPArrayTransformer;


### PR DESCRIPTION
## Problem

Five test files under `tests/Unit/MartinGeorgiev/Utils/` declared `namespace Tests\MartinGeorgiev\Utils;`, but `autoload-dev` maps `Tests\Unit\MartinGeorgiev\` to `tests/Unit/MartinGeorgiev/`. The namespace did not match the path — a PSR-4 violation with two concrete consequences:

1. **Composer could not autoload them by FQCN.** `composer dump-autoload --optimize --strict-psr` reported each one as `does not comply with psr-4 autoloading standard (rule: Tests\Unit\MartinGeorgiev\ => ./tests/Unit/MartinGeorgiev). Skipping.` They still ran only because PHPUnit discovers tests by file path.
2. **They sat outside the `Unit Tests` deptrac layer**, whose collector is `^Tests\Unit\MartinGeorgiev\.*`, so no architecture rule was enforced on them.

## Change

Namespace declarations only. No class renames, no import changes, no test logic touched.

- `tests/Unit/MartinGeorgiev/Utils/PHPArrayToPostgresRecordTransformerTest.php`
- `tests/Unit/MartinGeorgiev/Utils/PHPArrayToPostgresValueTransformerTest.php`
- `tests/Unit/MartinGeorgiev/Utils/PostgresArrayToPHPArrayTransformerTest.php`
- `tests/Unit/MartinGeorgiev/Utils/PostgresJsonToPHPArrayTransformerTest.php`
- `tests/Unit/MartinGeorgiev/Utils/PostgresRecordToPHPArrayTransformerTest.php`

No `use` statement or FQCN reference to the old namespace exists anywhere else in the repository, so nothing else needed updating.

## Verification

| Check | Before | After |
|---|---|---|
| `dump-autoload --optimize --strict-psr` | 5 "Skipping" warnings, 6712 classes | clean, 6717 classes |
| `deptrac debug:layer "Unit Tests"` | 599 members | 604 members |
| `composer run-unit-tests` | 5800 tests, 7937 assertions | 5800 tests, 7937 assertions |
| `composer run-static-analysis` | 0 violations | 0 violations |

The deptrac report's `Allowed` count rises from 68273 to 68303 — those are the `MartinGeorgiev\Utils\*` dependencies that are now actually being checked against the ruleset instead of ignored.

Also green: `php -d zend.assertions=-1 bin/phpunit --configuration ci/phpunit/config-unit.xml`, `composer phpstan`, `composer check-code-style`.

A repo-wide scan of `src/`, `fixtures/` and `tests/` found no other path/namespace mismatch. The only other file without a matching namespace is `tests/Integration/bootstrap.php`, which is a procedural bootstrap script declaring no class and is not subject to PSR-4.

The integration suite was not run — this change cannot affect it.
