### PR TITLE
feat: add scalar `date`, `timestamp` and `timestamptz` types that carry infinity

### DIFF
--- a/docs/AVAILABLE-TYPES.md
+++ b/docs/AVAILABLE-TYPES.md
@@ -18,12 +18,15 @@
 | double precision[] | _float8 | `MartinGeorgiev\Doctrine\DBAL\Types\DoublePrecisionArray` |
 | numeric[] | _numeric | `MartinGeorgiev\Doctrine\DBAL\Types\NumericArray` (see [note](#numeric-array-type)) |
 |---|---|---|
-| date[] | _date | `MartinGeorgiev\Doctrine\DBAL\Types\DateArray` (see [note](#datetime-array-types)) |
+| date | date | `MartinGeorgiev\Doctrine\DBAL\Types\Date` (see [note](#datetime-types)) |
+| date[] | _date | `MartinGeorgiev\Doctrine\DBAL\Types\DateArray` (see [note](#datetime-types)) |
 | interval | interval | `MartinGeorgiev\Doctrine\DBAL\Types\Interval` |
 | interval[] | _interval | `MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray` |
 | time[] | _time | `MartinGeorgiev\Doctrine\DBAL\Types\TimeArray` |
-| timestamp[] | _timestamp | `MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray` (see [note](#datetime-array-types)) |
-| timestamptz[] | _timestamptz | `MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray` (see [note](#datetime-array-types)) |
+| timestamp | timestamp | `MartinGeorgiev\Doctrine\DBAL\Types\Timestamp` (see [note](#datetime-types)) |
+| timestamp[] | _timestamp | `MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray` (see [note](#datetime-types)) |
+| timestamptz | timestamptz | `MartinGeorgiev\Doctrine\DBAL\Types\TimestampTz` (see [note](#datetime-types)) |
+| timestamptz[] | _timestamptz | `MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray` (see [note](#datetime-types)) |
 | timetz | timetz | `MartinGeorgiev\Doctrine\DBAL\Types\Timetz` |
 | timetz[] | _timetz | `MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray` |
 |---|---|---|
@@ -223,9 +226,9 @@ The `numeric[]` type maps array items to PHP strings (e.g. `'502.00'`) rather th
 
 ---
 
-## Datetime Array Types
+## Datetime Types
 
-Items of `date[]`, `timestamp[]` and `timestamptz[]` map to `\DateTimeImmutable`, with one exception: PostgreSQL's [`infinity` and `-infinity`](https://www.postgresql.org/docs/18/datatype-datetime.html#DATATYPE-DATETIME-SPECIAL-TABLE) sort before and after every other value of their type and have no `\DateTimeImmutable` counterpart, so they map to the `MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateTimeInfinity` enum instead. Reading a column that may hold them means widening the item check:
+`date`, `timestamp` and `timestamptz`, and the items of `date[]`, `timestamp[]` and `timestamptz[]`, map to `\DateTimeImmutable`, with one exception: PostgreSQL's [`infinity` and `-infinity`](https://www.postgresql.org/docs/18/datatype-datetime.html#DATATYPE-DATETIME-SPECIAL-TABLE) sort before and after every other value of their type and have no `\DateTimeImmutable` counterpart, so they map to the `MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateTimeInfinity` enum instead. Reading a column that may hold them means widening the value check:
 
 ```php
 use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateTimeInfinity;
@@ -240,12 +243,24 @@ foreach ($entity->getValidOn() as $item) {
 }
 ```
 
-Both are written back by putting the same enum case into the array. They are deliberately kept apart from `null`, which stays the SQL NULL: an unbounded date is not an unknown one.
+Both are written back by assigning the same enum case to the property or array item. They are deliberately kept apart from `null`, which stays the SQL NULL: an unbounded date is not an unknown one.
 
 Two further ranges PostgreSQL accepts are mapped without a sentinel, because `\DateTimeImmutable` can hold them:
 
 - **Years before 1 AD.** PostgreSQL numbers them in the BC era and has no year zero, while PHP numbers them astronomically and does. `0001-01-15 BC` therefore reads back as PHP year `0000`, and `0002-01-15 BC` as PHP year `-0001`. Format such values with `X` rather than `Y` to keep the sign visible.
 - **Years past 9999.** They round-trip unchanged; `Y` prints them in full.
+
+### The scalar types are an opt-in that shadows Doctrine's own
+
+The three scalar types are named after the PostgreSQL types they carry, as every type in this library is. Two of those names are free, but `date` is also the name of one of Doctrine's built-in types, so registering it is a deliberate, application-wide decision rather than a per-column one:
+
+- `Type::addType('date', ...)` throws, because the name is taken. Use `Type::overrideType('date', ...)`.
+- Doctrine's built-in `date` returns a mutable `\DateTime`. This one returns `\DateTimeImmutable` or `DateTimeInfinity`, so an entity property typed `\DateTime` will no longer be assignable.
+- Every `date` column in the application changes over at once. There is no way to keep some of them on Doctrine's type, short of mapping those to `date_immutable` or `datetime` instead.
+
+`timestamp` and `timestamptz` collide with nothing — Doctrine calls its equivalents `datetime` and `datetimetz` — so `Type::addType()` registers them and existing columns keep whatever type they are already mapped to. What they do change is the *reverse* mapping: `$platform->registerDoctrineTypeMapping('timestamp', 'timestamp')` replaces the platform default that resolves a PostgreSQL `timestamp` column to Doctrine's `datetime`, which schema introspection and diffing rely on. Register the mapping only if you want introspection to follow.
+
+None of this applies to the array types. `date[]`, `timestamp[]` and `timestamptz[]` have no Doctrine counterpart at all.
 
 ---
 

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -42,11 +42,17 @@ DoctrineType::addType('ulid', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Ulid");
 DoctrineType::addType('ulid[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\UlidArray");
 
 // Date and time types
+// The date, timestamp and timestamptz types below are an opt-in replacement for Doctrine's own date, datetime
+// and datetimetz handling. Register them only if you want the PostgreSQL semantics described in
+// AVAILABLE-TYPES.md (infinity values and \DateTimeImmutable).
+DoctrineType::overrideType('date', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Date"); // replaces Doctrine's built-in date type, addType() would throw
 DoctrineType::addType('date[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\DateArray");
 DoctrineType::addType('interval', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Interval");
 DoctrineType::addType('interval[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\IntervalArray");
 DoctrineType::addType('time[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimeArray");
+DoctrineType::addType('timestamp', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Timestamp");
 DoctrineType::addType('timestamp[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimestampArray");
+DoctrineType::addType('timestamptz', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimestampTz");
 DoctrineType::addType('timestamptz[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimestampTzArray");
 DoctrineType::addType('timetz', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Timetz");
 DoctrineType::addType('timetz[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\TimetzArray");
@@ -534,7 +540,11 @@ $platform->registerDoctrineTypeMapping('ulid', 'ulid');
 $platform->registerDoctrineTypeMapping('ulid[]', 'ulid[]');
 $platform->registerDoctrineTypeMapping('_ulid', 'ulid[]');
 
-// Datetime array type mappings
+// Date and time type mappings
+// The date, timestamp and timestamptz lines are only needed alongside the opt-in scalar types above. They also
+// replace the platform's default reverse mapping of those PostgreSQL types to datetime and datetimetz, which
+// schema introspection relies on.
+$platform->registerDoctrineTypeMapping('date', 'date');
 $platform->registerDoctrineTypeMapping('date[]', 'date[]');
 $platform->registerDoctrineTypeMapping('_date', 'date[]');
 $platform->registerDoctrineTypeMapping('interval', 'interval');
@@ -542,8 +552,10 @@ $platform->registerDoctrineTypeMapping('interval[]', 'interval[]');
 $platform->registerDoctrineTypeMapping('_interval', 'interval[]');
 $platform->registerDoctrineTypeMapping('time[]', 'time[]');
 $platform->registerDoctrineTypeMapping('_time', 'time[]');
+$platform->registerDoctrineTypeMapping('timestamp', 'timestamp');
 $platform->registerDoctrineTypeMapping('timestamp[]', 'timestamp[]');
 $platform->registerDoctrineTypeMapping('_timestamp', 'timestamp[]');
+$platform->registerDoctrineTypeMapping('timestamptz', 'timestamptz');
 $platform->registerDoctrineTypeMapping('timestamptz[]', 'timestamptz[]');
 $platform->registerDoctrineTypeMapping('_timestamptz', 'timestamptz[]');
 $platform->registerDoctrineTypeMapping('timetz', 'timetz');

--- a/docs/INTEGRATING-WITH-DOCTRINE.md
+++ b/docs/INTEGRATING-WITH-DOCTRINE.md
@@ -42,9 +42,10 @@ DoctrineType::addType('ulid', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Ulid");
 DoctrineType::addType('ulid[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\UlidArray");
 
 // Date and time types
-// The date, timestamp and timestamptz types below are an opt-in replacement for Doctrine's own date, datetime
-// and datetimetz handling. Register them only if you want the PostgreSQL semantics described in
-// AVAILABLE-TYPES.md (infinity values and \DateTimeImmutable).
+// The date, timestamp and timestamptz types below read and write PostgreSQL's infinity values and return
+// \DateTimeImmutable; see AVAILABLE-TYPES.md. Registering date replaces Doctrine's built-in date type across the
+// whole application, which is why it needs overrideType(). The timestamp and timestamptz names are free, as
+// Doctrine calls its own equivalents datetime and datetimetz, so registering those leaves existing columns alone.
 DoctrineType::overrideType('date', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Date"); // replaces Doctrine's built-in date type, addType() would throw
 DoctrineType::addType('date[]', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\DateArray");
 DoctrineType::addType('interval', "MartinGeorgiev\\Doctrine\\DBAL\\Types\\Interval");
@@ -541,9 +542,9 @@ $platform->registerDoctrineTypeMapping('ulid[]', 'ulid[]');
 $platform->registerDoctrineTypeMapping('_ulid', 'ulid[]');
 
 // Date and time type mappings
-// The date, timestamp and timestamptz lines are only needed alongside the opt-in scalar types above. They also
+// The date, timestamp and timestamptz lines are only needed alongside the scalar types above. The last two
 // replace the platform's default reverse mapping of those PostgreSQL types to datetime and datetimetz, which
-// schema introspection relies on.
+// schema introspection reads, so register them only if you want introspection to follow.
 $platform->registerDoctrineTypeMapping('date', 'date');
 $platform->registerDoctrineTypeMapping('date[]', 'date[]');
 $platform->registerDoctrineTypeMapping('_date', 'date[]');

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -79,6 +79,7 @@ return [
                 '_ulid' => 'ulid[]',
 
                 // Datetime array type mappings
+                'date' => 'date',
                 'date[]' => 'date[]',
                 '_date' => 'date[]',
                 'interval' => 'interval',
@@ -86,8 +87,10 @@ return [
                 '_interval' => 'interval[]',
                 'time[]' => 'time[]',
                 '_time' => 'time[]',
+                'timestamp' => 'timestamp',
                 'timestamp[]' => 'timestamp[]',
                 '_timestamp' => 'timestamp[]',
+                'timestamptz' => 'timestamptz',
                 'timestamptz[]' => 'timestamptz[]',
                 '_timestamptz' => 'timestamptz[]',
                 'timetz' => 'timetz',
@@ -265,11 +268,16 @@ return [
         'ulid[]' => MartinGeorgiev\Doctrine\DBAL\Types\UlidArray::class,
 
         // Date and time types
+        // Registering date, timestamp and timestamptz is an opt-in: it replaces Doctrine's own date, datetime
+        // and datetimetz handling application-wide. See AVAILABLE-TYPES.md before adding them.
+        'date' => MartinGeorgiev\Doctrine\DBAL\Types\Date::class,
         'date[]' => MartinGeorgiev\Doctrine\DBAL\Types\DateArray::class,
         'interval' => MartinGeorgiev\Doctrine\DBAL\Types\Interval::class,
         'interval[]' => MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray::class,
         'time[]' => MartinGeorgiev\Doctrine\DBAL\Types\TimeArray::class,
+        'timestamp' => MartinGeorgiev\Doctrine\DBAL\Types\Timestamp::class,
         'timestamp[]' => MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray::class,
+        'timestamptz' => MartinGeorgiev\Doctrine\DBAL\Types\TimestampTz::class,
         'timestamptz[]' => MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray::class,
         'timetz' => MartinGeorgiev\Doctrine\DBAL\Types\Timetz::class,
         'timetz[]' => MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray::class,

--- a/docs/INTEGRATING-WITH-LARAVEL.md
+++ b/docs/INTEGRATING-WITH-LARAVEL.md
@@ -268,8 +268,9 @@ return [
         'ulid[]' => MartinGeorgiev\Doctrine\DBAL\Types\UlidArray::class,
 
         // Date and time types
-        // Registering date, timestamp and timestamptz is an opt-in: it replaces Doctrine's own date, datetime
-        // and datetimetz handling application-wide. See AVAILABLE-TYPES.md before adding them.
+        // date, timestamp and timestamptz read and write PostgreSQL's infinity values; see AVAILABLE-TYPES.md.
+        // Registering date replaces Doctrine's built-in date type across the whole application. The timestamp and
+        // timestamptz names are free, so registering those leaves existing columns alone.
         'date' => MartinGeorgiev\Doctrine\DBAL\Types\Date::class,
         'date[]' => MartinGeorgiev\Doctrine\DBAL\Types\DateArray::class,
         'interval' => MartinGeorgiev\Doctrine\DBAL\Types\Interval::class,

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -34,11 +34,16 @@ doctrine:
             'varchar[]': MartinGeorgiev\Doctrine\DBAL\Types\VarcharArray
 
             # Date and time types
+            # Listing date, timestamp and timestamptz is an opt-in: it replaces Doctrine's own date, datetime and
+            # datetimetz handling application-wide. See AVAILABLE-TYPES.md before adding them.
+            date: MartinGeorgiev\Doctrine\DBAL\Types\Date
             'date[]': MartinGeorgiev\Doctrine\DBAL\Types\DateArray
             interval: MartinGeorgiev\Doctrine\DBAL\Types\Interval
             'interval[]': MartinGeorgiev\Doctrine\DBAL\Types\IntervalArray
             'time[]': MartinGeorgiev\Doctrine\DBAL\Types\TimeArray
+            timestamp: MartinGeorgiev\Doctrine\DBAL\Types\Timestamp
             'timestamp[]': MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray
+            timestamptz: MartinGeorgiev\Doctrine\DBAL\Types\TimestampTz
             'timestamptz[]': MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray
             timetz: MartinGeorgiev\Doctrine\DBAL\Types\Timetz
             'timetz[]': MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray
@@ -237,6 +242,7 @@ doctrine:
                     _ulid: !php/const MartinGeorgiev\Doctrine\DBAL\Type::ULID_ARRAY
 
                     # Datetime array type mappings
+                    date: !php/const MartinGeorgiev\Doctrine\DBAL\Type::DATE
                     'date[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::DATE_ARRAY
                     _date: !php/const MartinGeorgiev\Doctrine\DBAL\Type::DATE_ARRAY
                     interval: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INTERVAL
@@ -244,8 +250,10 @@ doctrine:
                     _interval: !php/const MartinGeorgiev\Doctrine\DBAL\Type::INTERVAL_ARRAY
                     'time[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIME_ARRAY
                     _time: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIME_ARRAY
+                    timestamp: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMP
                     'timestamp[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMP_ARRAY
                     _timestamp: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMP_ARRAY
+                    timestamptz: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMPTZ
                     'timestamptz[]': !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMPTZ_ARRAY
                     _timestamptz: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMESTAMPTZ_ARRAY
                     timetz: !php/const MartinGeorgiev\Doctrine\DBAL\Type::TIMETZ

--- a/docs/INTEGRATING-WITH-SYMFONY.md
+++ b/docs/INTEGRATING-WITH-SYMFONY.md
@@ -34,8 +34,9 @@ doctrine:
             'varchar[]': MartinGeorgiev\Doctrine\DBAL\Types\VarcharArray
 
             # Date and time types
-            # Listing date, timestamp and timestamptz is an opt-in: it replaces Doctrine's own date, datetime and
-            # datetimetz handling application-wide. See AVAILABLE-TYPES.md before adding them.
+            # date, timestamp and timestamptz read and write PostgreSQL's infinity values; see AVAILABLE-TYPES.md.
+            # Listing date replaces Doctrine's built-in date type across the whole application. The timestamp and
+            # timestamptz names are free, so listing those leaves existing columns alone.
             date: MartinGeorgiev\Doctrine\DBAL\Types\Date
             'date[]': MartinGeorgiev\Doctrine\DBAL\Types\DateArray
             interval: MartinGeorgiev\Doctrine\DBAL\Types\Interval

--- a/src/MartinGeorgiev/Doctrine/DBAL/Type.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Type.php
@@ -99,6 +99,11 @@ final class Type
     /**
      * @var string
      */
+    public const DATE = 'date';
+
+    /**
+     * @var string
+     */
     public const DATE_ARRAY = 'date[]';
 
     /**
@@ -414,7 +419,17 @@ final class Type
     /**
      * @var string
      */
+    public const TIMESTAMP = 'timestamp';
+
+    /**
+     * @var string
+     */
     public const TIMESTAMP_ARRAY = 'timestamp[]';
+
+    /**
+     * @var string
+     */
+    public const TIMESTAMPTZ = 'timestamptz';
 
     /**
      * @var string

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseDateTime.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseDateTime.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\PostgresDateTimeConversionTrait;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateTimeInfinity;
+
+/**
+ * Base class for the PostgreSQL datetime types (DATE, TIMESTAMP, TIMESTAMPTZ).
+ *
+ * Values are \DateTimeImmutable or DateTimeInfinity instances, matching the items of the array counterparts.
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-datetime.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+abstract class BaseDateTime extends BaseType
+{
+    use PostgresDateTimeConversionTrait;
+
+    abstract protected function throwInvalidDatabaseTypeException(mixed $value): never;
+
+    abstract protected function throwInvalidPHPTypeException(mixed $value): never;
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof DateTimeInfinity) {
+            return $value->value;
+        }
+
+        if (!$value instanceof \DateTimeInterface) {
+            $this->throwInvalidDatabaseTypeException($value);
+        }
+
+        return $this->transformDateTimeForPostgres($value);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): \DateTimeImmutable|DateTimeInfinity|null
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            $this->throwInvalidPHPTypeException($value);
+        }
+
+        return $this->transformPostgresStringForPHP($value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseDateTimeArray.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/BaseDateTimeArray.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MartinGeorgiev\Doctrine\DBAL\Types;
 
+use MartinGeorgiev\Doctrine\DBAL\Types\Traits\PostgresDateTimeConversionTrait;
 use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateTimeInfinity;
 use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
 
@@ -19,35 +20,9 @@ use MartinGeorgiev\Utils\PostgresArrayToPHPArrayTransformer;
  */
 abstract class BaseDateTimeArray extends BaseArray
 {
-    /**
-     * @var string
-     */
-    private const BC_ERA_SUFFIX = ' BC';
-
-    /**
-     * Returns the format string for serializing to PostgreSQL.
-     *
-     * It must open with the year, which is rewritten on its own for values in the BC era.
-     */
-    abstract protected function getPostgresFormat(): string;
-
-    /**
-     * Returns format strings for parsing from PostgreSQL, tried in order.
-     *
-     * To support the five-digit and non-positive years PostgreSQL emits, they use X rather than Y for the year format.
-     *
-     * @return non-empty-list<string>
-     */
-    abstract protected function getPHPFormats(): array;
-
-    protected function transformParsedValueForPHP(\DateTimeImmutable $value): \DateTimeImmutable
-    {
-        return $value;
-    }
+    use PostgresDateTimeConversionTrait;
 
     abstract protected function throwInvalidPHPTypeException(mixed $item): never;
-
-    abstract protected function throwInvalidPHPFormatException(mixed $item): never;
 
     public function isValidArrayItemForDatabase(mixed $item): bool
     {
@@ -73,22 +48,6 @@ abstract class BaseDateTimeArray extends BaseArray
         return '"'.$this->transformDateTimeForPostgres($item).'"';
     }
 
-    /**
-     * PostgreSQL has no year zero: it counts 1 BC where PHP counts year 0.
-     * Every non-positive PHP year is mirrored around 1 and written in the BC era, which PostgreSQL marks with a suffix.
-     */
-    private function transformDateTimeForPostgres(\DateTimeInterface $item): string
-    {
-        $yearToken = $item->format('Y');
-        $year = (int) $yearToken;
-        $formatted = $item->format($this->getPostgresFormat());
-        if ($year > 0) {
-            return $formatted;
-        }
-
-        return \sprintf('%04d', 1 - $year).\mb_substr($formatted, \mb_strlen($yearToken)).self::BC_ERA_SUFFIX;
-    }
-
     protected function transformPostgresArrayToPHPArray(string $postgresArray): array
     {
         return PostgresArrayToPHPArrayTransformer::transformPostgresArrayToPHPArray($postgresArray);
@@ -104,35 +63,6 @@ abstract class BaseDateTimeArray extends BaseArray
             $this->throwInvalidPHPTypeException($item);
         }
 
-        $infinity = DateTimeInfinity::tryFromString($item);
-        if ($infinity instanceof DateTimeInfinity) {
-            return $infinity;
-        }
-
-        $parsable = \str_ends_with($item, self::BC_ERA_SUFFIX)
-            ? $this->transformBcEraYearToAstronomicalYear(\mb_substr($item, 0, -\mb_strlen(self::BC_ERA_SUFFIX)))
-            : $item;
-
-        foreach ($this->getPHPFormats() as $format) {
-            $parsed = \DateTimeImmutable::createFromFormat($format, $parsable);
-            if ($parsed !== false) {
-                return $this->transformParsedValueForPHP($parsed);
-            }
-        }
-
-        $this->throwInvalidPHPFormatException($item);
-    }
-
-    /**
-     * Rewriting the era in the string keeps 29 February of a BC leap year intact.
-     * PHP counts it in the astronomical year, which is a leap year, while the BC year number PostgreSQL prints for it is not.
-     */
-    private function transformBcEraYearToAstronomicalYear(string $value): string
-    {
-        if (\preg_match('/^(\d+)(.*)\z/s', $value, $matches) !== 1) {
-            return $value;
-        }
-
-        return \sprintf('%+05d', 1 - (int) $matches[1]).$matches[2];
+        return $this->transformPostgresStringForPHP($item);
     }
 }

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Date.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Date.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidDateForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidDateForPHPException;
+
+/**
+ * Implementation of PostgreSQL DATE data type.
+ *
+ * Unlike Doctrine's own date type, it reads and writes the infinity sentinels PostgreSQL stores, and it returns
+ * \DateTimeImmutable rather than \DateTime. Registering it replaces the built-in date type for the whole
+ * application, so it is an explicit opt-in. See AVAILABLE-TYPES.md for the trade-off.
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-datetime.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class Date extends BaseDateTime
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::DATE;
+
+    protected function getPostgresFormat(): string
+    {
+        return 'Y-m-d';
+    }
+
+    protected function getPHPFormats(): array
+    {
+        return ['X-m-d'];
+    }
+
+    protected function transformParsedValueForPHP(\DateTimeImmutable $value): \DateTimeImmutable
+    {
+        return $value->setTime(0, 0, 0);
+    }
+
+    protected function throwInvalidDatabaseTypeException(mixed $value): never
+    {
+        throw InvalidDateForDatabaseException::forInvalidType($value);
+    }
+
+    protected function throwInvalidPHPTypeException(mixed $value): never
+    {
+        throw InvalidDateForPHPException::forInvalidType($value);
+    }
+
+    protected function throwInvalidPHPFormatException(mixed $item): never
+    {
+        throw InvalidDateForPHPException::forInvalidFormat($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidDateForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidDateForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidDateForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Value must be a DateTimeInterface or a DateTimeInfinity instance, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidDateForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidDateForPHPException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidDateForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Database value must be a string, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid date format: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimestampForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimestampForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTimestampForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Value must be a DateTimeInterface or a DateTimeInfinity instance, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimestampForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimestampForPHPException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTimestampForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Database value must be a string, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid timestamp format: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimestampTzForDatabaseException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimestampTzForDatabaseException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTimestampTzForDatabaseException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Value must be a DateTimeInterface or a DateTimeInfinity instance, %s given', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimestampTzForPHPException.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Exceptions/InvalidTimestampTzForPHPException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Exceptions;
+
+use Doctrine\DBAL\Types\ConversionException;
+
+/**
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class InvalidTimestampTzForPHPException extends ConversionException
+{
+    private static function create(string $message, mixed $value): self
+    {
+        return new self(\sprintf($message, \var_export($value, true)));
+    }
+
+    public static function forInvalidType(mixed $value): self
+    {
+        return self::create('Database value must be a string, %s given', $value);
+    }
+
+    public static function forInvalidFormat(mixed $value): self
+    {
+        return self::create('Invalid timestamptz format: %s', $value);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Timestamp.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Timestamp.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimestampForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimestampForPHPException;
+
+/**
+ * Implementation of PostgreSQL TIMESTAMP (timestamp without time zone) data type.
+ *
+ * Unlike Doctrine's own datetime type, it reads and writes the infinity sentinels PostgreSQL stores, and it
+ * returns \DateTimeImmutable rather than \DateTime.
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-datetime.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class Timestamp extends BaseDateTime
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::TIMESTAMP;
+
+    protected function getPostgresFormat(): string
+    {
+        return 'Y-m-d H:i:s.u';
+    }
+
+    protected function getPHPFormats(): array
+    {
+        return ['X-m-d H:i:s.u', 'X-m-d H:i:s'];
+    }
+
+    protected function throwInvalidDatabaseTypeException(mixed $value): never
+    {
+        throw InvalidTimestampForDatabaseException::forInvalidType($value);
+    }
+
+    protected function throwInvalidPHPTypeException(mixed $value): never
+    {
+        throw InvalidTimestampForPHPException::forInvalidType($value);
+    }
+
+    protected function throwInvalidPHPFormatException(mixed $item): never
+    {
+        throw InvalidTimestampForPHPException::forInvalidFormat($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/TimestampTz.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/TimestampTz.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimestampTzForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimestampTzForPHPException;
+
+/**
+ * Implementation of PostgreSQL TIMESTAMPTZ (timestamp with time zone) data type.
+ *
+ * Unlike Doctrine's own datetimetz type, it reads and writes the infinity sentinels PostgreSQL stores, and it
+ * returns \DateTimeImmutable rather than \DateTime.
+ *
+ * @see https://www.postgresql.org/docs/18/datatype-datetime.html
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+class TimestampTz extends BaseDateTime
+{
+    /**
+     * @var string
+     */
+    protected const TYPE_NAME = Type::TIMESTAMPTZ;
+
+    protected function getPostgresFormat(): string
+    {
+        return 'Y-m-d H:i:s.uP';
+    }
+
+    protected function getPHPFormats(): array
+    {
+        return ['X-m-d H:i:s.uP', 'X-m-d H:i:sP'];
+    }
+
+    protected function throwInvalidDatabaseTypeException(mixed $value): never
+    {
+        throw InvalidTimestampTzForDatabaseException::forInvalidType($value);
+    }
+
+    protected function throwInvalidPHPTypeException(mixed $value): never
+    {
+        throw InvalidTimestampTzForPHPException::forInvalidType($value);
+    }
+
+    protected function throwInvalidPHPFormatException(mixed $item): never
+    {
+        throw InvalidTimestampTzForPHPException::forInvalidFormat($item);
+    }
+}

--- a/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresDateTimeConversionTrait.php
+++ b/src/MartinGeorgiev/Doctrine/DBAL/Types/Traits/PostgresDateTimeConversionTrait.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MartinGeorgiev\Doctrine\DBAL\Types\Traits;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateTimeInfinity;
+
+/**
+ * Converts between a PostgreSQL date, timestamp or timestamptz value and its PHP counterpart.
+ *
+ * Shared by the scalar types and by the items of their array counterparts, so both sides read and write
+ * the same spellings: the infinity sentinels, the BC era and the years PostgreSQL prints with five digits.
+ *
+ * @since 4.8
+ *
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ */
+trait PostgresDateTimeConversionTrait
+{
+    /**
+     * @var string
+     */
+    private const BC_ERA_SUFFIX = ' BC';
+
+    /**
+     * Returns the format string for serializing to PostgreSQL.
+     *
+     * It must open with the year, which is rewritten on its own for values in the BC era.
+     */
+    abstract protected function getPostgresFormat(): string;
+
+    /**
+     * Returns format strings for parsing from PostgreSQL, tried in order.
+     *
+     * To support the five-digit and non-positive years PostgreSQL emits, they use X rather than Y for the year format.
+     *
+     * @return non-empty-list<string>
+     */
+    abstract protected function getPHPFormats(): array;
+
+    abstract protected function throwInvalidPHPFormatException(mixed $item): never;
+
+    protected function transformParsedValueForPHP(\DateTimeImmutable $value): \DateTimeImmutable
+    {
+        return $value;
+    }
+
+    /**
+     * PostgreSQL has no year zero: it counts 1 BC where PHP counts year 0.
+     * Every non-positive PHP year is mirrored around 1 and written in the BC era, which PostgreSQL marks with a suffix.
+     */
+    protected function transformDateTimeForPostgres(\DateTimeInterface $value): string
+    {
+        $yearToken = $value->format('Y');
+        $year = (int) $yearToken;
+        $formatted = $value->format($this->getPostgresFormat());
+        if ($year > 0) {
+            return $formatted;
+        }
+
+        return \sprintf('%04d', 1 - $year).\mb_substr($formatted, \mb_strlen($yearToken)).self::BC_ERA_SUFFIX;
+    }
+
+    protected function transformPostgresStringForPHP(string $value): \DateTimeImmutable|DateTimeInfinity
+    {
+        $infinity = DateTimeInfinity::tryFromString($value);
+        if ($infinity instanceof DateTimeInfinity) {
+            return $infinity;
+        }
+
+        $parsable = \str_ends_with($value, self::BC_ERA_SUFFIX)
+            ? $this->transformBcEraYearToAstronomicalYear(\mb_substr($value, 0, -\mb_strlen(self::BC_ERA_SUFFIX)))
+            : $value;
+
+        $formats = $this->getPHPFormats();
+        foreach ($formats as $format) {
+            $parsed = \DateTimeImmutable::createFromFormat($format, $parsable);
+            if ($parsed !== false) {
+                return $this->transformParsedValueForPHP($parsed);
+            }
+        }
+
+        $this->throwInvalidPHPFormatException($value);
+    }
+
+    /**
+     * Rewriting the era in the string keeps 29 February of a BC leap year intact.
+     * PHP counts it in the astronomical year, which is a leap year, while the BC year number PostgreSQL prints for it is not.
+     */
+    private function transformBcEraYearToAstronomicalYear(string $value): string
+    {
+        if (\preg_match('/^(\d+)(.*)\z/s', $value, $matches) !== 1) {
+            return $value;
+        }
+
+        return \sprintf('%+05d', 1 - (int) $matches[1]).$matches[2];
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/DateTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/DateTypeTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidDateForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateTimeInfinity;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class DateTypeTest extends ScalarTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return Type::DATE;
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function roundtrips_value(\DateTimeImmutable|DateTimeInfinity $testValue): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $testValue);
+    }
+
+    /**
+     * @return array<string, array{\DateTimeImmutable|DateTimeInfinity}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        $bcEraLeapDay = \DateTimeImmutable::createFromFormat('X-m-d H:i:s', '+0000-02-29 00:00:00');
+        $expandedYear = \DateTimeImmutable::createFromFormat('X-m-d H:i:s', '+10000-01-15 00:00:00');
+        \assert($bcEraLeapDay instanceof \DateTimeImmutable);
+        \assert($expandedYear instanceof \DateTimeImmutable);
+
+        return [
+            'positive infinity' => [DateTimeInfinity::POSITIVE],
+            'negative infinity' => [DateTimeInfinity::NEGATIVE],
+            'single date' => [new \DateTimeImmutable('2023-06-15')],
+            'leap day' => [new \DateTimeImmutable('2024-02-29')],
+            'date with time component stripped' => [new \DateTimeImmutable('2023-06-15 15:30:45')],
+            'leap day of the BC era' => [$bcEraLeapDay],
+            'five digit year' => [$expandedYear],
+        ];
+    }
+
+    #[DataProvider('provideValuesEmittedByPostgres')]
+    #[Test]
+    public function reads_values_emitted_by_postgres(string $postgresLiteral, \DateTimeImmutable|DateTimeInfinity $expectedValue): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $result = $this->fetchConvertedValueForPostgresLiteral($typeName, $columnType, $postgresLiteral);
+
+        $this->assertTypeValueEquals($expectedValue, $result, $typeName);
+    }
+
+    /**
+     * @return array<string, array{postgresLiteral: string, expectedValue: \DateTimeImmutable|DateTimeInfinity}>
+     */
+    public static function provideValuesEmittedByPostgres(): array
+    {
+        $bcEra = \DateTimeImmutable::createFromFormat('X-m-d H:i:s', '+0000-01-15 00:00:00');
+        \assert($bcEra instanceof \DateTimeImmutable);
+
+        return [
+            'positive infinity' => [
+                'postgresLiteral' => 'infinity',
+                'expectedValue' => DateTimeInfinity::POSITIVE,
+            ],
+            'negative infinity' => [
+                'postgresLiteral' => '-infinity',
+                'expectedValue' => DateTimeInfinity::NEGATIVE,
+            ],
+            'standard date' => [
+                'postgresLiteral' => '2023-06-15',
+                'expectedValue' => new \DateTimeImmutable('2023-06-15'),
+            ],
+            'first year of the BC era' => [
+                'postgresLiteral' => '0001-01-15 BC',
+                'expectedValue' => $bcEra,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidValues')]
+    #[Test]
+    public function rejects_non_datetime_value(mixed $value): void
+    {
+        $this->expectException(InvalidDateForDatabaseException::class);
+
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $value);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidValues(): array
+    {
+        return [
+            'string value' => ['2023-06-15'],
+            'integer value' => [20230615],
+        ];
+    }
+
+    protected function assertTypeValueEquals(mixed $expected, mixed $actual, string $typeName): void
+    {
+        if ($expected instanceof DateTimeInfinity) {
+            $this->assertSame($expected, $actual, \sprintf('Infinity mismatch for type %s', $typeName));
+
+            return;
+        }
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $expected);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $actual);
+        $this->assertSame(
+            $expected->format('X-m-d'),
+            $actual->format('X-m-d'),
+            \sprintf('Date mismatch for type %s', $typeName)
+        );
+        $this->assertSame(
+            '00:00:00',
+            $actual->format('H:i:s'),
+            \sprintf('Time component must be zeroed for type %s', $typeName)
+        );
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimestampTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimestampTypeTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimestampForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateTimeInfinity;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class TimestampTypeTest extends ScalarTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return Type::TIMESTAMP;
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function roundtrips_value(\DateTimeImmutable|DateTimeInfinity $testValue): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $testValue);
+    }
+
+    /**
+     * @return array<string, array{\DateTimeImmutable|DateTimeInfinity}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        $bcEraLeapDay = \DateTimeImmutable::createFromFormat('X-m-d H:i:s.u', '+0000-02-29 10:30:45.123456');
+        $expandedYear = \DateTimeImmutable::createFromFormat('X-m-d H:i:s.u', '+10000-01-15 10:30:45.123456');
+        \assert($bcEraLeapDay instanceof \DateTimeImmutable);
+        \assert($expandedYear instanceof \DateTimeImmutable);
+
+        return [
+            'positive infinity' => [DateTimeInfinity::POSITIVE],
+            'negative infinity' => [DateTimeInfinity::NEGATIVE],
+            'whole second' => [new \DateTimeImmutable('2023-06-15 10:30:45')],
+            'with microseconds' => [new \DateTimeImmutable('2023-06-15 10:30:45.123456')],
+            'midnight' => [new \DateTimeImmutable('2000-01-01 00:00:00')],
+            'leap day of the BC era' => [$bcEraLeapDay],
+            'five digit year' => [$expandedYear],
+        ];
+    }
+
+    #[DataProvider('provideValuesEmittedByPostgres')]
+    #[Test]
+    public function reads_values_emitted_by_postgres(string $postgresLiteral, \DateTimeImmutable|DateTimeInfinity $expectedValue): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $result = $this->fetchConvertedValueForPostgresLiteral($typeName, $columnType, $postgresLiteral);
+
+        $this->assertTypeValueEquals($expectedValue, $result, $typeName);
+    }
+
+    /**
+     * @return array<string, array{postgresLiteral: string, expectedValue: \DateTimeImmutable|DateTimeInfinity}>
+     */
+    public static function provideValuesEmittedByPostgres(): array
+    {
+        $bcEra = \DateTimeImmutable::createFromFormat('X-m-d H:i:s.u', '+0000-01-15 10:30:45.000000');
+        \assert($bcEra instanceof \DateTimeImmutable);
+
+        return [
+            'positive infinity' => [
+                'postgresLiteral' => 'infinity',
+                'expectedValue' => DateTimeInfinity::POSITIVE,
+            ],
+            'negative infinity' => [
+                'postgresLiteral' => '-infinity',
+                'expectedValue' => DateTimeInfinity::NEGATIVE,
+            ],
+            'standard timestamp' => [
+                'postgresLiteral' => '2023-06-15 10:30:45',
+                'expectedValue' => new \DateTimeImmutable('2023-06-15 10:30:45'),
+            ],
+            'first year of the BC era' => [
+                'postgresLiteral' => '0001-01-15 10:30:45 BC',
+                'expectedValue' => $bcEra,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidValues')]
+    #[Test]
+    public function rejects_non_datetime_value(mixed $value): void
+    {
+        $this->expectException(InvalidTimestampForDatabaseException::class);
+
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $value);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidValues(): array
+    {
+        return [
+            'string value' => ['2023-06-15 10:30:45'],
+            'integer value' => [20230615],
+        ];
+    }
+
+    protected function assertTypeValueEquals(mixed $expected, mixed $actual, string $typeName): void
+    {
+        if ($expected instanceof DateTimeInfinity) {
+            $this->assertSame($expected, $actual, \sprintf('Infinity mismatch for type %s', $typeName));
+
+            return;
+        }
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $expected);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $actual);
+        $this->assertSame(
+            $expected->format('X-m-d H:i:s.u'),
+            $actual->format('X-m-d H:i:s.u'),
+            \sprintf('Timestamp mismatch for type %s', $typeName)
+        );
+    }
+}

--- a/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimestampTzTypeTest.php
+++ b/tests/Integration/MartinGeorgiev/Doctrine/DBAL/Types/TimestampTzTypeTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Type;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimestampTzForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateTimeInfinity;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class TimestampTzTypeTest extends ScalarTypeTestCase
+{
+    protected function getTypeName(): string
+    {
+        return Type::TIMESTAMPTZ;
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function roundtrips_value(\DateTimeImmutable|DateTimeInfinity $testValue): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $testValue);
+    }
+
+    /**
+     * @return array<string, array{\DateTimeImmutable|DateTimeInfinity}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        $bcEraLeapDay = \DateTimeImmutable::createFromFormat('X-m-d H:i:s.uP', '+0000-02-29 10:30:45.123456+00:00');
+        $expandedYear = \DateTimeImmutable::createFromFormat('X-m-d H:i:s.uP', '+10000-01-15 10:30:45.123456+00:00');
+        \assert($bcEraLeapDay instanceof \DateTimeImmutable);
+        \assert($expandedYear instanceof \DateTimeImmutable);
+
+        return [
+            'positive infinity' => [DateTimeInfinity::POSITIVE],
+            'negative infinity' => [DateTimeInfinity::NEGATIVE],
+            'UTC offset' => [new \DateTimeImmutable('2023-06-15 10:30:45+00:00')],
+            'positive offset' => [new \DateTimeImmutable('2023-06-15 10:30:45+02:00')],
+            'negative offset' => [new \DateTimeImmutable('2023-06-15 10:30:45-05:00')],
+            'with microseconds' => [new \DateTimeImmutable('2023-06-15 10:30:45.123456+00:00')],
+            'leap day of the BC era' => [$bcEraLeapDay],
+            'five digit year' => [$expandedYear],
+        ];
+    }
+
+    #[DataProvider('provideValuesEmittedByPostgres')]
+    #[Test]
+    public function reads_values_emitted_by_postgres(string $postgresLiteral, \DateTimeImmutable|DateTimeInfinity $expectedValue): void
+    {
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $result = $this->fetchConvertedValueForPostgresLiteral($typeName, $columnType, $postgresLiteral);
+
+        $this->assertTypeValueEquals($expectedValue, $result, $typeName);
+    }
+
+    /**
+     * @return array<string, array{postgresLiteral: string, expectedValue: \DateTimeImmutable|DateTimeInfinity}>
+     */
+    public static function provideValuesEmittedByPostgres(): array
+    {
+        $bcEra = \DateTimeImmutable::createFromFormat('X-m-d H:i:s.uP', '+0000-01-15 10:30:45.000000+00:00');
+        \assert($bcEra instanceof \DateTimeImmutable);
+
+        return [
+            'positive infinity' => [
+                'postgresLiteral' => 'infinity',
+                'expectedValue' => DateTimeInfinity::POSITIVE,
+            ],
+            'negative infinity' => [
+                'postgresLiteral' => '-infinity',
+                'expectedValue' => DateTimeInfinity::NEGATIVE,
+            ],
+            'standard timestamptz' => [
+                'postgresLiteral' => '2023-06-15 10:30:45+00',
+                'expectedValue' => new \DateTimeImmutable('2023-06-15 10:30:45+00:00'),
+            ],
+            'first year of the BC era' => [
+                'postgresLiteral' => '0001-01-15 10:30:45+00 BC',
+                'expectedValue' => $bcEra,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidValues')]
+    #[Test]
+    public function rejects_non_datetime_value(mixed $value): void
+    {
+        $this->expectException(InvalidTimestampTzForDatabaseException::class);
+
+        $typeName = $this->getTypeName();
+        $columnType = $this->getPostgresTypeName();
+
+        $this->runDbalBindingRoundTrip($typeName, $columnType, $value);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidValues(): array
+    {
+        return [
+            'string value' => ['2023-06-15 10:30:45+00:00'],
+            'integer value' => [20230615],
+        ];
+    }
+
+    protected function assertTypeValueEquals(mixed $expected, mixed $actual, string $typeName): void
+    {
+        if ($expected instanceof DateTimeInfinity) {
+            $this->assertSame($expected, $actual, \sprintf('Infinity mismatch for type %s', $typeName));
+
+            return;
+        }
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $expected);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $actual);
+        $this->assertSame(
+            $expected->getTimestamp(),
+            $actual->getTimestamp(),
+            \sprintf('TimestampTz mismatch for type %s', $typeName)
+        );
+        $this->assertSame(
+            (int) $expected->format('u'),
+            (int) $actual->format('u'),
+            \sprintf('TimestampTz microseconds mismatch for type %s', $typeName)
+        );
+    }
+}

--- a/tests/Integration/MartinGeorgiev/TestCase.php
+++ b/tests/Integration/MartinGeorgiev/TestCase.php
@@ -31,6 +31,7 @@ use MartinGeorgiev\Doctrine\DBAL\Types\Citext;
 use MartinGeorgiev\Doctrine\DBAL\Types\CitextArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Cube;
 use MartinGeorgiev\Doctrine\DBAL\Types\CubeArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Date;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateMultirange;
 use MartinGeorgiev\Doctrine\DBAL\Types\DateMultirangeArray;
@@ -92,7 +93,9 @@ use MartinGeorgiev\Doctrine\DBAL\Types\SmallIntArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Sparsevec;
 use MartinGeorgiev\Doctrine\DBAL\Types\TextArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\TimeArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\Timestamp;
 use MartinGeorgiev\Doctrine\DBAL\Types\TimestampArray;
+use MartinGeorgiev\Doctrine\DBAL\Types\TimestampTz;
 use MartinGeorgiev\Doctrine\DBAL\Types\TimestampTzArray;
 use MartinGeorgiev\Doctrine\DBAL\Types\Timetz;
 use MartinGeorgiev\Doctrine\DBAL\Types\TimetzArray;
@@ -294,6 +297,7 @@ abstract class TestCase extends BaseTestCase
             'citext[]' => CitextArray::class,
             'cube' => Cube::class,
             'cube[]' => CubeArray::class,
+            'date' => Date::class,
             'date[]' => DateArray::class,
             'daterange' => DateRange::class,
             'daterange[]' => DateRangeArray::class,
@@ -354,7 +358,9 @@ abstract class TestCase extends BaseTestCase
             'smallint[]' => SmallIntArray::class,
             'text[]' => TextArray::class,
             'time[]' => TimeArray::class,
+            'timestamp' => Timestamp::class,
             'timestamp[]' => TimestampArray::class,
+            'timestamptz' => TimestampTz::class,
             'timestamptz[]' => TimestampTzArray::class,
             'timetz' => Timetz::class,
             'timetz[]' => TimetzArray::class,

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseDateTimeTestCase.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/BaseDateTimeTestCase.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use MartinGeorgiev\Doctrine\DBAL\Types\BaseDateTime;
+use MartinGeorgiev\Doctrine\DBAL\Types\ValueObject\DateTimeInfinity;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseDateTimeTestCase extends TestCase
+{
+    /**
+     * @var AbstractPlatform&MockObject
+     */
+    protected MockObject $platform;
+
+    protected BaseDateTime $fixture;
+
+    abstract protected function createFixture(): BaseDateTime;
+
+    abstract protected function getExpectedTypeName(): string;
+
+    /**
+     * @return class-string<\Throwable>
+     */
+    abstract protected static function getPHPExceptionClass(): string;
+
+    /**
+     * @return class-string<\Throwable>
+     */
+    abstract protected static function getDatabaseExceptionClass(): string;
+
+    /**
+     * The format the era and expanded-year assertions render parsed values with.
+     * It uses X so that years outside the four-digit range stay distinguishable from the years inside it.
+     */
+    abstract protected static function getComparisonFormat(): string;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->fixture = $this->createFixture();
+    }
+
+    #[Test]
+    public function has_name(): void
+    {
+        $this->assertSame($this->getExpectedTypeName(), $this->fixture->getName());
+    }
+
+    #[Test]
+    public function converts_null_to_database_value(): void
+    {
+        $this->assertNull($this->fixture->convertToDatabaseValue(null, $this->platform));
+    }
+
+    #[Test]
+    public function converts_null_to_php_value(): void
+    {
+        $this->assertNull($this->fixture->convertToPHPValue(null, $this->platform));
+    }
+
+    #[DataProvider('provideInfinityTransformations')]
+    #[Test]
+    public function converts_infinity_to_php_value(string $postgresValue, DateTimeInfinity $dateTimeInfinity): void
+    {
+        $this->assertSame($dateTimeInfinity, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    #[DataProvider('provideInfinityTransformations')]
+    #[Test]
+    public function converts_infinity_to_database_value(string $postgresValue, DateTimeInfinity $dateTimeInfinity): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($dateTimeInfinity, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{postgresValue: string, dateTimeInfinity: DateTimeInfinity}>
+     */
+    public static function provideInfinityTransformations(): array
+    {
+        return [
+            'positive infinity' => [
+                'postgresValue' => 'infinity',
+                'dateTimeInfinity' => DateTimeInfinity::POSITIVE,
+            ],
+            'negative infinity' => [
+                'postgresValue' => '-infinity',
+                'dateTimeInfinity' => DateTimeInfinity::NEGATIVE,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideBcEraAndExpandedYearTransformationsToPHP')]
+    #[Test]
+    public function converts_bc_era_and_expanded_year_to_php_value(string $postgresValue, string $expectedFormattedValue): void
+    {
+        $result = $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $result);
+        $this->assertSame($expectedFormattedValue, $result->format(static::getComparisonFormat()));
+    }
+
+    /**
+     * @return array<string, array{postgresValue: string, expectedFormattedValue: string}>
+     */
+    abstract public static function provideBcEraAndExpandedYearTransformationsToPHP(): array;
+
+    #[DataProvider('provideBcEraAndExpandedYearTransformationsToPostgres')]
+    #[Test]
+    public function converts_bc_era_and_expanded_year_to_database_value(\DateTimeImmutable $phpValue, string $expectedPostgresValue): void
+    {
+        $this->assertSame($expectedPostgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{phpValue: \DateTimeImmutable, expectedPostgresValue: string}>
+     */
+    abstract public static function provideBcEraAndExpandedYearTransformationsToPostgres(): array;
+
+    #[DataProvider('provideInvalidDatabaseValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_database_value_inputs(mixed $value): void
+    {
+        $this->expectException(static::getDatabaseExceptionClass());
+
+        $this->fixture->convertToDatabaseValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidDatabaseValueInputs(): array
+    {
+        return [
+            'string' => ['2023-06-15'],
+            'integer' => [20230615],
+            'boolean' => [true],
+            'array' => [[]],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueInputs')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_inputs(mixed $value): void
+    {
+        $this->expectException(static::getPHPExceptionClass());
+
+        $this->fixture->convertToPHPValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideInvalidPHPValueInputs(): array
+    {
+        return [
+            'integer' => [20230615],
+            'boolean' => [true],
+            'array' => [[]],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    #[DataProvider('provideInvalidPHPValueFormats')]
+    #[Test]
+    public function throws_exception_for_invalid_php_value_formats(string $value): void
+    {
+        $this->expectException(static::getPHPExceptionClass());
+
+        $this->fixture->convertToPHPValue($value, $this->platform);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueFormats(): array
+    {
+        return [
+            'garbage string' => ['not-a-datetime'],
+            'empty string' => [''],
+            'era suffix without a value' => [' BC'],
+            'infinity spelled as a float' => ['inf'],
+        ];
+    }
+
+    /**
+     * @throws \UnexpectedValueException when the format does not describe the given value
+     */
+    protected static function createImmutableDateTime(string $format, string $datetime): \DateTimeImmutable
+    {
+        $parsed = \DateTimeImmutable::createFromFormat($format, $datetime);
+        if (!$parsed instanceof \DateTimeImmutable) {
+            throw new \UnexpectedValueException(\sprintf('Cannot read "%s" as "%s"', $datetime, $format));
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * Creates a mutable DateTime instance. Uses variable class instantiation
+     * to prevent the date_time_immutable cs-fixer rule from rewriting it.
+     */
+    protected static function createMutableDateTime(string $datetime): \DateTimeInterface
+    {
+        /** @var class-string<\DateTimeInterface> $class */
+        $class = 'DateTime';
+
+        return new $class($datetime);
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DateTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/DateTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\Date;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidDateForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidDateForPHPException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class DateTest extends BaseDateTimeTestCase
+{
+    protected function createFixture(): Date
+    {
+        return new Date();
+    }
+
+    protected function getExpectedTypeName(): string
+    {
+        return 'date';
+    }
+
+    protected static function getPHPExceptionClass(): string
+    {
+        return InvalidDateForPHPException::class;
+    }
+
+    protected static function getDatabaseExceptionClass(): string
+    {
+        return InvalidDateForDatabaseException::class;
+    }
+
+    protected static function getComparisonFormat(): string
+    {
+        return 'X-m-d';
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(\DateTimeImmutable $phpValue, string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(\DateTimeImmutable $phpValue, string $postgresValue): void
+    {
+        $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{phpValue: \DateTimeImmutable, postgresValue: string}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'standard date' => [
+                'phpValue' => new \DateTimeImmutable('2023-06-15'),
+                'postgresValue' => '2023-06-15',
+            ],
+            'leap day' => [
+                'phpValue' => new \DateTimeImmutable('2024-02-29'),
+                'postgresValue' => '2024-02-29',
+            ],
+            'first day of the year' => [
+                'phpValue' => new \DateTimeImmutable('2000-01-01'),
+                'postgresValue' => '2000-01-01',
+            ],
+        ];
+    }
+
+    #[Test]
+    public function converts_mutable_date_time_to_database_value(): void
+    {
+        $phpValue = self::createMutableDateTime('2023-06-15');
+
+        $this->assertSame('2023-06-15', $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[Test]
+    public function converts_to_php_value_at_midnight(): void
+    {
+        $result = $this->fixture->convertToPHPValue('2023-06-15', $this->platform);
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $result);
+        $this->assertSame('2023-06-15 00:00:00.000000', $result->format('Y-m-d H:i:s.u'));
+    }
+
+    /**
+     * @return array<string, array{postgresValue: string, expectedFormattedValue: string}>
+     */
+    public static function provideBcEraAndExpandedYearTransformationsToPHP(): array
+    {
+        return [
+            'first year of the BC era' => [
+                'postgresValue' => '0001-01-15 BC',
+                'expectedFormattedValue' => '+0000-01-15',
+            ],
+            'leap day of the first year of the BC era' => [
+                'postgresValue' => '0001-02-29 BC',
+                'expectedFormattedValue' => '+0000-02-29',
+            ],
+            'second year of the BC era' => [
+                'postgresValue' => '0002-01-15 BC',
+                'expectedFormattedValue' => '-0001-01-15',
+            ],
+            'five digit year' => [
+                'postgresValue' => '10000-01-15',
+                'expectedFormattedValue' => '+10000-01-15',
+            ],
+            'first year of the AD era' => [
+                'postgresValue' => '0001-01-01',
+                'expectedFormattedValue' => '+0001-01-01',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{phpValue: \DateTimeImmutable, expectedPostgresValue: string}>
+     */
+    public static function provideBcEraAndExpandedYearTransformationsToPostgres(): array
+    {
+        return [
+            'astronomical year zero' => [
+                'phpValue' => self::createImmutableDateTime('X-m-d H:i:s', '+0000-01-15 00:00:00'),
+                'expectedPostgresValue' => '0001-01-15 BC',
+            ],
+            'leap day of astronomical year zero' => [
+                'phpValue' => self::createImmutableDateTime('X-m-d H:i:s', '+0000-02-29 00:00:00'),
+                'expectedPostgresValue' => '0001-02-29 BC',
+            ],
+            'negative astronomical year' => [
+                'phpValue' => self::createImmutableDateTime('X-m-d H:i:s', '-0001-01-15 00:00:00'),
+                'expectedPostgresValue' => '0002-01-15 BC',
+            ],
+            'five digit year' => [
+                'phpValue' => self::createImmutableDateTime('X-m-d H:i:s', '+10000-01-15 00:00:00'),
+                'expectedPostgresValue' => '10000-01-15',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueFormats(): array
+    {
+        return [
+            'garbage string' => ['not-a-date'],
+            'date with time' => ['2023-06-15 10:30:00'],
+            'US date format' => ['06/15/2023'],
+            'empty string' => [''],
+            'era suffix without a value' => [' BC'],
+            'era suffix on a garbage string' => ['not-a-date BC'],
+            'infinity spelled as a float' => ['inf'],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimestampTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimestampTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimestampForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimestampForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Timestamp;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class TimestampTest extends BaseDateTimeTestCase
+{
+    protected function createFixture(): Timestamp
+    {
+        return new Timestamp();
+    }
+
+    protected function getExpectedTypeName(): string
+    {
+        return 'timestamp';
+    }
+
+    protected static function getPHPExceptionClass(): string
+    {
+        return InvalidTimestampForPHPException::class;
+    }
+
+    protected static function getDatabaseExceptionClass(): string
+    {
+        return InvalidTimestampForDatabaseException::class;
+    }
+
+    protected static function getComparisonFormat(): string
+    {
+        return 'X-m-d H:i:s';
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(\DateTimeImmutable $phpValue, string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(\DateTimeImmutable $phpValue, string $postgresValue): void
+    {
+        $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{phpValue: \DateTimeImmutable, postgresValue: string}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'whole second' => [
+                'phpValue' => new \DateTimeImmutable('2023-06-15 10:30:45'),
+                'postgresValue' => '2023-06-15 10:30:45.000000',
+            ],
+            'with microseconds' => [
+                'phpValue' => new \DateTimeImmutable('2023-06-15 10:30:45.123456'),
+                'postgresValue' => '2023-06-15 10:30:45.123456',
+            ],
+            'midnight' => [
+                'phpValue' => new \DateTimeImmutable('2000-01-01 00:00:00'),
+                'postgresValue' => '2000-01-01 00:00:00.000000',
+            ],
+        ];
+    }
+
+    #[Test]
+    public function converts_mutable_date_time_to_database_value(): void
+    {
+        $phpValue = self::createMutableDateTime('2023-06-15 10:30:45');
+
+        $this->assertSame('2023-06-15 10:30:45.000000', $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[Test]
+    public function converts_to_php_value_without_microseconds(): void
+    {
+        $result = $this->fixture->convertToPHPValue('2023-06-15 10:30:45', $this->platform);
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $result);
+        $this->assertSame('2023-06-15 10:30:45.000000', $result->format('Y-m-d H:i:s.u'));
+    }
+
+    /**
+     * @return array<string, array{postgresValue: string, expectedFormattedValue: string}>
+     */
+    public static function provideBcEraAndExpandedYearTransformationsToPHP(): array
+    {
+        return [
+            'first year of the BC era' => [
+                'postgresValue' => '0001-01-15 10:30:00 BC',
+                'expectedFormattedValue' => '+0000-01-15 10:30:00',
+            ],
+            'leap day of the first year of the BC era' => [
+                'postgresValue' => '0001-02-29 10:30:00 BC',
+                'expectedFormattedValue' => '+0000-02-29 10:30:00',
+            ],
+            'second year of the BC era' => [
+                'postgresValue' => '0002-01-15 10:30:00 BC',
+                'expectedFormattedValue' => '-0001-01-15 10:30:00',
+            ],
+            'five digit year' => [
+                'postgresValue' => '10000-01-15 10:30:00',
+                'expectedFormattedValue' => '+10000-01-15 10:30:00',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{phpValue: \DateTimeImmutable, expectedPostgresValue: string}>
+     */
+    public static function provideBcEraAndExpandedYearTransformationsToPostgres(): array
+    {
+        return [
+            'astronomical year zero' => [
+                'phpValue' => self::createImmutableDateTime('X-m-d H:i:s.u', '+0000-01-15 10:30:00.000000'),
+                'expectedPostgresValue' => '0001-01-15 10:30:00.000000 BC',
+            ],
+            'negative astronomical year' => [
+                'phpValue' => self::createImmutableDateTime('X-m-d H:i:s.u', '-0001-01-15 10:30:00.000000'),
+                'expectedPostgresValue' => '0002-01-15 10:30:00.000000 BC',
+            ],
+            'five digit year' => [
+                'phpValue' => self::createImmutableDateTime('X-m-d H:i:s.u', '+10000-01-15 10:30:00.000000'),
+                'expectedPostgresValue' => '10000-01-15 10:30:00.000000',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueFormats(): array
+    {
+        return [
+            'garbage string' => ['not-a-timestamp'],
+            'date only' => ['2023-06-15'],
+            'US date format' => ['06/15/2023 10:30:00'],
+            'empty string' => [''],
+            'era suffix without a value' => [' BC'],
+            'era suffix on a garbage string' => ['not-a-timestamp BC'],
+            'infinity spelled as a float' => ['inf'],
+        ];
+    }
+}

--- a/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimestampTzTest.php
+++ b/tests/Unit/MartinGeorgiev/Doctrine/DBAL/Types/TimestampTzTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MartinGeorgiev\Doctrine\DBAL\Types;
+
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimestampTzForDatabaseException;
+use MartinGeorgiev\Doctrine\DBAL\Types\Exceptions\InvalidTimestampTzForPHPException;
+use MartinGeorgiev\Doctrine\DBAL\Types\TimestampTz;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class TimestampTzTest extends BaseDateTimeTestCase
+{
+    protected function createFixture(): TimestampTz
+    {
+        return new TimestampTz();
+    }
+
+    protected function getExpectedTypeName(): string
+    {
+        return 'timestamptz';
+    }
+
+    protected static function getPHPExceptionClass(): string
+    {
+        return InvalidTimestampTzForPHPException::class;
+    }
+
+    protected static function getDatabaseExceptionClass(): string
+    {
+        return InvalidTimestampTzForDatabaseException::class;
+    }
+
+    protected static function getComparisonFormat(): string
+    {
+        return 'X-m-d H:i:sP';
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_database_value(\DateTimeImmutable $phpValue, string $postgresValue): void
+    {
+        $this->assertSame($postgresValue, $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideValidTransformations')]
+    #[Test]
+    public function converts_to_php_value(\DateTimeImmutable $phpValue, string $postgresValue): void
+    {
+        $this->assertEquals($phpValue, $this->fixture->convertToPHPValue($postgresValue, $this->platform));
+    }
+
+    /**
+     * @return array<string, array{phpValue: \DateTimeImmutable, postgresValue: string}>
+     */
+    public static function provideValidTransformations(): array
+    {
+        return [
+            'UTC offset' => [
+                'phpValue' => new \DateTimeImmutable('2023-06-15 10:30:45+00:00'),
+                'postgresValue' => '2023-06-15 10:30:45.000000+00:00',
+            ],
+            'positive offset' => [
+                'phpValue' => new \DateTimeImmutable('2023-06-15 10:30:45+02:00'),
+                'postgresValue' => '2023-06-15 10:30:45.000000+02:00',
+            ],
+            'negative offset' => [
+                'phpValue' => new \DateTimeImmutable('2023-06-15 10:30:45-05:00'),
+                'postgresValue' => '2023-06-15 10:30:45.000000-05:00',
+            ],
+            'with microseconds' => [
+                'phpValue' => new \DateTimeImmutable('2023-06-15 10:30:45.123456+02:00'),
+                'postgresValue' => '2023-06-15 10:30:45.123456+02:00',
+            ],
+        ];
+    }
+
+    #[Test]
+    public function converts_mutable_date_time_to_database_value(): void
+    {
+        $phpValue = self::createMutableDateTime('2023-06-15 10:30:45+02:00');
+
+        $this->assertSame('2023-06-15 10:30:45.000000+02:00', $this->fixture->convertToDatabaseValue($phpValue, $this->platform));
+    }
+
+    #[DataProvider('provideOffsetPreservations')]
+    #[Test]
+    public function preserves_offset_on_php_value(string $postgresValue, string $expectedDatetime, string $expectedOffset): void
+    {
+        $result = $this->fixture->convertToPHPValue($postgresValue, $this->platform);
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $result);
+        $this->assertSame($expectedDatetime, $result->format('Y-m-d H:i:s'));
+        $this->assertSame($expectedOffset, $result->format('P'));
+    }
+
+    /**
+     * @return array<string, array{postgresValue: string, expectedDatetime: string, expectedOffset: string}>
+     */
+    public static function provideOffsetPreservations(): array
+    {
+        return [
+            'without microseconds and UTC offset' => [
+                'postgresValue' => '2023-06-15 10:30:45+00:00',
+                'expectedDatetime' => '2023-06-15 10:30:45',
+                'expectedOffset' => '+00:00',
+            ],
+            'positive offset' => [
+                'postgresValue' => '2023-06-15 10:30:45.000000+02:00',
+                'expectedDatetime' => '2023-06-15 10:30:45',
+                'expectedOffset' => '+02:00',
+            ],
+            'negative offset' => [
+                'postgresValue' => '2023-06-15 10:30:45.000000-05:00',
+                'expectedDatetime' => '2023-06-15 10:30:45',
+                'expectedOffset' => '-05:00',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{postgresValue: string, expectedFormattedValue: string}>
+     */
+    public static function provideBcEraAndExpandedYearTransformationsToPHP(): array
+    {
+        return [
+            'first year of the BC era' => [
+                'postgresValue' => '0001-01-15 10:30:00+00 BC',
+                'expectedFormattedValue' => '+0000-01-15 10:30:00+00:00',
+            ],
+            'leap day of the first year of the BC era' => [
+                'postgresValue' => '0001-02-29 10:30:00+00 BC',
+                'expectedFormattedValue' => '+0000-02-29 10:30:00+00:00',
+            ],
+            'second year of the BC era' => [
+                'postgresValue' => '0002-01-15 10:30:00+00 BC',
+                'expectedFormattedValue' => '-0001-01-15 10:30:00+00:00',
+            ],
+            'five digit year' => [
+                'postgresValue' => '10000-01-15 10:30:00+00',
+                'expectedFormattedValue' => '+10000-01-15 10:30:00+00:00',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{phpValue: \DateTimeImmutable, expectedPostgresValue: string}>
+     */
+    public static function provideBcEraAndExpandedYearTransformationsToPostgres(): array
+    {
+        return [
+            'astronomical year zero' => [
+                'phpValue' => self::createImmutableDateTime('X-m-d H:i:s.uP', '+0000-01-15 10:30:00.000000+00:00'),
+                'expectedPostgresValue' => '0001-01-15 10:30:00.000000+00:00 BC',
+            ],
+            'negative astronomical year' => [
+                'phpValue' => self::createImmutableDateTime('X-m-d H:i:s.uP', '-0001-01-15 10:30:00.000000+00:00'),
+                'expectedPostgresValue' => '0002-01-15 10:30:00.000000+00:00 BC',
+            ],
+            'five digit year' => [
+                'phpValue' => self::createImmutableDateTime('X-m-d H:i:s.uP', '+10000-01-15 10:30:00.000000+00:00'),
+                'expectedPostgresValue' => '10000-01-15 10:30:00.000000+00:00',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideInvalidPHPValueFormats(): array
+    {
+        return [
+            'garbage string' => ['not-a-timestamp'],
+            'date only' => ['2023-06-15'],
+            'timestamp without time zone' => ['2023-06-15 10:30:45'],
+            'empty string' => [''],
+            'era suffix without a value' => [' BC'],
+            'era suffix on a timestamp without time zone' => ['0001-01-15 10:30:00 BC'],
+            'infinity spelled as a float' => ['inf'],
+        ];
+    }
+}


### PR DESCRIPTION
PostgreSQL stores `infinity` and `-infinity` in `date`, `timestamp` and `timestamptz` columns. #727 taught the **array** types to carry them as `DateTimeInfinity`, but the library ships no **scalar** equivalents, so such a column falls through to Doctrine's own `date` / `datetime` / `datetimetz` — and those throw:

```
Doctrine\DBAL\Types\Exception\InvalidFormat: Could not convert database value "infinity"
to Doctrine Type Doctrine\DBAL\Types\DateType. Expected format "Y-m-d".
```

This adds `Date`, `Timestamp` and `TimestampTz` so the scalar and array sides behave alike: `\DateTimeImmutable` for ordinary values, `DateTimeInfinity` for the two sentinels, `null` still reserved for SQL NULL. The BC era and five-digit years come along for free, since both sides now share one conversion trait.

## The naming trade-off

The types are named `date`, `timestamp` and `timestamptz` — after the PostgreSQL types they carry, as every type in this library is. `timestamp` and `timestamptz` collide with nothing (Doctrine calls its equivalents `datetime` and `datetimetz`), but **`date` shadows one of Doctrine's built-in types**. That is deliberate, and three things decided it:

1. **The library's own machinery assumes type name == PostgreSQL type name.** `BaseType::getSQLDeclaration()` returns `strtoupper($platform->getDoctrineTypeMapping(TYPE_NAME))`, the integration harness registers `registerDoctrineTypeMapping($typeName, $typeName)`, and `TestCase::type_will_be_registered` asserts the declaration equals `strtoupper($typeName)`. An invented name such as `date_infinity` would emit `DATE_INFINITY` as the column type — not a thing PostgreSQL accepts — or force an override of shared test plumbing.
2. **There is no second spelling.** PostgreSQL has no alias for `date`, so a type honestly named after it cannot dodge the collision.
3. **The collision is opt-in and loud.** `Type::addType('date', ...)` throws `TypeAlreadyRegistered`; a user has to reach for `Type::overrideType()` on purpose. Nothing changes for anyone who does not.

What opting in costs is documented in `AVAILABLE-TYPES.md` under a new sub-section, and repeated at each registration snippet:

- Doctrine's built-in `date` returns a mutable `\DateTime`; this one returns `\DateTimeImmutable` or `DateTimeInfinity`, so a property typed `\DateTime` stops being assignable.
- The switch is application-wide — there is no per-column half-measure, short of mapping the columns you want left alone to `date_immutable` or `datetime`.
- `registerDoctrineTypeMapping('timestamp', 'timestamp')` replaces the platform's default reverse mapping of a PostgreSQL `timestamp` column to Doctrine's `datetime`, which schema introspection and diffing read. Register it only if you want introspection to follow.

The alternative — shipping only `timestamp` and `timestamptz` and leaving `date` out — was rejected: `date` is where unbounded validity periods actually live, and a half-closed gap is worse than a documented trade-off.

## What is in here

- `Types/BaseDateTime` + `Date`, `Timestamp`, `TimestampTz`, and six `Invalid{Type}For{PHP,Database}Exception` classes
- `Traits/PostgresDateTimeConversionTrait` — the BC-era, expanded-year and infinity conversion lifted out of `BaseDateTimeArray`, which now uses it. Strictly behavior-preserving: every existing array test passes unmodified
- `Type::DATE`, `Type::TIMESTAMP`, `Type::TIMESTAMPTZ`; registration in the integration `TestCase`
- `AVAILABLE-TYPES.md` (catalog rows, and "Datetime Array Types" widened into "Datetime Types"), plus the Doctrine, Symfony and Laravel integration guides
- Unit tests via a shared `BaseDateTimeTestCase`, and integration tests that round-trip every value through real `DATE` / `TIMESTAMP` / `TIMESTAMPTZ` columns, in both directions: bound `DateTimeInfinity` written out, and `infinity` / `-infinity` / `0001-01-15 BC` inserted as PostgreSQL literals and read back

## Verification

`composer run-unit-tests` (5920), the same suite with `zend.assertions=-1`, `composer phpstan`, `composer check-code-style`, `composer run-static-analysis` (deptrac: 0 violations), and the full `composer run-integration-tests` against PostgreSQL 18 / PostGIS 3.6 — 2492 tests green, including 45 new ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL scalar `date`, `timestamp`, and `timestamptz` type support.
  * Added support for infinity values, microseconds, time-zone offsets, BC-era dates, and expanded years.
  * Added clear validation errors for invalid date/time values.
* **Documentation**
  * Updated Doctrine, Laravel, and Symfony integration guidance.
  * Expanded available-type documentation for scalar date/time types.
* **Tests**
  * Added comprehensive unit and PostgreSQL integration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->