### PR TITLE
fix: throw the correct exception family from network type conversions

### DIFF
--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Cidr.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Cidr.php
@@ -34,11 +34,11 @@ class Cidr extends BaseType
         }
 
         if (!\is_string($value)) {
-            throw InvalidCidrForPHPException::forInvalidType($value);
+            throw InvalidCidrForDatabaseException::forInvalidType($value);
         }
 
         if (!$this->isValidCidrAddress($value)) {
-            throw InvalidCidrForPHPException::forInvalidFormat($value);
+            throw InvalidCidrForDatabaseException::forInvalidFormat($value);
         }
 
         return $value;
@@ -51,11 +51,11 @@ class Cidr extends BaseType
         }
 
         if (!\is_string($value)) {
-            throw InvalidCidrForDatabaseException::forInvalidType($value);
+            throw InvalidCidrForPHPException::forInvalidType($value);
         }
 
         if (!$this->isValidCidrAddress($value)) {
-            throw InvalidCidrForDatabaseException::forInvalidFormat($value);
+            throw InvalidCidrForPHPException::forInvalidFormat($value);
         }
 
         return $value;

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCidrForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCidrForDatabaseException.php
@@ -20,11 +20,11 @@ class InvalidCidrForDatabaseException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Database value must be a string, %s given', $value);
+        return self::create('Value must be a string, %s given', $value);
     }
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Invalid CIDR address format in database: %s', $value);
+        return self::create('Invalid CIDR address format: %s', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCidrForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidCidrForPHPException.php
@@ -20,11 +20,11 @@ class InvalidCidrForPHPException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Value must be a string, %s given', $value);
+        return self::create('Database value must be a string, %s given', $value);
     }
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Invalid CIDR address format: %s', $value);
+        return self::create('Invalid CIDR address format in database: %s', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInetForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInetForDatabaseException.php
@@ -20,11 +20,11 @@ class InvalidInetForDatabaseException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Database value must be a string, %s given', $value);
+        return self::create('Value must be a string, %s given', $value);
     }
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Invalid INET address format in database: %s', $value);
+        return self::create('Invalid INET address format: %s', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInetForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidInetForPHPException.php
@@ -20,11 +20,11 @@ class InvalidInetForPHPException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Value must be a string, %s given', $value);
+        return self::create('Database value must be a string, %s given', $value);
     }
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Invalid INET address format: %s', $value);
+        return self::create('Invalid INET address format in database: %s', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddr8ForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddr8ForDatabaseException.php
@@ -20,11 +20,11 @@ class InvalidMacaddr8ForDatabaseException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Database value must be a string, %s given', $value);
+        return self::create('Value must be a string, %s given', $value);
     }
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Invalid EUI-64 MAC address format in database: %s', $value);
+        return self::create('Invalid EUI-64 MAC address format: %s', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddr8ForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddr8ForPHPException.php
@@ -20,11 +20,11 @@ class InvalidMacaddr8ForPHPException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Value must be a string, %s given', $value);
+        return self::create('Database value must be a string, %s given', $value);
     }
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Invalid EUI-64 MAC address format: %s', $value);
+        return self::create('Invalid EUI-64 MAC address format in database: %s', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddrForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddrForDatabaseException.php
@@ -20,11 +20,11 @@ class InvalidMacaddrForDatabaseException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Database value must be a string, %s given', $value);
+        return self::create('Value must be a string, %s given', $value);
     }
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Invalid MAC address format in database: %s', $value);
+        return self::create('Invalid MAC address format: %s', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddrForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidMacaddrForPHPException.php
@@ -20,11 +20,11 @@ class InvalidMacaddrForPHPException extends ConversionException
 
     public static function forInvalidType(mixed $value): self
     {
-        return self::create('Value must be a string, %s given', $value);
+        return self::create('Database value must be a string, %s given', $value);
     }
 
     public static function forInvalidFormat(mixed $value): self
     {
-        return self::create('Invalid MAC address format: %s', $value);
+        return self::create('Invalid MAC address format in database: %s', $value);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Inet.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Inet.php
@@ -34,11 +34,11 @@ class Inet extends BaseType
         }
 
         if (!\is_string($value)) {
-            throw InvalidInetForPHPException::forInvalidType($value);
+            throw InvalidInetForDatabaseException::forInvalidType($value);
         }
 
         if (!$this->isValidInetAddress($value)) {
-            throw InvalidInetForPHPException::forInvalidFormat($value);
+            throw InvalidInetForDatabaseException::forInvalidFormat($value);
         }
 
         return $value;
@@ -51,11 +51,11 @@ class Inet extends BaseType
         }
 
         if (!\is_string($value)) {
-            throw InvalidInetForDatabaseException::forInvalidType($value);
+            throw InvalidInetForPHPException::forInvalidType($value);
         }
 
         if (!$this->isValidInetAddress($value)) {
-            throw InvalidInetForDatabaseException::forInvalidFormat($value);
+            throw InvalidInetForPHPException::forInvalidFormat($value);
         }
 
         return $value;

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr.php
@@ -34,11 +34,11 @@ class Macaddr extends BaseType
         }
 
         if (!\is_string($value)) {
-            throw InvalidMacaddrForPHPException::forInvalidType($value);
+            throw InvalidMacaddrForDatabaseException::forInvalidType($value);
         }
 
         if (!$this->isValidMacAddress($value)) {
-            throw InvalidMacaddrForPHPException::forInvalidFormat($value);
+            throw InvalidMacaddrForDatabaseException::forInvalidFormat($value);
         }
 
         return $this->normalizeMacAddressFormat($value);
@@ -51,11 +51,11 @@ class Macaddr extends BaseType
         }
 
         if (!\is_string($value)) {
-            throw InvalidMacaddrForDatabaseException::forInvalidType($value);
+            throw InvalidMacaddrForPHPException::forInvalidType($value);
         }
 
         if (!$this->isValidMacAddress($value)) {
-            throw InvalidMacaddrForDatabaseException::forInvalidFormat($value);
+            throw InvalidMacaddrForPHPException::forInvalidFormat($value);
         }
 
         return $value;

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8.php
@@ -34,11 +34,11 @@ final class Macaddr8 extends BaseType
         }
 
         if (!\is_string($value)) {
-            throw InvalidMacaddr8ForPHPException::forInvalidType($value);
+            throw InvalidMacaddr8ForDatabaseException::forInvalidType($value);
         }
 
         if (!$this->isValidMacAddress($value)) {
-            throw InvalidMacaddr8ForPHPException::forInvalidFormat($value);
+            throw InvalidMacaddr8ForDatabaseException::forInvalidFormat($value);
         }
 
         return $this->normalizeMacAddressFormat($value);
@@ -51,11 +51,11 @@ final class Macaddr8 extends BaseType
         }
 
         if (!\is_string($value)) {
-            throw InvalidMacaddr8ForDatabaseException::forInvalidType($value);
+            throw InvalidMacaddr8ForPHPException::forInvalidType($value);
         }
 
         if (!$this->isValidMacAddress($value)) {
-            throw InvalidMacaddr8ForDatabaseException::forInvalidFormat($value);
+            throw InvalidMacaddr8ForPHPException::forInvalidFormat($value);
         }
 
         return $value;

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CidrTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/CidrTypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
-use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCidrForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidCidrForDatabaseException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -44,7 +44,7 @@ final class CidrTypeTest extends ScalarTypeTestCase
     #[Test]
     public function rejects_invalid_network(string $value): void
     {
-        $this->expectException(InvalidCidrForPHPException::class);
+        $this->expectException(InvalidCidrForDatabaseException::class);
 
         $typeName = $this->getTypeName();
         $columnType = $this->getPostgresTypeName();

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/InetTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/InetTypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
-use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInetForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidInetForDatabaseException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -66,7 +66,7 @@ final class InetTypeTest extends ScalarTypeTestCase
     #[Test]
     public function rejects_invalid_value(string $value): void
     {
-        $this->expectException(InvalidInetForPHPException::class);
+        $this->expectException(InvalidInetForDatabaseException::class);
 
         $typeName = $this->getTypeName();
         $columnType = $this->getPostgresTypeName();

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8TypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8TypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
-use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddr8ForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddr8ForDatabaseException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -40,7 +40,7 @@ final class Macaddr8TypeTest extends ScalarTypeTestCase
     #[Test]
     public function rejects_invalid_address(): void
     {
-        $this->expectException(InvalidMacaddr8ForPHPException::class);
+        $this->expectException(InvalidMacaddr8ForDatabaseException::class);
 
         $typeName = $this->getTypeName();
         $columnType = $this->getPostgresTypeName();

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrTypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
 
-use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddrForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidMacaddrForDatabaseException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -42,7 +42,7 @@ final class MacaddrTypeTest extends ScalarTypeTestCase
     #[Test]
     public function rejects_invalid_address(): void
     {
-        $this->expectException(InvalidMacaddrForPHPException::class);
+        $this->expectException(InvalidMacaddrForDatabaseException::class);
 
         $typeName = $this->getTypeName();
         $columnType = $this->getPostgresTypeName();

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CidrTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/CidrTest.php
@@ -97,7 +97,7 @@ final class CidrTest extends TestCase
     #[Test]
     public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
     {
-        $this->expectException(InvalidCidrForPHPException::class);
+        $this->expectException(InvalidCidrForDatabaseException::class);
         $this->fixture->convertToDatabaseValue($phpValue, $this->platform);
     }
 
@@ -135,7 +135,7 @@ final class CidrTest extends TestCase
     #[Test]
     public function throws_exception_for_invalid_php_value_inputs(mixed $dbValue): void
     {
-        $this->expectException(InvalidCidrForDatabaseException::class);
+        $this->expectException(InvalidCidrForPHPException::class);
         $this->fixture->convertToPHPValue($dbValue, $this->platform);
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/InetTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/InetTest.php
@@ -113,7 +113,7 @@ final class InetTest extends TestCase
     #[Test]
     public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
     {
-        $this->expectException(InvalidInetForPHPException::class);
+        $this->expectException(InvalidInetForDatabaseException::class);
         $this->fixture->convertToDatabaseValue($phpValue, $this->platform);
     }
 
@@ -155,7 +155,7 @@ final class InetTest extends TestCase
     #[Test]
     public function throws_exception_for_invalid_php_value_inputs(mixed $postgresValue): void
     {
-        $this->expectException(InvalidInetForDatabaseException::class);
+        $this->expectException(InvalidInetForPHPException::class);
         $this->fixture->convertToPHPValue($postgresValue, $this->platform);
     }
 

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8Test.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/Macaddr8Test.php
@@ -96,7 +96,7 @@ final class Macaddr8Test extends TestCase
     #[Test]
     public function throws_exception_for_invalid_database_value_inputs(mixed $value): void
     {
-        $this->expectException(InvalidMacaddr8ForPHPException::class);
+        $this->expectException(InvalidMacaddr8ForDatabaseException::class);
 
         $this->fixture->convertToDatabaseValue($value, $this->platform);
     }
@@ -124,7 +124,7 @@ final class Macaddr8Test extends TestCase
     #[Test]
     public function throws_exception_for_invalid_php_value_inputs(mixed $value): void
     {
-        $this->expectException(InvalidMacaddr8ForDatabaseException::class);
+        $this->expectException(InvalidMacaddr8ForPHPException::class);
 
         $this->fixture->convertToPHPValue($value, $this->platform);
     }
@@ -147,7 +147,7 @@ final class Macaddr8Test extends TestCase
     #[Test]
     public function throws_exception_for_invalid_php_value_formats(string $value): void
     {
-        $this->expectException(InvalidMacaddr8ForDatabaseException::class);
+        $this->expectException(InvalidMacaddr8ForPHPException::class);
         $this->expectExceptionMessage('Invalid EUI-64 MAC address format in database');
 
         $this->fixture->convertToPHPValue($value, $this->platform);

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/MacaddrTest.php
@@ -116,7 +116,7 @@ final class MacaddrTest extends TestCase
     #[Test]
     public function throws_exception_for_invalid_database_value_inputs(mixed $phpValue): void
     {
-        $this->expectException(InvalidMacaddrForPHPException::class);
+        $this->expectException(InvalidMacaddrForDatabaseException::class);
 
         $this->fixture->convertToDatabaseValue($phpValue, $this->platform);
     }
@@ -151,7 +151,7 @@ final class MacaddrTest extends TestCase
     #[Test]
     public function throws_exception_for_invalid_php_value_inputs(mixed $invalidValue): void
     {
-        $this->expectException(InvalidMacaddrForDatabaseException::class);
+        $this->expectException(InvalidMacaddrForPHPException::class);
         $this->expectExceptionMessage('Database value must be a string');
 
         $this->fixture->convertToPHPValue($invalidValue, $this->platform);
@@ -175,7 +175,7 @@ final class MacaddrTest extends TestCase
     #[Test]
     public function throws_exception_for_invalid_php_value_formats(string $invalidFormat): void
     {
-        $this->expectException(InvalidMacaddrForDatabaseException::class);
+        $this->expectException(InvalidMacaddrForPHPException::class);
         $this->expectExceptionMessage('Invalid MAC address format in database');
 
         $this->fixture->convertToPHPValue($invalidFormat, $this->platform);


### PR DESCRIPTION
convertToDatabaseValue() and convertToPHPValue() on Macaddr, Macaddr8,
Inet and Cidr had their exception families exactly swapped relative to
the documented convention (.ai-tools/rules/exceptions.md): PHP-value
errors on the write path threw *ForPHPException instead of
*ForDatabaseException, and database-value errors on the read path threw
*ForDatabaseException instead of *ForPHPException.

convertToDatabaseValue() now throws InvalidMacaddrForDatabaseException /
InvalidMacaddr8ForDatabaseException / InvalidInetForDatabaseException /
InvalidCidrForDatabaseException when the PHP value is not a string or
is not a valid address. convertToPHPValue() now throws the matching
*ForPHPException for a non-string or malformed database value.

BC BREAK: code that specifically catches InvalidMacaddrForPHPException
around convertToDatabaseValue(), or InvalidMacaddrForDatabaseException
around convertToPHPValue() (and the Macaddr8, Inet and Cidr
equivalents), will stop catching the exception now thrown from that
path. Catching the base ConversionException, or catching both exception
classes, is unaffected.

No new exception classes or factories were needed; both classes in each
pair already carried forInvalidType() and forInvalidFormat(), and both
conversion paths genuinely produce a type error and a format error. The
message bodies were swapped along with the classes, because swapping the
classes alone would have made a malformed database value report "Invalid
MAC address format", which describes the write path, not the read one.
Each path therefore keeps the wording it had before: the write path says
"Value must be a string" / "Invalid <X> address format", and the read
path says "Database value must be a string" / "Invalid <X> address
format in database".

The MACADDR[], MACADDR8[], INET[] and CIDR[] array types are unaffected.
They throw the separate Invalid*ArrayItemFor{PHP,Database}Exception
family, which was already oriented correctly, and neither
BaseNetworkTypeArray nor the network validation traits reference the
scalar exception classes.

